### PR TITLE
Audit M3.3: TODO triage — issues #27–#34, code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 
 ### Internal
 
+- TODO triage: all 37 inline `# todo` markers removed — meaningful ones converted to GitHub issues #27–#34, stale ones and commented-out code blocks deleted
+
 - Renamed `crud_views/lib/formsets/x.py` to `render_tree.py` with a module docstring explaining the XForm/XFormSet render-tree model; renamed `XFormSet.start_at_rows` to `render_rows_only` (semi-private formsets API)
 
 - New nested-formset test suite (Publisher → Book → BookNote) raising formsets coverage from 34–62% to 78–100%; total coverage 95% with a `fail_under = 88` CI gate

--- a/src/crud_views/lib/check.py
+++ b/src/crud_views/lib/check.py
@@ -43,7 +43,6 @@ class Check(BaseModel):
         return template.format(**kwargs)
 
 
-# todo: check for type
 class CheckAttribute(Check):
     """
     Check for attribute
@@ -71,7 +70,6 @@ class CheckAttribute(Check):
         return getattr(self.context, self.attribute)
 
     def messages(self) -> Iterable[CheckMessage]:
-        # yield from super().messages()
         if not self.exists or (self.value is None and not self.nullable):
             yield Error(id=self.get_id(), msg=self.get_message())
 
@@ -127,8 +125,6 @@ class CheckEitherAttribute(Check):
         return getattr(self.context, self.attribute2, None)
 
     def messages(self) -> Iterable[CheckMessage]:
-        # yield from super().messages()
-
         if not self.value1 and not self.value2 and not self.allow_none:
             yield Error(
                 id=self.get_id(),
@@ -182,7 +178,6 @@ class ContextActionCheck(Check):
     Checks for context action
     """
 
-    # todo: check when all apps are loaded
     msg: str = "Attribute »{attribute}» does not exist or is not set at »{context}»"
 
     def messages(self) -> Iterable[CheckMessage]:
@@ -190,9 +185,6 @@ class ContextActionCheck(Check):
         actions = self.context.cv_context_actions or list()  # noqa
         for action in actions:  # noqa
             is_view = viewset.has_view(action)
-            # is_special = action in viewset.special_keys
-            # if not (is_view or is_special):
-            #    yield Error(id=f"viewset.{self.id}", msg=f"{self.msg} at {self.context}: {action}")
             if not is_view:
                 yield Error(id=f"viewset.{self.id}", msg=f"{self.msg} at {self.context}: {action}")
 

--- a/src/crud_views/lib/crispy/form.py
+++ b/src/crud_views/lib/crispy/form.py
@@ -130,6 +130,6 @@ class CrispyViewMixin:
         return kwargs
 
 
-# todo: remove this
+# Deprecated alias kept for backwards compatibility, see issue #34
 class CrispyModelViewMixin(CrispyViewMixin):
     pass

--- a/src/crud_views/lib/formsets/formsets.py
+++ b/src/crud_views/lib/formsets/formsets.py
@@ -25,8 +25,8 @@ class FormSet(BaseModel, arbitrary_types_allowed=True):
     key: str | None = None
     original_key: str | None = None
     title: str | None = None
-    fields: List[str]  # todo: get from formset klass ?
-    pk_field: str  # todo: get from formset klass ?
+    fields: List[str]
+    pk_field: str
     cv_view: CrudView | None = None
     parent: Self | None = None
     klass: Type[BaseInlineFormSet]
@@ -112,8 +112,7 @@ class FormSet(BaseModel, arbitrary_types_allowed=True):
                 "formset": self,
                 "instance": form.instance,
                 "prefix": prefix,
-                "parent_form": form if level > 0 else None,  # todo
-                # "form_kwargs": {"cv_view": None} # TODO HACK!!
+                "parent_form": form if level > 0 else None,
             }
             if request.POST:
                 kwargs["data"] = request.POST
@@ -197,7 +196,6 @@ class FormSet(BaseModel, arbitrary_types_allowed=True):
             form_prefix = form.prefix.rsplit("-", 1)[0] + f"-{force_form_index}"
             form.prefix = form_prefix
             forms = [form]
-            # todo: limit number of formset_instance.forms to 1 ?
 
         for formset_instance_form_index, formset_instance_form in enumerate(forms):
             # force the form index on level 0
@@ -209,7 +207,6 @@ class FormSet(BaseModel, arbitrary_types_allowed=True):
                 prefix_key=formset_instance_form_prefix_key,
                 form=formset_instance_form,
                 formset=self,
-                # instance=formset_instance,
                 parent=x_formset,
             )
             x_formset.forms.append(x_form)
@@ -263,7 +260,6 @@ class FormSets(BaseModel, arbitrary_types_allowed=True):
 
     @model_validator(mode="after")
     def apply_hierarchy(self) -> Self:
-        # todo: check this
         def apply_key(formset: FormSet, key: str, original_key: str, parent: FormSet | None = None):
             formset.original_key = original_key
             if formset.key is None:

--- a/src/crud_views/lib/formsets/inline_formset.py
+++ b/src/crud_views/lib/formsets/inline_formset.py
@@ -54,7 +54,7 @@ class InlineFormSet(BaseInlineFormSet):
         helper.form_tag = False
         helper.disable_csrf = True
         helper.render_hidden_fields = True  # IMPORTANT: crispy needs this to render hidden fields
-        helper.form_show_labels = False  # todo: get this from formset config
+        helper.form_show_labels = False
 
         fields = self.get_helper_layout_fields()
         assert isinstance(fields, list)
@@ -130,7 +130,7 @@ class CrispyInlineFormMixin:
         helper.form_tag = False
         helper.disable_csrf = True
         helper.render_hidden_fields = True  # IMPORTANT: crispy needs this to render hidden fields
-        helper.form_show_labels = True  # todo: get this from formset config
+        helper.form_show_labels = True
         fields = self.get_layout_fields()
         if not isinstance(fields, (list, tuple)):
             fields = [fields]

--- a/src/crud_views/lib/formsets/mixins.py
+++ b/src/crud_views/lib/formsets/mixins.py
@@ -20,7 +20,7 @@ class FormSetMixinBase:
         Iterator of checks for the view
         """
         yield from super().checks()
-        yield CheckAttribute(context=cls, id="E200", attribute="cv_formsets_required")  # todo check for type
+        yield CheckAttribute(context=cls, id="E200", attribute="cv_formsets_required")
 
     def get_context_data(self, **kwargs):
         """
@@ -138,26 +138,9 @@ class FormSetMixinBase:
 
         return formsets
 
-    # def cv_form_valid(self, form: ModelForm, formsets: FormSets):
-    #     """
-    #     Use a custom form_valid method to handle formsets because the form_valid method
-    #     would recreate the formsets again
-    #     """
-    #
-    #     with transaction.atomic():
-    #         # delete first
-    #         # formsets.deleted()
-    #
-    #         self.object = form.save(commit=True)
-    #         formsets.save(commit=True)
-    #
-    #     return HttpResponseRedirect(self.get_success_url())  # noqa
-
 
 class FormSetMixin(FormSetMixinBase):
     cv_formsets: FormSets
-
-    # todo: checks for cv_formsets: FormSets
 
     @classmethod
     def checks(cls) -> Iterable[Check]:
@@ -165,17 +148,15 @@ class FormSetMixin(FormSetMixinBase):
         Iterator of checks for the view
         """
         yield from super().checks()
-        yield CheckAttribute(context=cls, id="E200", attribute="cv_formsets")  # todo check for type
+        yield CheckAttribute(context=cls, id="E200", attribute="cv_formsets")
 
     def cv_get_formsets(self) -> FormSets:
         return self.cv_formsets.clone(cv_view=self)  # noqa
 
 
-# todo: rename, because this class name collides with django polymorphic
+# Naming collides with django-polymorphic's formset classes, see issue #30
 class PolymorphicFormSetMixin(FormSetMixinBase):
     cv_polymorphic_formsets: Dict[Type[Model], FormSets]
-
-    # todo: checks for cv_polymorphic_formsets
 
     @classmethod
     def checks(cls) -> Iterable[Check]:
@@ -183,7 +164,7 @@ class PolymorphicFormSetMixin(FormSetMixinBase):
         Iterator of checks for the view
         """
         yield from super().checks()
-        yield CheckAttribute(context=cls, id="E200", attribute="cv_polymorphic_formsets")  # todo check for type
+        yield CheckAttribute(context=cls, id="E200", attribute="cv_polymorphic_formsets")
 
     def cv_get_formsets(self) -> FormSets | None:
         model = self.polymorphic_model

--- a/src/crud_views/lib/view/base.py
+++ b/src/crud_views/lib/view/base.py
@@ -74,11 +74,6 @@ class CrudView(metaclass=CrudViewMetaClass):
         yield CheckAttributeReg(context=cls, id="E200", attribute="cv_key", **check.REGS["name"])
         yield CheckAttributeReg(context=cls, id="E201", attribute="cv_path", **check.REGS["path"])
 
-        # todo: cv_extends test template if defined
-
-        # todo: reactivate
-        # yield ContextActionCheck(context=cls, id="E203", msg="action not defined")
-
         # templates are required for frontend views
         is_frontend = not cls.cv_backend_only
         if is_frontend:
@@ -271,10 +266,7 @@ class CrudView(metaclass=CrudViewMetaClass):
         return ViewContext(**kwargs)
 
     def cv_get_context_button(self, key: str) -> ContextButton | None:
-        # todo: first look in CrudView context_buttons
-        pass
-
-        # then look as ViewSet context_buttons
+        # view-level context buttons are not supported yet, see issue #27
         for cb in self.cv_viewset.context_buttons:
             if cb.key == key:
                 return cb
@@ -344,7 +336,6 @@ class CrudView(metaclass=CrudViewMetaClass):
         viewset = self.cv_viewset.get_viewset(name)
         if viewset.parent.name != self.cv_viewset.name:
             raise ParentViewSetError(f"ViewSet {viewset} is no child of {self.cv_viewset}")
-        # todo: check if this is a child of self.cv
         name = viewset.get_router_name(key)
         args = viewset.get_parent_url_args()
         attrs = viewset.get_parent_attributes()
@@ -409,7 +400,6 @@ class CrudViewPermissionRequiredMixin(PermissionRequiredMixin):
         Iterator of checks for the view
         """
         yield from super().checks()  # noqa
-        # todo
         yield CheckAttribute(context=cls, id="E202", attribute="cv_permission")
 
     @cached_property

--- a/src/crud_views/lib/view/buttons.py
+++ b/src/crud_views/lib/view/buttons.py
@@ -149,14 +149,12 @@ class FilterContextButton(ContextButton):
         if not isinstance(context.view, ListViewTableFilterMixin):
             return dict_kwargs
 
-        # todo, check permission ?
-
         list_url = context.view.cv_get_url(key=context.view.cv_key)
 
         data = dict()
 
         # render action label
-        cv_action_label = "Filter"  # todo, add render
+        cv_action_label = "Filter"
         if cv_action_label:
             data["cv_action_label"] = cv_action_label
 

--- a/src/crud_views/lib/views/action.py
+++ b/src/crud_views/lib/views/action.py
@@ -16,8 +16,6 @@ class ActionView(CrudView, SingleObjectMixin, generic.View):
             self.cv_action_success_hook(context)
         else:
             self.cv_action_error_hook(context)
-        # todo: evaluate result
-        # todo: message
         url = self.get_success_url()
         return HttpResponseRedirect(url)
 

--- a/src/crud_views/lib/views/list.py
+++ b/src/crud_views/lib/views/list.py
@@ -34,8 +34,6 @@ class ListView(CrudView, generic.ListView):
     # icons
     cv_icon_action = "fa-regular fa-rectangle-list"
 
-    # todo: add check for cv_filter_header_template/cv_filter_header_template_code
-
     @staticmethod
     def cv_get_filter_icon() -> str:
         """
@@ -65,7 +63,7 @@ class ListViewFilterFormHelper(FormHelper):
     """
 
     form_method = "GET"  # filter parameters are always GET
-    form_tag = False  # todo really?, just add hidden stuff
+    form_tag = False
 
     def __init__(self, view, request, form=None):
         super().__init__(form)

--- a/src/crud_views/lib/views/mixins.py
+++ b/src/crud_views/lib/views/mixins.py
@@ -161,8 +161,6 @@ class ListViewTableFilterMixin(FilterView):
     cv_filter_persistence: bool = crud_views_settings.filter_persistence
     cv_session_key_querystring: str = "filter_query_string"
 
-    # todo: check cv_filter_persistence cv_session_key_querystring
-
     def get_filterset(self, filterset_class):  # noqa
         kwargs = self.get_filterset_kwargs(filterset_class)
         filterset = filterset_class(**kwargs)
@@ -174,10 +172,6 @@ class ListViewTableFilterMixin(FilterView):
         context = super().get_context_data(**kwargs)
 
         filter_expanded = SessionData.from_view(self).get("filter_expanded", False)
-        #
-        # with SessionData.from_view(self) as sd:
-        #     filter_expanded = sd["filter_expanded"]
-
         context["cv_filter_expanded"] = filter_expanded
         return context
 
@@ -215,7 +209,7 @@ class ListViewTableFilterMixin(FilterView):
             query_string = self.request.META["QUERY_STRING"]
 
             # reset filter ?
-            qs = parse_qs(query_string)  # todo: is this correct? looks strange with that lists
+            qs = parse_qs(query_string)
             reset_filter = qs.get("reset_filter", ["false"])[0] == "true"
             if reset_filter:
                 try:

--- a/src/crud_views/lib/viewset/__init__.py
+++ b/src/crud_views/lib/viewset/__init__.py
@@ -367,14 +367,12 @@ class ViewSet(BaseModel):
         content_type = ContentType.objects.get_for_model(model)
         permissions = OrderedDict()
         for permission in Permission.objects.filter(content_type=content_type):
-            # todo: model name must in codename
             action = permission.codename.split(f"_{permission.content_type.model}")[0]
             permissions[action] = f"{permission.content_type.app_label}.{permission.codename}"
         return permissions
 
     @cached_property
     def permissions(self) -> OrderedDict[str, str]:
-        # todo: move to view ?
         return self.default_permissions
 
     def get_meta(self, context: ViewContext) -> dict:

--- a/src/crud_views_plain/apps.py
+++ b/src/crud_views_plain/apps.py
@@ -7,5 +7,4 @@ class CrudViewsPlainConfig(AppConfig):
 
     def ready(self):
         pass
-        # todo: run checks
         # import viewset.checks  # noqa

--- a/src/crud_views_workflow/apps.py
+++ b/src/crud_views_workflow/apps.py
@@ -7,6 +7,5 @@ class CrudViewsWorkflowConfig(AppConfig):
     label = "cvw"
 
     def ready(self):
-        # todo: check if needed apps are installed: fsm2 fsm2-admin auditlog
         # import crud_views.checks  # noqa
         pass

--- a/src/crud_views_workflow/lib/views.py
+++ b/src/crud_views_workflow/lib/views.py
@@ -79,7 +79,6 @@ class WorkflowView(CustomFormView):
         context["has_workflow_choices"] = self.object.workflow_has_any_possible_transition(self.request.user)
         return context
 
-    # todo: cv_form_valid instead of cv_form_valid_hook?
     def cv_form_valid_hook(self, context: dict):
         """
         Process workflow transition
@@ -100,7 +99,6 @@ class WorkflowView(CustomFormView):
         wf_method = getattr(self.object, transition, None)
         assert callable(wf_method), f"Invalid transition {transition}"
 
-        # todo: configurable
         with transaction.atomic():
             # get old state
             state_old = self.object.state


### PR DESCRIPTION
## Summary

Task 3.3 of the audit improvement plan (`AUDIT.md`). All 37 inline `# todo` markers in `src/` are gone:

**Converted to issues** (real, actionable work): #27 view-level context buttons, #28 system-check expansion, #29 formsets ergonomics, #30 PolymorphicFormSetMixin rename, #31 workflow transaction configurability, #32 ActionView messages, #33 permission codename parsing, #34 CrispyModelViewMixin deprecation.

**Deleted**: stale/answered TODOs (e.g. the `parse_qs` doubt — the code is correct), bare `# todo` markers, and all commented-out code blocks (`FormSetMixinBase`'s old `cv_form_valid`, `ContextActionCheck`'s `is_special` branch, the commented `SessionData` usage, the E203 reactivation stub). Three load-bearing spots carry a one-line issue reference instead of a TODO.

Comment-only change set — no behavior touched (`grep -rci todo src` is now 0, audit acceptance was < 10).

## Test plan
- [x] Full suite: 314 passed, 1 skipped; ruff format + check clean