### PR TITLE
fix: demo app startup crash — duplicate "poly" ViewSet name in bootstrap5 example

### DIFF
--- a/examples/bootstrap5/app/views/formset/__init__.py
+++ b/examples/bootstrap5/app/views/formset/__init__.py
@@ -32,7 +32,7 @@ from .two import PolyTwoForm
 
 cv_poly_formset = ViewSet(
     model=Poly,
-    name="poly",
+    name="poly_formset",
     icon_header="fa-solid fa-sun",
     parent=ParentViewSet(
         name="parent",

--- a/examples/bootstrap5/app/views/formset/parent.py
+++ b/examples/bootstrap5/app/views/formset/parent.py
@@ -63,7 +63,7 @@ class ParentDeleteView(CrispyModelViewMixin, DeleteViewPermissionRequired):
 
 class RedirectPolyView(RedirectChildView):
     cv_action_label = _("Manage Poly")
-    cv_redirect = "poly"
+    cv_redirect = "poly_formset"
     cv_redirect_key = "list"
     cv_icon_action = "fa-solid fa-sun"
 


### PR DESCRIPTION
## Problem

The bootstrap5 demo app crashed on startup with:

```
crud_views.lib.exceptions.ViewSetError: ViewSet name poly is already registered by ViewSet(poly)
```

## Root cause

The duplicate ViewSet name guard added in 8a4b847 (audit M2) exposed a pre-existing collision in the example app: both the main Poly ViewSet (`app/views/poly/__init__.py`) and the formset variant (`app/views/formset/__init__.py`) registered under `name="poly"`. Before the guard, the registry silently overwrote the first entry — the demo started, but `get_viewset("poly")` lookups resolved to whichever ViewSet was imported last, and both generated colliding `poly-*` URL names.

This was the only true collision; other apparent duplicates (foo, book, bar, author) are `ParentViewSet` parent references, which don't register globally.

## Fix

- Rename the formset variant to `name="poly_formset"` (underscore style matching `book_review`)
- Update `cv_redirect = "poly_formset"` in `formset/parent.py` — this redirect resolves through the registry to the parent's child viewset, which is the formset one

The nav template's `{% url "poly-list" %}` continues to target the main Poly ViewSet, now unambiguously.

## Verification

- `manage.py check` passes (the same check phase that crashed)
- Dev server boots; index returns 200, `/poly/` returns its normal 302 to login
- ruff format + check pass