### PR TITLE
feat(filter): pinned (always-visible) filter via cv_filter_pinned

### DIFF
--- a/.run/django-crud-views-runserver.run.xml
+++ b/.run/django-crud-views-runserver.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="runserver" type="Python.DjangoServer" factoryName="Django server">
+  <configuration default="false" name="django-crud-views-runserver" type="Python.DjangoServer" factoryName="Django server">
     <module name="django-crud-views" />
     <option name="ENV_FILES" value="" />
     <option name="INTERPRETER_OPTIONS" value="" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Pinned filter: set `cv_filter_pinned = True` on a filtered `ListView`/`CardListView` (or the global `CRUD_VIEWS_FILTER_PINNED` setting, default `False`) to render the filter always-open and hide the filter toggle button. Filter field values are still persisted to the session via `cv_filter_persistence`; only the now-irrelevant expanded/collapsed state is dropped (bootstrap5 renders the filter without its collapse wrapper; the plain theme is unaffected)
+
 ## 0.6.0
 
 ### Added

--- a/docs/reference/card-list-view.md
+++ b/docs/reference/card-list-view.md
@@ -124,6 +124,12 @@ class AuthorCardListView(ListViewTableFilterMixin, CardListViewPermissionRequire
     cv_card_actions = [...]
 ```
 
+### Pinned filter
+
+`CardListView` shares `ListViewTableFilterMixin` with `ListView`, so `cv_filter_pinned = True`
+works the same way: the filter renders always-open and the toggle button is hidden. See
+[ListView → Always-visible (pinned) filter](list_view.md).
+
 ## Ordering
 
 Declare orderable fields with `cv_order_fields`. The card view then renders an

--- a/docs/reference/list_view.md
+++ b/docs/reference/list_view.md
@@ -146,6 +146,23 @@ when navigating away and back. Control this with:
 
 This can also be configured globally via the `FILTER_PERSISTENCE` setting.
 
+### Always-visible (pinned) filter
+
+By default the filter is collapsed and opened via the filter toggle button. Set
+`cv_filter_pinned = True` on a filtered view to render the filter **always open** and
+hide the toggle button entirely:
+
+```python
+class AuthorListView(ListViewTableMixin, ListViewTableFilterMixin, ListViewPermissionRequired):
+    filterset_class = AuthorFilter
+    cv_filter_pinned = True
+```
+
+The default comes from the `CRUD_VIEWS_FILTER_PINNED` setting (default `False`). Filter
+field values are still persisted to the session when `cv_filter_persistence` is enabled;
+only the (now irrelevant) expanded/collapsed state is dropped. Applies equally to
+[CardListView](card-list-view.md).
+
 ---
 
 > To disable an action the user *is* permitted to perform, based on object state

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -26,6 +26,7 @@ Settings for filter.
 | Key                           | Description                                     | Type   | Default            |
 |-------------------------------|-------------------------------------------------|--------|--------------------|
 | FILTER_PERSISTENCE            | Store filter in Django session                  | `bool` | True               |
+| CRUD_VIEWS_FILTER_PINNED      | When `True`, list/card filters render always-open and the filter toggle button is hidden. Per-view override via `cv_filter_pinned`. | `bool` | False |
 | FILTER_ICON                   | Filter icon (boostrap5 only)                    | `str`  | fa-solid fa-filter |
 | FILTER_RESET_BUTTON_CSS_CLASS | Filter reset button css flass (bootstrap5 only) | `str`  | btn btn-secondary  |
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -26,7 +26,7 @@ Settings for filter.
 | Key                           | Description                                     | Type   | Default            |
 |-------------------------------|-------------------------------------------------|--------|--------------------|
 | FILTER_PERSISTENCE            | Store filter in Django session                  | `bool` | True               |
-| CRUD_VIEWS_FILTER_PINNED      | When `True`, list/card filters render always-open and the filter toggle button is hidden. Per-view override via `cv_filter_pinned`. | `bool` | False |
+| FILTER_PINNED                 | When `True`, list/card filters render always-open and the filter toggle button is hidden. Per-view override via `cv_filter_pinned`. | `bool` | False |
 | FILTER_ICON                   | Filter icon (boostrap5 only)                    | `str`  | fa-solid fa-filter |
 | FILTER_RESET_BUTTON_CSS_CLASS | Filter reset button css flass (bootstrap5 only) | `str`  | btn btn-secondary  |
 

--- a/examples/bootstrap5/app/views/author.py
+++ b/examples/bootstrap5/app/views/author.py
@@ -84,6 +84,7 @@ class AuthorListView(ListViewTableMixin, ListViewTableFilterMixin, GuardianListV
     # filter config
     filterset_class = AuthorFilter
     formhelper_class = AuthorFilterFormHelper
+    cv_filter_pinned = True  # always-open filter, no toggle button
 
     # viewset config
     cv_viewset = cv_author

--- a/examples/bootstrap5/app/views/book.py
+++ b/examples/bootstrap5/app/views/book.py
@@ -67,6 +67,7 @@ class BookCardListView(ListViewTableFilterMixin, GuardianCardListViewPermissionR
     cv_path = ""
     filterset_class = BookFilter
     formhelper_class = BookFilterFormHelper
+    cv_filter_pinned = True  # always-open filter, no toggle button
     cv_order_fields = ["title", ("price", "Price")]
     cv_order_default = "title"
     paginate_by = 6

--- a/skills/django-crud-views/SKILL.md
+++ b/skills/django-crud-views/SKILL.md
@@ -281,6 +281,8 @@ class AuthorListView(ListViewTableMixin, ListViewTableFilterMixin, ListViewPermi
     cv_viewset = cv_author
 ```
 
+To show a filter always-open with no toggle button, set `cv_filter_pinned = True` (or the `CRUD_VIEWS_FILTER_PINNED` setting).
+
 ---
 
 ## Ordered Actions (move up/down)

--- a/skills/django-crud-views/references/api-reference.md
+++ b/skills/django-crud-views/references/api-reference.md
@@ -71,6 +71,7 @@ class MyListView(ListViewTableMixin, ListViewPermissionRequired):
     cv_context_actions = ["parent", "filter", "create"]  # page-level action buttons
     paginate_by = 10
     cv_filter_persistence = True  # store filter state in session
+    cv_filter_pinned = False  # True = filter always open, toggle button hidden
 ```
 
 ### DetailView / DetailViewPermissionRequired
@@ -297,7 +298,7 @@ Add `"redirect_child"` (or the specific cv_key) to `cv_list_actions`.
 
 ## Context Buttons
 
-Context buttons appear in the `cv_context_actions` area (typically top-right of a view). The ViewSet's `context_buttons` list controls which custom buttons are available. Default buttons: `home` (link to list), `parent` (link to parent viewset), `filter` (toggle filter form).
+Context buttons appear in the `cv_context_actions` area (typically top-right of a view). The ViewSet's `context_buttons` list controls which custom buttons are available. Default buttons: `home` (link to list), `parent` (link to parent viewset), `filter` (toggle filter form; hidden when `cv_filter_pinned` is set).
 
 ```python
 from crud_views.lib.viewset import context_buttons_default
@@ -486,6 +487,8 @@ class MyListView(ListViewTableMixin, ListViewTableFilterMixin, ListViewPermissio
     filterset_class = MyFilter
     formhelper_class = MyFilterFormHelper
 ```
+
+Set `cv_filter_pinned = True` to render the filter always-open and hide the toggle button (default from the `CRUD_VIEWS_FILTER_PINNED` setting). Field-value persistence is unaffected.
 
 ---
 

--- a/src/crud_views/lib/settings.py
+++ b/src/crud_views/lib/settings.py
@@ -31,6 +31,7 @@ class CrudViewsSettings(BaseModel):
 
     # filter
     filter_persistence: bool = from_settings("CRUD_VIEWS_FILTER_PERSISTENCE", default=True)
+    filter_pinned: bool = from_settings("CRUD_VIEWS_FILTER_PINNED", default=False)
     filter_icon: str = from_settings("CRUD_VIEWS_FILTER_ICON", default="fa-solid fa-filter")
     filter_reset_button_css_class: str = from_settings(
         "CRUD_VIEWS_FILTER_RESET_BUTTON_CSS_CLASS", default="btn btn-secondary"

--- a/src/crud_views/lib/view/buttons.py
+++ b/src/crud_views/lib/view/buttons.py
@@ -158,6 +158,10 @@ class FilterContextButton(ContextButton):
         if not isinstance(context.view, ListViewTableFilterMixin):
             return dict_kwargs
 
+        # pinned filter is always visible -> no toggle button
+        if getattr(context.view, "cv_filter_pinned", False):
+            return dict_kwargs
+
         list_url = context.view.cv_get_url(key=context.view.cv_key)
 
         data = dict()

--- a/src/crud_views/lib/views/mixins.py
+++ b/src/crud_views/lib/views/mixins.py
@@ -237,6 +237,7 @@ class ListViewTableFilterMixin(FilterView):
 
     cv_filter_persistence: bool = crud_views_settings.filter_persistence
     cv_session_key_querystring: str = "filter_query_string"
+    cv_filter_pinned: bool = crud_views_settings.filter_pinned
 
     def get_filterset(self, filterset_class):  # noqa
         kwargs = self.get_filterset_kwargs(filterset_class)
@@ -248,7 +249,12 @@ class ListViewTableFilterMixin(FilterView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        filter_expanded = SessionData.from_view(self).get("filter_expanded", False)
+        if self.cv_filter_pinned:
+            # pinned filter is always shown; the toggle/session-expanded state is moot
+            filter_expanded = True
+        else:
+            filter_expanded = SessionData.from_view(self).get("filter_expanded", False)
+        context["cv_filter_pinned"] = self.cv_filter_pinned
         context["cv_filter_expanded"] = filter_expanded
         return context
 

--- a/src/crud_views/templates/crud_views/tags/list_filter.html
+++ b/src/crud_views/templates/crud_views/tags/list_filter.html
@@ -1,7 +1,3 @@
-{% load crispy_forms_tags %}
-{% load static %}
-{% load crud_views %}
-
 {% if cv_filter_pinned %}
     <div class="card" id="filter-pinned">
         {% include "crud_views/tags/list_filter.inner.html" %}

--- a/src/crud_views/templates/crud_views/tags/list_filter.html
+++ b/src/crud_views/templates/crud_views/tags/list_filter.html
@@ -2,23 +2,16 @@
 {% load static %}
 {% load crud_views %}
 
-<div class="collapse{% if cv_filter_expanded %} show{% endif %}" id="filter-collapse">
-    <div class="card">
-        <div class="card-header">
-            {% block cv_filter_header_icon %}
-                {% cv_filter_icon %}
-            {% endblock cv_filter_header_icon %}
-            {% block cv_filter_header %}
-                {% cv_filter_header %}
-            {% endblock cv_filter_header %}
-        </div>
-        <div class="card-body">
-            {% block cv_content_filter %}
-                <form id="filter-form" method="get">
-                    {% crispy filter.form filter.form.helper %}
-                </form>
-            {% endblock cv_content_filter %}
-        </div>
+{% if cv_filter_pinned %}
+    <div class="card" id="filter-pinned">
+        {% include "crud_views/tags/list_filter.inner.html" %}
     </div>
     <br>
-</div>
+{% else %}
+    <div class="collapse{% if cv_filter_expanded %} show{% endif %}" id="filter-collapse">
+        <div class="card">
+            {% include "crud_views/tags/list_filter.inner.html" %}
+        </div>
+        <br>
+    </div>
+{% endif %}

--- a/src/crud_views/templates/crud_views/tags/list_filter.inner.html
+++ b/src/crud_views/templates/crud_views/tags/list_filter.inner.html
@@ -1,0 +1,18 @@
+{% load crispy_forms_tags %}
+{% load crud_views %}
+
+<div class="card-header">
+    {% block cv_filter_header_icon %}
+        {% cv_filter_icon %}
+    {% endblock cv_filter_header_icon %}
+    {% block cv_filter_header %}
+        {% cv_filter_header %}
+    {% endblock cv_filter_header %}
+</div>
+<div class="card-body">
+    {% block cv_content_filter %}
+        <form id="filter-form" method="get">
+            {% crispy filter.form filter.form.helper %}
+        </form>
+    {% endblock cv_content_filter %}
+</div>

--- a/superpowers/instructions/0002-filter-improvements.md
+++ b/superpowers/instructions/0002-filter-improvements.md
@@ -1,0 +1,16 @@
+# Improve Filter
+
+Currently, we have filters for ListView and CardView.
+They are not visible by default.
+When the user clicks on the filter context button, the the filter is expanded.
+The state is stored in the session, if configured.
+
+Our ux department wants to make the filter visible by default.
+
+What it should be:
+- configurable state in `ListViewTableFilterMixin`, e.g. `cv_filter_visible_by_default = True`
+- the same for `CardListView`
+- if the filter is always present
+  - the filter context button should be hidden: make a proposal on how to do this
+- in both cases the filter settings can be stored in the session
+

--- a/superpowers/plans/2026-06-17-filter-pinned.md
+++ b/superpowers/plans/2026-06-17-filter-pinned.md
@@ -1,0 +1,539 @@
+# Pinned Filter (`cv_filter_pinned`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in `cv_filter_pinned` mode so list/card filters render always-open with the toggle button hidden, defaulting off (current collapsed behavior unchanged).
+
+**Architecture:** A new `CRUD_VIEWS_FILTER_PINNED` setting feeds a `cv_filter_pinned` class attribute on `ListViewTableFilterMixin` (covering both `ListView` and `CardListView`). The mixin exposes the flag + forces the filter expanded in context; `FilterContextButton` reuses its existing no-button path to hide the toggle when pinned; the bootstrap5 `list_filter.html` drops the collapse wrapper when pinned. Plain theme needs no template change (already always-visible).
+
+**Tech Stack:** Python, Django, django-filter, Pydantic settings, django-crispy-forms templates, pytest + pytest-django, lxml (HTML assertions).
+
+**Spec:** `superpowers/specs/2026-06-17-filter-pinned-design.md`
+
+> **Testing note — import-time snapshot:** `cv_filter_pinned = crud_views_settings.filter_pinned` is evaluated at class-definition time (same pattern as `cv_filter_persistence`). Monkeypatching `crud_views_settings.filter_pinned` at runtime does **not** retroactively change already-imported view classes. So behavior tests set the flag with `monkeypatch.setattr(SomeView, "cv_filter_pinned", True)` (this models both the per-view override and a setting-driven default, since both surface as the class attribute). The setting→default *wiring* is verified separately by asserting the mixin's default equals the setting value.
+
+> **Test infrastructure already present:** `tests/test1/app/views.py` has filter-enabled views `PublisherListView` (a `ListView`, URL `/publisher/`) and `PublisherOrderCardListView` (a `CardListView`, URL `/publisher_order/card/`). `tests/test1/test_card_order.py` shows the fixture/HTML-assertion patterns (`client_publisher_order`, `publishers`, `lxml.html` + `cssselect`, `user_viewset_permission`). Run tests from the `tests/` dir: `cd tests && pytest ...`. A pre-commit hook runs `ruff format` + `ruff check`.
+
+---
+
+### Task 1: Setting + mixin flag plumbing
+
+**Files:**
+- Modify: `src/crud_views/lib/settings.py` (after the `filter_persistence` line, ~33)
+- Modify: `src/crud_views/lib/views/mixins.py` (`ListViewTableFilterMixin`: attribute ~239, `get_context_data` ~248–253)
+- Test: `tests/test1/test_filter_pinned.py` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test1/test_filter_pinned.py`:
+
+```python
+import pytest
+from django.contrib.auth.models import User
+from django.test.client import Client
+
+from tests.lib.helper.user import user_viewset_permission
+
+
+@pytest.fixture
+def cv_publisher_order():
+    from tests.test1.app.views import cv_publisher_order as ret
+
+    return ret
+
+
+@pytest.fixture
+def client_publisher_order(client, cv_publisher_order) -> Client:
+    user = User.objects.create_user(username="user_pinned_card", password="password")
+    user_viewset_permission(user, cv_publisher_order, "view")
+    client.force_login(user)
+    return client
+
+
+@pytest.fixture
+def publishers(db):
+    from tests.test1.app.models import Publisher
+
+    return [
+        Publisher.objects.create(name="Charlie"),
+        Publisher.objects.create(name="Alpha"),
+        Publisher.objects.create(name="Bravo"),
+    ]
+
+
+def test_filter_pinned_default_comes_from_setting():
+    from crud_views.lib.settings import crud_views_settings
+    from crud_views.lib.views import ListViewTableFilterMixin
+
+    # default attribute is sourced from the setting (which defaults False)
+    assert ListViewTableFilterMixin.cv_filter_pinned == crud_views_settings.filter_pinned
+    assert crud_views_settings.filter_pinned is False
+
+
+@pytest.mark.django_db
+def test_pinned_view_forces_filter_expanded_context(client_publisher_order, publishers, monkeypatch):
+    from tests.test1.app.views import PublisherOrderCardListView
+
+    # not pinned: expanded comes from session (default False)
+    response = client_publisher_order.get("/publisher_order/card/")
+    assert response.status_code == 200
+    assert response.context["cv_filter_pinned"] is False
+    assert response.context["cv_filter_expanded"] is False
+
+    # pinned: forced expanded
+    monkeypatch.setattr(PublisherOrderCardListView, "cv_filter_pinned", True)
+    response = client_publisher_order.get("/publisher_order/card/")
+    assert response.status_code == 200
+    assert response.context["cv_filter_pinned"] is True
+    assert response.context["cv_filter_expanded"] is True
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd tests && pytest test1/test_filter_pinned.py -v`
+Expected: FAIL — `AttributeError`/`KeyError` on `cv_filter_pinned` (attribute and context key don't exist yet).
+
+- [ ] **Step 3: Add the setting**
+
+In `src/crud_views/lib/settings.py`, immediately after the existing line
+`filter_persistence: bool = from_settings("CRUD_VIEWS_FILTER_PERSISTENCE", default=True)`
+add:
+
+```python
+    filter_pinned: bool = from_settings("CRUD_VIEWS_FILTER_PINNED", default=False)
+```
+
+- [ ] **Step 4: Add the mixin attribute and update `get_context_data`**
+
+In `src/crud_views/lib/views/mixins.py`, in `ListViewTableFilterMixin`, after the line
+`cv_session_key_querystring: str = "filter_query_string"` add:
+
+```python
+    cv_filter_pinned: bool = crud_views_settings.filter_pinned
+```
+
+Replace the existing `get_context_data`:
+
+```python
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        filter_expanded = SessionData.from_view(self).get("filter_expanded", False)
+        context["cv_filter_expanded"] = filter_expanded
+        return context
+```
+
+with:
+
+```python
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        if self.cv_filter_pinned:
+            # pinned filter is always shown; the toggle/session-expanded state is moot
+            filter_expanded = True
+        else:
+            filter_expanded = SessionData.from_view(self).get("filter_expanded", False)
+        context["cv_filter_pinned"] = self.cv_filter_pinned
+        context["cv_filter_expanded"] = filter_expanded
+        return context
+```
+
+(`crud_views_settings` is already imported at the top of `mixins.py`.)
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd tests && pytest test1/test_filter_pinned.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/crud_views/lib/settings.py src/crud_views/lib/views/mixins.py tests/test1/test_filter_pinned.py
+git commit -m "feat(filter): add cv_filter_pinned flag + CRUD_VIEWS_FILTER_PINNED setting"
+```
+
+---
+
+### Task 2: Hide the filter toggle button when pinned
+
+**Files:**
+- Modify: `src/crud_views/lib/view/buttons.py` (`FilterContextButton.get_context`, ~152–174)
+- Test: `tests/test1/test_filter_pinned.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test1/test_filter_pinned.py`:
+
+```python
+@pytest.mark.django_db
+def test_pinned_hides_filter_toggle_button(client_publisher_order, publishers, monkeypatch):
+    from lxml import html
+
+    from tests.test1.app.views import PublisherOrderCardListView
+
+    # not pinned: toggle button present
+    response = client_publisher_order.get("/publisher_order/card/")
+    doc = html.fromstring(response.content)
+    assert doc.cssselect("#cv-filter-toggle"), "toggle should be present when not pinned"
+
+    # pinned: toggle button hidden
+    monkeypatch.setattr(PublisherOrderCardListView, "cv_filter_pinned", True)
+    response = client_publisher_order.get("/publisher_order/card/")
+    doc = html.fromstring(response.content)
+    assert not doc.cssselect("#cv-filter-toggle"), "toggle should be hidden when pinned"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd tests && pytest test1/test_filter_pinned.py::test_pinned_hides_filter_toggle_button -v`
+Expected: FAIL — the `#cv-filter-toggle` button still renders when pinned.
+
+- [ ] **Step 3: Hide the button when pinned**
+
+In `src/crud_views/lib/view/buttons.py`, in `FilterContextButton.get_context`, find:
+
+```python
+        # if view has no filter, no button is shown
+        if not isinstance(context.view, ListViewTableFilterMixin):
+            return dict_kwargs
+```
+
+and add immediately after it:
+
+```python
+        # pinned filter is always visible -> no toggle button
+        if getattr(context.view, "cv_filter_pinned", False):
+            return dict_kwargs
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd tests && pytest test1/test_filter_pinned.py::test_pinned_hides_filter_toggle_button -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/crud_views/lib/view/buttons.py tests/test1/test_filter_pinned.py
+git commit -m "feat(filter): hide the filter toggle button when cv_filter_pinned"
+```
+
+---
+
+### Task 3: bootstrap5 template — drop the collapse wrapper when pinned
+
+**Files:**
+- Modify: `src/crud_views/templates/crud_views/tags/list_filter.html`
+- Create: `src/crud_views/templates/crud_views/tags/list_filter.inner.html`
+- Test: `tests/test1/test_filter_pinned.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test1/test_filter_pinned.py`:
+
+```python
+@pytest.mark.django_db
+def test_pinned_renders_filter_without_collapse(client_publisher_order, publishers, monkeypatch):
+    from lxml import html
+
+    from tests.test1.app.views import PublisherOrderCardListView
+
+    # not pinned: collapse wrapper present, filter form present
+    response = client_publisher_order.get("/publisher_order/card/")
+    doc = html.fromstring(response.content)
+    assert doc.cssselect("#filter-collapse"), "collapse wrapper expected when not pinned"
+    assert doc.cssselect("form#filter-form"), "filter form expected"
+
+    # pinned: no collapse wrapper, but filter form still rendered
+    monkeypatch.setattr(PublisherOrderCardListView, "cv_filter_pinned", True)
+    response = client_publisher_order.get("/publisher_order/card/")
+    doc = html.fromstring(response.content)
+    assert not doc.cssselect("#filter-collapse"), "collapse wrapper must be gone when pinned"
+    assert doc.cssselect("form#filter-form"), "filter form must still render when pinned"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd tests && pytest test1/test_filter_pinned.py::test_pinned_renders_filter_without_collapse -v`
+Expected: FAIL — `#filter-collapse` is still present when pinned (template unchanged).
+
+- [ ] **Step 3: Extract the inner filter card to a partial**
+
+Create `src/crud_views/templates/crud_views/tags/list_filter.inner.html` with exactly:
+
+```django
+{% load crispy_forms_tags %}
+{% load crud_views %}
+
+<div class="card-header">
+    {% block cv_filter_header_icon %}
+        {% cv_filter_icon %}
+    {% endblock cv_filter_header_icon %}
+    {% block cv_filter_header %}
+        {% cv_filter_header %}
+    {% endblock cv_filter_header %}
+</div>
+<div class="card-body">
+    {% block cv_content_filter %}
+        <form id="filter-form" method="get">
+            {% crispy filter.form filter.form.helper %}
+        </form>
+    {% endblock cv_content_filter %}
+</div>
+```
+
+- [ ] **Step 4: Branch the wrapper on `cv_filter_pinned`**
+
+Replace the entire contents of `src/crud_views/templates/crud_views/tags/list_filter.html` with:
+
+```django
+{% load crispy_forms_tags %}
+{% load static %}
+{% load crud_views %}
+
+{% if cv_filter_pinned %}
+    <div class="card" id="filter-pinned">
+        {% include "crud_views/tags/list_filter.inner.html" %}
+    </div>
+    <br>
+{% else %}
+    <div class="collapse{% if cv_filter_expanded %} show{% endif %}" id="filter-collapse">
+        <div class="card">
+            {% include "crud_views/tags/list_filter.inner.html" %}
+        </div>
+        <br>
+    </div>
+{% endif %}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd tests && pytest test1/test_filter_pinned.py::test_pinned_renders_filter_without_collapse -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full filter-pinned file + a regression sweep of filter/card tests**
+
+Run: `cd tests && pytest test1/test_filter_pinned.py test1/test_card_order.py test1/test_basic.py -v`
+Expected: all PASS (the non-pinned branch reproduces the original markup, so `test_card_order.py`'s `form#filter-form` assertions still hold).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/crud_views/templates/crud_views/tags/list_filter.html src/crud_views/templates/crud_views/tags/list_filter.inner.html tests/test1/test_filter_pinned.py
+git commit -m "feat(filter): render pinned filter without the collapse wrapper (bootstrap5)"
+```
+
+---
+
+### Task 4: ListView parity + session field-value persistence under pinning
+
+**Files:**
+- Test: `tests/test1/test_filter_pinned.py` (append)
+
+- [ ] **Step 1: Write the tests**
+
+Append to `tests/test1/test_filter_pinned.py`:
+
+```python
+@pytest.fixture
+def client_publisher_view(client):
+    from tests.test1.app.views import cv_publisher
+
+    user = User.objects.create_user(username="user_pinned_list", password="password")
+    user_viewset_permission(user, cv_publisher, "view")
+    client.force_login(user)
+    return client
+
+
+@pytest.mark.django_db
+def test_pinned_listview_parity(client_publisher_view, monkeypatch):
+    from lxml import html
+
+    from tests.test1.app.views import PublisherListView
+
+    monkeypatch.setattr(PublisherListView, "cv_filter_pinned", True)
+    response = client_publisher_view.get("/publisher/")
+    assert response.status_code == 200
+    doc = html.fromstring(response.content)
+    assert not doc.cssselect("#cv-filter-toggle"), "toggle hidden for pinned ListView"
+    assert not doc.cssselect("#filter-collapse"), "no collapse wrapper for pinned ListView"
+    assert doc.cssselect("form#filter-form"), "filter form rendered for pinned ListView"
+
+
+@pytest.mark.django_db
+def test_pinned_still_persists_filter_values_to_session(client_publisher_order, publishers, monkeypatch):
+    from tests.test1.app.views import PublisherOrderCardListView
+
+    monkeypatch.setattr(PublisherOrderCardListView, "cv_filter_pinned", True)
+
+    # submit a filter value -> stored in session (cv_filter_persistence defaults True)
+    response = client_publisher_order.get("/publisher_order/card/?name=Alp")
+    assert response.status_code == 200
+
+    # a bare GET restores the stored query string via redirect
+    response = client_publisher_order.get("/publisher_order/card/", follow=False)
+    assert response.status_code == 302
+    assert "name=Alp" in response.url
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cd tests && pytest test1/test_filter_pinned.py -v`
+Expected: PASS (all tests in the file). No implementation changes are needed — these assert that Tasks 1–3 already deliver ListView parity (same mixin/button/template) and that pinning does not disturb the field-value session persistence in `ListViewTableFilterMixin.get()`.
+
+  If `test_pinned_listview_parity` fails on the fixture/URL, confirm the `cv_publisher` viewset name and that `PublisherListView` is registered at `/publisher/` (see `tests/test1/app/urls.py` and `tests/test1/app/views.py`); fix the fixture/URL to match, not the source.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test1/test_filter_pinned.py
+git commit -m "test(filter): cover pinned ListView parity and session persistence"
+```
+
+---
+
+### Task 5: Documentation
+
+**Files:**
+- Modify: `docs/reference/list_view.md`
+- Modify: `docs/reference/card-list-view.md`
+- Modify: `docs/reference/settings.md`
+
+- [ ] **Step 1: Document on the ListView filtering page**
+
+In `docs/reference/list_view.md`, locate the "## Filtering with django-filter" section. After its existing content (the filter example block), add:
+
+```markdown
+### Always-visible (pinned) filter
+
+By default the filter is collapsed and opened via the filter toggle button. Set
+`cv_filter_pinned = True` on a filtered view to render the filter **always open** and
+hide the toggle button entirely:
+
+\`\`\`python
+class AuthorListView(ListViewTableMixin, ListViewTableFilterMixin, ListViewPermissionRequired):
+    filterset_class = AuthorFilter
+    cv_filter_pinned = True
+\`\`\`
+
+The default comes from the `CRUD_VIEWS_FILTER_PINNED` setting (default `False`). Filter
+field values are still persisted to the session when `cv_filter_persistence` is enabled;
+only the (now irrelevant) expanded/collapsed state is dropped. Applies equally to
+[CardListView](card-list-view.md).
+```
+
+(Replace the `\`\`\`` markers with real triple-backticks when writing the file.)
+
+- [ ] **Step 2: Note it on the CardListView page**
+
+In `docs/reference/card-list-view.md`, add a short subsection near the filtering content (or at the end if there is none):
+
+```markdown
+### Pinned filter
+
+`CardListView` shares `ListViewTableFilterMixin` with `ListView`, so `cv_filter_pinned = True`
+works the same way: the filter renders always-open and the toggle button is hidden. See
+[ListView → Always-visible (pinned) filter](list_view.md).
+```
+
+- [ ] **Step 3: Add the setting row**
+
+In `docs/reference/settings.md`, add a row to the main `CRUD_VIEWS_*` settings table (place it next to `CRUD_VIEWS_FILTER_PERSISTENCE` if present, otherwise anywhere in that table). Use the table's existing column order `| Setting | Description | Type | Default |`:
+
+```markdown
+| CRUD_VIEWS_FILTER_PINNED | When `True`, list/card filters render always-open and the filter toggle button is hidden. Per-view override via `cv_filter_pinned`. | `bool` | `False` |
+```
+
+If the table's column order differs, match the existing order — verify by reading the header row first.
+
+- [ ] **Step 4: Verify the docs build (strict)**
+
+Run: `mkdocs build --strict` (from repo root; this is the same command CI runs in `.github/workflows/docs.yml`).
+Expected: builds with no warnings/errors. If `mkdocs` is unavailable locally, instead confirm the three files have no broken relative links by inspection.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/reference/list_view.md docs/reference/card-list-view.md docs/reference/settings.md
+git commit -m "docs: document cv_filter_pinned and CRUD_VIEWS_FILTER_PINNED"
+```
+
+---
+
+### Task 6: In-project skill
+
+**Files:**
+- Modify: `skills/django-crud-views/references/api-reference.md`
+- Modify: `skills/django-crud-views/SKILL.md`
+
+- [ ] **Step 1: Update the API reference example**
+
+In `skills/django-crud-views/references/api-reference.md`, find the line (~73):
+
+```python
+    cv_filter_persistence = True  # store filter state in session
+```
+
+and add directly below it:
+
+```python
+    cv_filter_pinned = False  # True = filter always open, toggle button hidden
+```
+
+- [ ] **Step 2: Update the filter-button description in the skill reference**
+
+In the same file, find the context-buttons description (~line 300) that reads
+`... \`filter\` (toggle filter form).` and append a clause so it reads:
+`... \`filter\` (toggle filter form; hidden when \`cv_filter_pinned\` is set).`
+
+- [ ] **Step 3: Mention it in the Filtering section**
+
+In the same file, in the Filtering section (~lines 256–259, near the `cv_filter_persistence` mention), add a sentence:
+
+```markdown
+Set `cv_filter_pinned = True` to render the filter always-open and hide the toggle button
+(default from the `CRUD_VIEWS_FILTER_PINNED` setting). Field-value persistence is unaffected.
+```
+
+- [ ] **Step 4: One-line mention in SKILL.md**
+
+In `skills/django-crud-views/SKILL.md`, find the filter guidance and add a sentence:
+"To show a filter always-open with no toggle button, set `cv_filter_pinned = True` (or the `CRUD_VIEWS_FILTER_PINNED` setting)."
+
+- [ ] **Step 5: Verify the edits landed**
+
+Run: `grep -rn "cv_filter_pinned" skills/django-crud-views/`
+Expected: matches in both `references/api-reference.md` (3 spots) and `SKILL.md` (1 spot).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add skills/django-crud-views/references/api-reference.md skills/django-crud-views/SKILL.md
+git commit -m "docs(skill): document cv_filter_pinned"
+```
+
+---
+
+### Task 7: Final full-suite verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the entire test suite**
+
+Run: `cd tests && pytest -q`
+Expected: all pass (prior baseline: 346 passed, 1 skipped — now +~6 new tests). No regressions in `test_card_order.py` / `test_basic.py` / guardian tests.
+
+- [ ] **Step 2: Confirm default-off behavior is unchanged**
+
+Run: `cd tests && pytest test1/test_card_order.py -q`
+Expected: PASS — confirms the non-pinned (default) path still renders the collapse wrapper and `#filter-form` exactly as before.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** setting (Task 1 Step 3) ✓; mixin attribute + forced-expand context (Task 1 Step 4) ✓; button hide (Task 2) ✓; bootstrap5 collapse-drop (Task 3) ✓; plain theme unchanged (no task needed — covered by shared button-hide, noted) ✓; session field-value persistence preserved (Task 4 persistence test) ✓; ListView+CardListView parity (Tasks 1–4 use both `PublisherOrderCardListView` and `PublisherListView`) ✓; docs 3 files (Task 5) ✓; skill 2 files (Task 6) ✓; tests (a)–(e) mapped: (a) Task 2/3 card pinned, (b) non-pinned assertions in Tasks 2/3, (c) card pinned throughout, (d) Task 1 setting-default test + monkeypatch-attribute behavior tests, (e) Task 4 persistence test ✓.
+- **Placeholder scan:** none — every code/template/test step has full content; doc steps give exact text to insert and a grep/verify.
+- **Naming consistency:** `cv_filter_pinned` (attribute), `filter_pinned` (settings field), `CRUD_VIEWS_FILTER_PINNED` (env/setting key), `FilterContextButton`, `list_filter.inner.html` used consistently across tasks.
+- **Snapshot trap:** explicitly called out so the implementer tests behavior via `monkeypatch.setattr(View, "cv_filter_pinned", True)` rather than patching the setting at runtime.

--- a/superpowers/specs/2026-06-17-filter-pinned-design.md
+++ b/superpowers/specs/2026-06-17-filter-pinned-design.md
@@ -1,0 +1,151 @@
+# Pinned filter (`cv_filter_pinned`) — design
+
+**Date:** 2026-06-17
+**Status:** approved (pending user review of this spec)
+**Source instruction:** `superpowers/instructions/0002-filter-improvements.md`
+
+## Goal
+
+The UX department wants the list/card filter to be **visible by default** instead of
+hidden behind the collapse toggle. Add an opt-in, configurable "pinned" mode: when
+enabled, the filter is permanently expanded and the toggle (filter context button) is
+hidden. Default behavior is unchanged (filter collapsed, toggle present).
+
+## Behavioral model
+
+`cv_filter_pinned = True` ⇒ **pinned mode**:
+- The filter form is always rendered, expanded.
+- The filter context button (the `#cv-filter-toggle`) is **hidden** — the user cannot
+  collapse the filter.
+- Filter **field values** still persist to the session exactly as today (governed by
+  `cv_filter_persistence`). The `filter_expanded` session key is irrelevant in this mode
+  (there is no toggle to record).
+
+`cv_filter_pinned = False` (default) ⇒ today's behavior: filter collapsed by default,
+toggle button present, expanded-state persisted to session.
+
+Applies to **both** `ListView` and `CardListView`, because both obtain filtering from the
+same `ListViewTableFilterMixin`.
+
+## Current state (for context)
+
+- `ListViewTableFilterMixin` (`src/crud_views/lib/views/mixins.py`) drives filtering;
+  `get_context_data` sets `cv_filter_expanded` from `SessionData(...).get("filter_expanded", False)`.
+- `FilterButton` (`src/crud_views/lib/view/buttons.py`, `key="filter"`) renders the toggle
+  button via `tags/context_action_filter.html`. It already returns a no-button result
+  (`dict(cv_access=False)`) when the view is **not** a `ListViewTableFilterMixin`.
+- bootstrap5 `tags/list_filter.html` wraps the filter in
+  `<div class="collapse{% if cv_filter_expanded %} show{% endif %}" id="filter-collapse">`.
+- plain `tags/list_filter.html` has **no** collapse wrapper — the filter is already always
+  visible there.
+- `list.filter.js` binds the `#cv-filter-toggle` click handler; when the button is absent
+  the handler binds to an empty set (no-op).
+
+## Approach
+
+Reuse the existing button auto-hide path rather than mutating `cv_context_actions`.
+`FilterButton.get_context` already hides the button for non-filter views; extend the same
+guard to also hide it when the view is pinned. This is theme-agnostic (one Python change
+covers bootstrap5 and plain) and leaves the toggle JS untouched.
+
+*Rejected alternative:* auto-stripping `"filter"` from `cv_context_actions` at view
+registration — more invasive and duplicates the button's own self-hiding logic.
+
+## Changes
+
+### 1. Setting (`src/crud_views/lib/settings.py`)
+Add a Pydantic setting mirroring `filter_persistence`:
+```python
+filter_pinned: bool = from_settings("CRUD_VIEWS_FILTER_PINNED", default=False)
+```
+
+### 2. Mixin (`src/crud_views/lib/views/mixins.py`, `ListViewTableFilterMixin`)
+- Add class attribute:
+  ```python
+  cv_filter_pinned: bool = crud_views_settings.filter_pinned
+  ```
+- In `get_context_data`, expose the flag and force-expand when pinned:
+  ```python
+  pinned = self.cv_filter_pinned
+  context["cv_filter_pinned"] = pinned
+  filter_expanded = True if pinned else SessionData.from_view(self).get("filter_expanded", False)
+  context["cv_filter_expanded"] = filter_expanded
+  ```
+- The `post`/`get` session logic is unchanged. (In pinned mode the toggle never POSTs, so
+  `filter_expanded` is never written; field-value persistence in `get` is unaffected.)
+
+### 3. Button hide (`src/crud_views/lib/view/buttons.py`, `FilterButton.get_context`)
+After the existing `isinstance(context.view, ListViewTableFilterMixin)` guard, add:
+```python
+if getattr(context.view, "cv_filter_pinned", False):
+    return dict_kwargs  # pinned filter has no toggle button
+```
+(`dict_kwargs` is the existing `dict(cv_access=False)` no-button result.)
+
+### 4. bootstrap5 template (`src/crud_views/templates/crud_views/tags/list_filter.html`)
+When `cv_filter_pinned`, render the filter card **without** the `collapse` wrapper (plain
+always-visible card); otherwise keep the existing collapse markup. Sketch:
+```django
+{% if cv_filter_pinned %}
+    <div class="card">
+        {# header + body, same inner content as today #}
+    </div>
+    <br>
+{% else %}
+    <div class="collapse{% if cv_filter_expanded %} show{% endif %}" id="filter-collapse">
+        {# unchanged existing markup #}
+    </div>
+{% endif %}
+```
+The inner header/body blocks (`cv_filter_header_icon`, `cv_filter_header`,
+`cv_content_filter`, the `#filter-form`) are identical in both branches — factor to avoid
+duplication if practical.
+
+### 5. plain template
+No change — the plain `list_filter.html` is already always-visible; the shared button-hide
+(change 3) removes its now-useless toggle when pinned.
+
+### 6. Documentation (`docs/`)
+- `docs/reference/list_view.md` — in "Filtering with django-filter", add a `cv_filter_pinned`
+  subsection: always-open + toggle hidden, default `False`, field-value persistence still
+  applies.
+- `docs/reference/card-list-view.md` — note `cv_filter_pinned` applies to card lists too
+  (same mixin).
+- `docs/reference/settings.md` — add a `CRUD_VIEWS_FILTER_PINNED` row (`bool`, default
+  `False`).
+
+### 7. In-project skill (`skills/django-crud-views/`)
+- `references/api-reference.md` — add `cv_filter_pinned = False` near the existing
+  `cv_filter_persistence` example; mention it in the Filtering section; update the `filter`
+  button description to note it is hidden when the filter is pinned.
+- `SKILL.md` — one line in the filter guidance mentioning the pinned option.
+
+## Testing (`tests/test1/`)
+New tests (django-filter is already used by existing test views):
+- **a)** Pinned `ListView` renders the filter form expanded and emits **no**
+  `#cv-filter-toggle` button.
+- **b)** Non-pinned `ListView` is unchanged: filter collapsed (no forced `show`), button present.
+- **c)** Pinned `CardListView` behaves like (a).
+- **d)** `CRUD_VIEWS_FILTER_PINNED=True` flips the default; a per-view `cv_filter_pinned`
+  attribute overrides the setting either way.
+- **e)** With pinning on, submitting filter values still persists them to the session when
+  `cv_filter_persistence` is enabled (field-value persistence unaffected).
+
+Assertions key off response HTML: presence/absence of `id="cv-filter-toggle"` and the
+filter form / pinned card. Follow the existing patterns in `tests/test1/test_basic.py` and
+`tests/test1/test_card_order.py` (logged-in client fixtures, `client.get(...)`,
+`assertContains`/`assertNotContains`).
+
+## Constraints & non-goals
+- Default **off** — zero behavior change for existing projects.
+- Do not alter the session field-value persistence logic or `cv_filter_persistence`.
+- No change to the plain theme's filter template.
+- Spec location: `superpowers/specs/` (never under `docs/`).
+
+## Acceptance criteria
+- A view with `cv_filter_pinned = True` (or the global setting on) shows the filter open
+  and no toggle button, for both ListView and CardListView, in the bootstrap5 theme.
+- Non-pinned views are byte-for-byte unchanged in behavior.
+- Field-value session persistence still works in pinned mode.
+- Docs (3 files) and skill (2 files) document the flag and setting.
+- New tests cover (a)–(e) and pass; full suite stays green.

--- a/tests/test1/test_filter_pinned.py
+++ b/tests/test1/test_filter_pinned.py
@@ -91,3 +91,44 @@ def test_pinned_renders_filter_without_collapse(client_publisher_order, publishe
     doc = html.fromstring(response.content)
     assert not doc.cssselect("#filter-collapse"), "collapse wrapper must be gone when pinned"
     assert doc.cssselect("form#filter-form"), "filter form must still render when pinned"
+
+
+@pytest.fixture
+def client_publisher_view(client):
+    from tests.test1.app.views import cv_publisher
+
+    user = User.objects.create_user(username="user_pinned_list", password="password")
+    user_viewset_permission(user, cv_publisher, "view")
+    client.force_login(user)
+    return client
+
+
+@pytest.mark.django_db
+def test_pinned_listview_parity(client_publisher_view, monkeypatch):
+    from lxml import html
+
+    from tests.test1.app.views import PublisherListView
+
+    monkeypatch.setattr(PublisherListView, "cv_filter_pinned", True)
+    response = client_publisher_view.get("/publisher/")
+    assert response.status_code == 200
+    doc = html.fromstring(response.content)
+    assert not doc.cssselect("#cv-filter-toggle"), "toggle hidden for pinned ListView"
+    assert not doc.cssselect("#filter-collapse"), "no collapse wrapper for pinned ListView"
+    assert doc.cssselect("form#filter-form"), "filter form rendered for pinned ListView"
+
+
+@pytest.mark.django_db
+def test_pinned_still_persists_filter_values_to_session(client_publisher_order, publishers, monkeypatch):
+    from tests.test1.app.views import PublisherOrderCardListView
+
+    monkeypatch.setattr(PublisherOrderCardListView, "cv_filter_pinned", True)
+
+    # submit a filter value -> stored in session (cv_filter_persistence defaults True)
+    response = client_publisher_order.get("/publisher_order/card/?name=Alp")
+    assert response.status_code == 200
+
+    # a bare GET restores the stored query string via redirect
+    response = client_publisher_order.get("/publisher_order/card/", follow=False)
+    assert response.status_code == 302
+    assert "name=Alp" in response.url

--- a/tests/test1/test_filter_pinned.py
+++ b/tests/test1/test_filter_pinned.py
@@ -1,0 +1,55 @@
+import pytest
+from django.contrib.auth.models import User
+from django.test.client import Client
+
+from tests.lib.helper.user import user_viewset_permission
+
+
+@pytest.fixture
+def cv_publisher_order():
+    from tests.test1.app.views import cv_publisher_order as ret
+
+    return ret
+
+
+@pytest.fixture
+def client_publisher_order(client, cv_publisher_order) -> Client:
+    user = User.objects.create_user(username="user_pinned_card", password="password")
+    user_viewset_permission(user, cv_publisher_order, "view")
+    client.force_login(user)
+    return client
+
+
+@pytest.fixture
+def publishers(db):
+    from tests.test1.app.models import Publisher
+
+    return [
+        Publisher.objects.create(name="Charlie"),
+        Publisher.objects.create(name="Alpha"),
+        Publisher.objects.create(name="Bravo"),
+    ]
+
+
+def test_filter_pinned_default_comes_from_setting():
+    from crud_views.lib.settings import crud_views_settings
+    from crud_views.lib.views import ListViewTableFilterMixin
+
+    assert ListViewTableFilterMixin.cv_filter_pinned == crud_views_settings.filter_pinned
+    assert crud_views_settings.filter_pinned is False
+
+
+@pytest.mark.django_db
+def test_pinned_view_forces_filter_expanded_context(client_publisher_order, publishers, monkeypatch):
+    from tests.test1.app.views import PublisherOrderCardListView
+
+    response = client_publisher_order.get("/publisher_order/card/")
+    assert response.status_code == 200
+    assert response.context["cv_filter_pinned"] is False
+    assert response.context["cv_filter_expanded"] is False
+
+    monkeypatch.setattr(PublisherOrderCardListView, "cv_filter_pinned", True)
+    response = client_publisher_order.get("/publisher_order/card/")
+    assert response.status_code == 200
+    assert response.context["cv_filter_pinned"] is True
+    assert response.context["cv_filter_expanded"] is True

--- a/tests/test1/test_filter_pinned.py
+++ b/tests/test1/test_filter_pinned.py
@@ -53,3 +53,21 @@ def test_pinned_view_forces_filter_expanded_context(client_publisher_order, publ
     assert response.status_code == 200
     assert response.context["cv_filter_pinned"] is True
     assert response.context["cv_filter_expanded"] is True
+
+
+@pytest.mark.django_db
+def test_pinned_hides_filter_toggle_button(client_publisher_order, publishers, monkeypatch):
+    from lxml import html
+
+    from tests.test1.app.views import PublisherOrderCardListView
+
+    # not pinned: toggle button present
+    response = client_publisher_order.get("/publisher_order/card/")
+    doc = html.fromstring(response.content)
+    assert doc.cssselect("#cv-filter-toggle"), "toggle should be present when not pinned"
+
+    # pinned: toggle button hidden
+    monkeypatch.setattr(PublisherOrderCardListView, "cv_filter_pinned", True)
+    response = client_publisher_order.get("/publisher_order/card/")
+    doc = html.fromstring(response.content)
+    assert not doc.cssselect("#cv-filter-toggle"), "toggle should be hidden when pinned"

--- a/tests/test1/test_filter_pinned.py
+++ b/tests/test1/test_filter_pinned.py
@@ -71,3 +71,23 @@ def test_pinned_hides_filter_toggle_button(client_publisher_order, publishers, m
     response = client_publisher_order.get("/publisher_order/card/")
     doc = html.fromstring(response.content)
     assert not doc.cssselect("#cv-filter-toggle"), "toggle should be hidden when pinned"
+
+
+@pytest.mark.django_db
+def test_pinned_renders_filter_without_collapse(client_publisher_order, publishers, monkeypatch):
+    from lxml import html
+
+    from tests.test1.app.views import PublisherOrderCardListView
+
+    # not pinned: collapse wrapper present, filter form present
+    response = client_publisher_order.get("/publisher_order/card/")
+    doc = html.fromstring(response.content)
+    assert doc.cssselect("#filter-collapse"), "collapse wrapper expected when not pinned"
+    assert doc.cssselect("form#filter-form"), "filter form expected"
+
+    # pinned: no collapse wrapper, but filter form still rendered
+    monkeypatch.setattr(PublisherOrderCardListView, "cv_filter_pinned", True)
+    response = client_publisher_order.get("/publisher_order/card/")
+    doc = html.fromstring(response.content)
+    assert not doc.cssselect("#filter-collapse"), "collapse wrapper must be gone when pinned"
+    assert doc.cssselect("form#filter-form"), "filter form must still render when pinned"


### PR DESCRIPTION
## Summary

- Adds opt-in `cv_filter_pinned` on `ListViewTableFilterMixin` (covers both `ListView` and `CardListView`): when `True`, the filter renders always-open and the filter toggle context button is hidden.
- Default comes from a new flat setting `CRUD_VIEWS_FILTER_PINNED` (default `False`) — existing behavior unchanged.
- Filter field-value session persistence (`cv_filter_persistence`) is unaffected; only the now-irrelevant expanded/collapsed state is dropped.
- bootstrap5 `list_filter.html` drops the collapse wrapper when pinned (shared `list_filter.inner.html` partial); the plain theme needs no template change (its filter is already always-visible; the shared button-hide removes its dead toggle).
- Docs (`list_view`, `card-list-view`, `settings`) + in-project skill updated; bootstrap5 example pins the filter on `AuthorListView` and `BookCardListView`.

Implemented TDD via subagent-driven development (spec → plan in `superpowers/`); each task passed spec + code-quality review.

## Test Plan
- [x] `cd tests && pytest` — 352 passed, 1 skipped (+6 new tests in `test_filter_pinned.py`)
- [x] Default-off parity: non-pinned path renders the original collapse markup unchanged
- [x] bootstrap5 example passes `manage.py check`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)