### PR TITLE
Audit M2.1: CRUD_VIEWS_STRICT setting and error-handling sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- New `CRUD_VIEWS_STRICT` setting (defaults to `DEBUG`): in strict mode, exceptions previously swallowed by `ignore_exception` (e.g. unknown view keys in `cv_context_action` template tags or table link columns) are raised so misconfigurations fail loudly during development; in non-strict mode they are logged as warnings under the `crud_views` logger hierarchy
+- Logging: swallowed/narrowed exceptions in `DeleteView.cv_get_related_object_url` and the guardian create-button parent resolution are now logged instead of silently ignored
+
 ### Fixed
 
 - Formsets: a form/x-form mismatch during nested formset save now raises `CrudViewError` instead of failing silently (the previous `assert Exception(...)` never raised)

--- a/src/crud_views/lib/exceptions.py
+++ b/src/crud_views/lib/exceptions.py
@@ -1,5 +1,8 @@
+import logging
 from functools import wraps
 from typing import Type
+
+logger = logging.getLogger(__name__)
 
 
 class ViewSetNotFoundError(Exception):
@@ -27,12 +30,11 @@ def cv_raise(expression: bool, msg: str, exception: Type[Exception] = ViewSetErr
         raise exception(msg)
 
 
-STRICT = False
-
-
 def ignore_exception(exception_type, default_value=None, default_empty_dict: bool = False):
     """
-    Ignore exception and return default value if strict is False
+    Ignore exception and return a default value.
+    In strict mode (setting CRUD_VIEWS_STRICT, defaults to DEBUG) the exception
+    is raised instead, so misconfigurations fail loudly during development.
     """
 
     def decorator(func):
@@ -40,10 +42,12 @@ def ignore_exception(exception_type, default_value=None, default_empty_dict: boo
         def wrapper(*args, **kwargs):
             try:
                 return func(*args, **kwargs)
-            except exception_type as e:
-                # todo: get strict from settings
-                if STRICT:
-                    raise e
+            except exception_type:
+                from django.conf import settings
+
+                if getattr(settings, "CRUD_VIEWS_STRICT", settings.DEBUG):
+                    raise
+                logger.warning("ignoring exception in %s", func.__qualname__, exc_info=True)
                 if default_empty_dict:
                     return dict()
                 return default_value

--- a/src/crud_views/lib/views/delete.py
+++ b/src/crud_views/lib/views/delete.py
@@ -1,13 +1,17 @@
+import logging
 from collections import defaultdict
 from typing import NamedTuple
 
 from django.contrib.admin.utils import NestedObjects
 from django.db import router
+from django.urls import NoReverseMatch, reverse
 from django.views import generic
 
 from crud_views.lib.settings import crud_views_settings
 from crud_views.lib.view import CrudView, CrudViewPermissionRequiredMixin
 from crud_views.lib.views.mixins import CrudViewProcessFormMixin
+
+logger = logging.getLogger(__name__)
 
 
 class RelatedObjects(NamedTuple):
@@ -62,8 +66,6 @@ class DeleteView(CrudViewProcessFormMixin, CrudView, generic.DeleteView):
         for viewset in _REGISTRY.values():
             if viewset.model == model and viewset.is_view_registered("detail"):
                 try:
-                    from django.urls import reverse
-
                     router_name = viewset.get_router_name("detail")
                     kwargs = {viewset.pk_name: obj.pk}
                     if viewset.parent:
@@ -72,7 +74,8 @@ class DeleteView(CrudViewProcessFormMixin, CrudView, generic.DeleteView):
                         if parent_obj:
                             kwargs[viewset.parent.get_pk_name()] = parent_obj.pk
                     return reverse(router_name, kwargs=kwargs)
-                except Exception:
+                except NoReverseMatch:
+                    logger.debug("cannot reverse detail url for %r at %s", obj, viewset, exc_info=True)
                     return None
         return None
 

--- a/src/crud_views_guardian/lib/mixins.py
+++ b/src/crud_views_guardian/lib/mixins.py
@@ -1,6 +1,10 @@
+import logging
+
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.shortcuts import get_object_or_404
+
+logger = logging.getLogger(__name__)
 
 
 class GuardianObjectPermissionMixin:
@@ -131,7 +135,12 @@ class GuardianQuerysetMixin:
                 if hasattr(target_cls, "cv_create_has_access"):
                     try:
                         parent_obj = self.cv_get_parent_object()
-                    except Exception:
+                    except (Http404, KeyError):
+                        logger.warning(
+                            "could not resolve parent object for create button visibility at %s",
+                            self,
+                            exc_info=True,
+                        )
                         parent_obj = None
                     ctx["cv_access"] = target_cls.cv_create_has_access(user, self, parent_obj)
 

--- a/tests/test1/test_strict_mode.py
+++ b/tests/test1/test_strict_mode.py
@@ -1,0 +1,39 @@
+"""
+Audit task 2.1: the ignore_exception decorator must honor the
+CRUD_VIEWS_STRICT setting (defaulting to DEBUG) instead of a hardcoded
+module-level STRICT = False, so misconfigurations fail loudly in development.
+"""
+
+import pytest
+from django.test import override_settings
+
+from crud_views.lib.exceptions import ignore_exception
+
+
+@ignore_exception(KeyError, default_value="fallback")
+def _boom():
+    raise KeyError("k")
+
+
+def test_ignore_exception_raises_in_strict_mode():
+    with override_settings(CRUD_VIEWS_STRICT=True):
+        with pytest.raises(KeyError):
+            _boom()
+
+
+def test_ignore_exception_swallows_when_not_strict():
+    with override_settings(CRUD_VIEWS_STRICT=False):
+        assert _boom() == "fallback"
+
+
+def test_strict_defaults_to_debug_on():
+    # without CRUD_VIEWS_STRICT set, strictness follows DEBUG
+    # (note: pytest-django forces DEBUG=False during tests, so set it explicitly)
+    with override_settings(DEBUG=True):
+        with pytest.raises(KeyError):
+            _boom()
+
+
+def test_strict_defaults_to_swallow_when_debug_off():
+    with override_settings(DEBUG=False):
+        assert _boom() == "fallback"


### PR DESCRIPTION
## Summary

Task 2.1 of the audit improvement plan (`AUDIT.md`): failures are surfaced instead of silenced.

- `ignore_exception` now honors a new **`CRUD_VIEWS_STRICT`** setting (defaults to `DEBUG`): in strict mode the wrapped exception is raised so misconfigurations (unknown view keys in `cv_context_action` tags, table link columns) fail loudly during development; otherwise it is logged as a warning and the default value is returned. Replaces the hardcoded module-level `STRICT = False`.
- `DeleteView.cv_get_related_object_url`: bare `except Exception` narrowed to `NoReverseMatch` + debug log.
- Guardian create-button parent resolution: bare `except Exception` narrowed to `(Http404, KeyError)` + warning log.
- Module loggers added under the `crud_views` namespace (the package previously had no logging at all).

**Behavior note:** projects running with `DEBUG=True` will now see exceptions where buttons/links previously vanished silently — that is the point; set `CRUD_VIEWS_STRICT=False` to opt out. Documented in CHANGELOG.

## Test plan
- [x] New `test_strict_mode.py`: raise in strict mode, swallow+default when not strict, default follows DEBUG both ways (TDD: watched fail first)
- [x] Full suite: 302 passed, 1 skipped; ruff clean