### PR TITLE
Audit M3.1: rename formsets x.py to render_tree.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 
 ### Internal
 
+- Renamed `crud_views/lib/formsets/x.py` to `render_tree.py` with a module docstring explaining the XForm/XFormSet render-tree model; renamed `XFormSet.start_at_rows` to `render_rows_only` (semi-private formsets API)
+
 - New nested-formset test suite (Publisher → Book → BookNote) raising formsets coverage from 34–62% to 78–100%; total coverage 95% with a `fail_under = 88` CI gate
 - `task bump-patch` now invokes `bump-my-version` (was the unrelated `bumpver` tool); removed the nonexistent `bootstrap5` extra from `noxfile.py`
 - Moved internal planning artifacts from `docs/superpowers/` to `superpowers/` so they are no longer built into the documentation site

--- a/src/crud_views/lib/formsets/formsets.py
+++ b/src/crud_views/lib/formsets/formsets.py
@@ -14,7 +14,7 @@ from django.template.loader import render_to_string
 from pydantic import BaseModel, Field, model_validator
 from enum import Enum
 
-from .x import XForm, XFormSet
+from .render_tree import XForm, XFormSet
 
 
 class FormSet(BaseModel, arbitrary_types_allowed=True):
@@ -182,7 +182,7 @@ class FormSet(BaseModel, arbitrary_types_allowed=True):
             formset=self,
             parent=parent,
             management_form=formset_instance.management_form,
-            start_at_rows=True if level == 0 else False,
+            render_rows_only=True if level == 0 else False,
         )
 
         # get the forms

--- a/src/crud_views/lib/formsets/render_tree.py
+++ b/src/crud_views/lib/formsets/render_tree.py
@@ -1,3 +1,22 @@
+"""
+Render tree for (nested) inline formsets.
+
+When a view with formsets renders, the declarative FormSet hierarchy
+(crud_views.lib.formsets.formsets.FormSet) is instantiated into a tree of
+runtime nodes that the templates iterate over:
+
+- ``XFormSet`` wraps one bound/unbound Django formset instance: it knows its
+  unique prefix within the nested hierarchy, its level, layout helpers
+  (columns), and the JSON payload the JavaScript needs to add/remove rows.
+- ``XForm`` wraps one form (row) of an XFormSet and holds the child
+  XFormSets nested under that row.
+
+``FormSet.init()`` builds this tree for a request (recursively for all
+children); ``FormSet.template()`` builds a single-branch tree used to render
+the empty-row template returned by the AJAX endpoint. ``save()``/``is_valid()``
+walk the tree depth-first, handling deletes before updates.
+"""
+
 from __future__ import annotations
 
 import json
@@ -78,7 +97,7 @@ class XFormSet(BaseModel, arbitrary_types_allowed=True):
     management_form: Any
     forms: List[XForm] = Field(default_factory=lambda: list())
     parent: XForm | None = None
-    start_at_rows: bool = False  # todo: bad name, improve
+    render_rows_only: bool = False  # True for the AJAX row template: skip the fieldset wrapper
 
     def __str__(self):
         return f"XFormSet({self.prefix},{self.prefix_key},{self.level})"

--- a/src/crud_views/templates/crud_views/formsets/formset.html
+++ b/src/crud_views/templates/crud_views/formsets/formset.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_tags %}
 {% load crud_views_formsets %}
 
-{% if not x_formset.start_at_rows %}
+{% if not x_formset.render_rows_only %}
 
     <!-- formsets: start {{ x_formset.prefix }} -->
     <div class="row">


### PR DESCRIPTION
## Summary

Task 3.1 of the audit improvement plan (`AUDIT.md`).

- `crud_views/lib/formsets/x.py` → `render_tree.py` (git mv, history preserved) with a module docstring explaining the XForm/XFormSet render-tree model: what the nodes are, how `FormSet.init()` and `FormSet.template()` build the tree, and how `save()`/`is_valid()` walk it
- `XFormSet.start_at_rows` (self-labeled `# todo: bad name, improve`) → `render_rows_only` — it marks the single-branch AJAX row template that skips the fieldset wrapper; the bootstrap5 template updated accordingly
- The formsets API is semi-private per audit decision #1, so no deprecation shims; the example app does not import the module directly (verified — only `crud_views.lib.formsets` package imports)

Pure refactor — no behavior change; covered by the 18-test formsets suite from Milestone 0 (including the AJAX template-rendering path that exercises `render_rows_only`).

## Test plan
- [x] Full suite: 314 passed, 1 skipped; ruff format + check clean