### PR TITLE
docs(skill): correct settings docs to flat CRUD_VIEWS_* settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__
 *.pyc
 db.sqlite3
 uv.lock
+/site
 /dist
 /django_crud_views.egg-info
 /PRIVATE.md

--- a/skills/django-crud-views/SKILL.md
+++ b/skills/django-crud-views/SKILL.md
@@ -394,23 +394,26 @@ Full API: [references/api-reference.md](references/api-reference.md). Reference 
 
 ## Settings (Django `settings.py`)
 
+Each setting is a flat, module-level Django setting prefixed with `CRUD_VIEWS_` (read via
+`getattr(settings, "CRUD_VIEWS_<NAME>", default)`). There is no `CRUD_VIEWS = {...}` dict.
+Only `CRUD_VIEWS_EXTENDS` is required; the rest show their defaults:
+
 ```python
-CRUD_VIEWS = {
-    "EXTENDS": "base.html",                    # required: base template
-    "MANAGE_VIEWS_ENABLED": "debug_only",      # "yes" | "no" | "debug_only"
-    "CRUD_VIEWS_MANAGE_GROUP": "CRUD_VIEWS_MANAGE",  # group name granting manage access
-    "CRUD_VIEWS_MANAGE_SHOW_USERS": False,      # show Users column in Permission Holders
-    "SESSION_DATA_KEY": "viewset",
-    "FILTER_PERSISTENCE": True,
-    "FILTER_ICON": "fa-solid fa-filter",
-    "FILTER_RESET_BUTTON_CSS_CLASS": "btn btn-secondary",
-    "LIST_ACTIONS": ["detail", "update", "delete"],
-    "LIST_CONTEXT_ACTIONS": ["parent", "filter", "create"],
-    "DETAIL_CONTEXT_ACTIONS": ["home", "update", "delete"],
-    "CREATE_CONTEXT_ACTIONS": ["home"],
-    "UPDATE_CONTEXT_ACTIONS": ["home"],
-    "DELETE_CONTEXT_ACTIONS": ["home"],
-}
+CRUD_VIEWS_EXTENDS = "base.html"                       # required: base template
+CRUD_VIEWS_MANAGE_VIEWS_ENABLED = "debug_only"         # "yes" | "no" | "debug_only"
+CRUD_VIEWS_MANAGE_GROUP = "CRUD_VIEWS_MANAGE"           # group name granting manage access
+CRUD_VIEWS_MANAGE_SHOW_USERS = False                   # show Users column in Permission Holders
+CRUD_VIEWS_SESSION_DATA_KEY = "viewset"
+CRUD_VIEWS_FILTER_PERSISTENCE = True                   # store filter state in session
+CRUD_VIEWS_FILTER_PINNED = False                       # True = filter always open, toggle hidden
+CRUD_VIEWS_FILTER_ICON = "fa-solid fa-filter"
+CRUD_VIEWS_FILTER_RESET_BUTTON_CSS_CLASS = "btn btn-secondary"
+CRUD_VIEWS_LIST_ACTIONS = ["detail", "update", "delete"]
+CRUD_VIEWS_LIST_CONTEXT_ACTIONS = ["parent", "list", "filter", "create"]
+CRUD_VIEWS_DETAIL_CONTEXT_ACTIONS = ["home", "detail", "update", "delete"]
+CRUD_VIEWS_CREATE_CONTEXT_ACTIONS = ["home", "create"]
+CRUD_VIEWS_UPDATE_CONTEXT_ACTIONS = ["home", "detail", "update", "delete"]
+CRUD_VIEWS_DELETE_CONTEXT_ACTIONS = ["home", "detail", "update", "delete"]
 ```
 
 See [references/api-reference.md](references/api-reference.md) for full settings and all ViewSet/view attributes.

--- a/skills/django-crud-views/references/api-reference.md
+++ b/skills/django-crud-views/references/api-reference.md
@@ -577,36 +577,37 @@ class VehicleListView(ListViewTableMixin, ListViewPermissionRequired):
 
 ## Settings
 
-All settings go under `CRUD_VIEWS` in `settings.py`:
+Settings are flat, module-level Django settings, each prefixed with `CRUD_VIEWS_`
+(read via `getattr(settings, "CRUD_VIEWS_<NAME>", default)`) — there is no `CRUD_VIEWS = {...}`
+dict. Only `CRUD_VIEWS_EXTENDS` is required; the rest show their defaults:
 
 ```python
-CRUD_VIEWS = {
-    # Required
-    "EXTENDS": "base.html",                    # base template to extend
+# Required
+CRUD_VIEWS_EXTENDS = "base.html"                       # base template to extend
 
-    # Manage view
-    "MANAGE_VIEWS_ENABLED": "debug_only",      # "yes" | "no" | "debug_only"
+# Manage view
+CRUD_VIEWS_MANAGE_VIEWS_ENABLED = "debug_only"         # "yes" | "no" | "debug_only"
 
-    # Session
-    "SESSION_DATA_KEY": "viewset",
+# Session
+CRUD_VIEWS_SESSION_DATA_KEY = "viewset"
 
-    # Filter
-    "FILTER_PERSISTENCE": True,
-    "FILTER_ICON": "fa-solid fa-filter",
-    "FILTER_RESET_BUTTON_CSS_CLASS": "btn btn-secondary",
+# Filter
+CRUD_VIEWS_FILTER_PERSISTENCE = True
+CRUD_VIEWS_FILTER_PINNED = False                       # True = filter always open, toggle hidden
+CRUD_VIEWS_FILTER_ICON = "fa-solid fa-filter"
+CRUD_VIEWS_FILTER_RESET_BUTTON_CSS_CLASS = "btn btn-secondary"
 
-    # Default per-row actions for list views
-    "LIST_ACTIONS": ["detail", "update", "delete"],
+# Default per-row actions for list views
+CRUD_VIEWS_LIST_ACTIONS = ["detail", "update", "delete"]
 
-    # Default page-level (context) actions per view type
-    "LIST_CONTEXT_ACTIONS": ["parent", "filter", "create"],
-    "DETAIL_CONTEXT_ACTIONS": ["home", "update", "delete"],
-    "CREATE_CONTEXT_ACTIONS": ["home"],
-    "UPDATE_CONTEXT_ACTIONS": ["home"],
-    "DELETE_CONTEXT_ACTIONS": ["home"],
-    "MANAGE_CONTEXT_ACTIONS": ["home"],
-    "CREATE_SELECT_CONTEXT_ACTIONS": ["home"],
-}
+# Default page-level (context) actions per view type
+CRUD_VIEWS_LIST_CONTEXT_ACTIONS = ["parent", "list", "filter", "create"]
+CRUD_VIEWS_DETAIL_CONTEXT_ACTIONS = ["home", "detail", "update", "delete"]
+CRUD_VIEWS_CREATE_CONTEXT_ACTIONS = ["home", "create"]
+CRUD_VIEWS_UPDATE_CONTEXT_ACTIONS = ["home", "detail", "update", "delete"]
+CRUD_VIEWS_DELETE_CONTEXT_ACTIONS = ["home", "detail", "update", "delete"]
+CRUD_VIEWS_MANAGE_CONTEXT_ACTIONS = ["home"]
+CRUD_VIEWS_CREATE_SELECT_CONTEXT_ACTIONS = ["home", "create_select"]
 ```
 
 ### django-object-detail settings (for DetailView)


### PR DESCRIPTION
## Summary

The in-project skill documented settings as a `CRUD_VIEWS = {...}` dict, but the package reads **flat, module-level** Django settings (`getattr(settings, "CRUD_VIEWS_<NAME>", default)`). That dict would silently do nothing.

- Converts both skill settings examples (`SKILL.md` and `references/api-reference.md`) to flat `CRUD_VIEWS_*` assignments.
- Corrects stale default values to match `src/crud_views/lib/settings.py` (e.g. `LIST_CONTEXT_ACTIONS` now includes `"list"`; detail/create/update/delete context-action defaults updated; `CREATE_SELECT_CONTEXT_ACTIONS` default fixed).
- Adds the new `CRUD_VIEWS_FILTER_PINNED` setting.
- Notes only `CRUD_VIEWS_EXTENDS` is required.

Docs-only change to skill files; not exercised by the test suite.

## Test Plan
- [x] No `CRUD_VIEWS = {` dict form remains in `skills/` (only the explanatory "there is no ... dict" text)
- [x] Setting names/defaults match `src/crud_views/lib/settings.py`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)