### PR TITLE
Context button templating & manual placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Context button templating & manual placement: `ContextButton` now accepts `template`/`template_code` to render the whole button (not just its label, which `label_template`/`label_template_code` still cover), defaulting to the new `CRUD_VIEWS_CONTEXT_BUTTON_TEMPLATE` setting (default `crud_views/tags/context_action.html`). Place a single button anywhere with `{% cv_context_button "key" %}` (object defaults to the view's object; renders nothing when access is denied — unlike the `{% cv_context_actions %}` container, which greys it out); render a custom loop via `view.cv_get_context_buttons` (access-filtered) + `{% cv_render_context_button ctx %}`; and gate surrounding markup with the `view|cv_context_has_permission:"key"` filter
 - Pinned filter: set `cv_filter_pinned = True` on a filtered `ListView`/`CardListView` (or the global `CRUD_VIEWS_FILTER_PINNED` setting, default `False`) to render the filter always-open and hide the filter toggle button. Filter field values are still persisted to the session via `cv_filter_persistence`; only the now-irrelevant expanded/collapsed state is dropped (bootstrap5 renders the filter without its collapse wrapper; the plain theme is unaffected)
 
 ## 0.6.0

--- a/docs/.pages
+++ b/docs/.pages
@@ -2,4 +2,5 @@ nav:
     - Home: index.md
     - getting_started
     - reference
+    - FAQ: faq.md
     - development

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,143 @@
+# FAQ
+
+## How to template context buttons
+
+Every [context button](reference/context_buttons.md) is rendered through a Django template.
+By default that template is the theme's `crud_views/tags/context_action.html`, configurable
+project-wide via the `CRUD_VIEWS_CONTEXT_BUTTON_TEMPLATE` setting.
+
+A `ContextButton` can override the template *for that button only* with two fields:
+
+| Field           | Type          | Description                                              |
+|-----------------|---------------|----------------------------------------------------------|
+| `template`      | `str \| None` | Path to a Django template for the whole button           |
+| `template_code` | `str \| None` | Inline Django template string for the whole button       |
+
+`template_code` takes precedence over `template`; if neither is set, the
+`CRUD_VIEWS_CONTEXT_BUTTON_TEMPLATE` default is used.
+
+!!! note
+    These template the **whole button**. The existing `label_template` /
+    `label_template_code` fields only template the button's **label** inside the default
+    button markup.
+
+The button template is rendered with the resolved button context, which includes:
+
+- `cv_url` — the target URL
+- `cv_key` — the action key
+- `cv_action_label` — the rendered label
+- `cv_icon_action` — the icon CSS class
+- `cv_access` — `True` when the user may access the target
+- `cv_action_enabled` — `False` hides the button
+- `cv_is_active` — `True` when the button points at the current view
+
+### Give a button a different shape in one view
+
+Define a variant button in the viewset with its own template, then reference it only from
+the view that needs the different shape:
+
+```python
+from crud_views.lib.viewset import ViewSet, context_buttons_default
+from crud_views.lib.view import ContextButton
+from crud_views.lib.views import DetailViewPermissionRequired, ListViewPermissionRequired
+
+cv_author = ViewSet(
+    model=Author,
+    name="author",
+    context_buttons=context_buttons_default() + [
+        # the standard edit button, plus a variant with a custom template
+        ContextButton(key="edit", key_target="update"),
+        ContextButton(
+            key="edit_detail",
+            key_target="update",
+            template_code=(
+                '<a href="{{ cv_url }}" class="btn btn-primary btn-lg" cv-key="{{ cv_key }}">'
+                '<i class="{{ cv_icon_action }}"></i> {{ cv_action_label }}</a>'
+            ),
+        ),
+    ],
+)
+
+
+class AuthorListView(ListViewPermissionRequired):
+    cv_viewset = cv_author
+    cv_context_actions = ["edit", "delete"]          # default-shaped edit button
+
+
+class AuthorDetailView(DetailViewPermissionRequired):
+    cv_viewset = cv_author
+    cv_context_actions = ["edit_detail", "delete"]   # custom-shaped edit button
+```
+
+To change the layout of *all* context buttons project-wide, override
+`crud_views/tags/context_action.html` in your project's templates, or point
+`CRUD_VIEWS_CONTEXT_BUTTON_TEMPLATE` at your own template.
+
+## I need to render a context button manually in a template
+
+Use the `cv_context_button` tag to place a single button anywhere in your own layout,
+referenced by its key:
+
+```django
+{% load crud_views %}
+
+<div class="my-toolbar">
+    {% cv_context_button "edit_detail" %}
+    {% cv_context_button "delete" %}
+</div>
+```
+
+The object defaults to the view's current object, so you don't normally pass it. To target
+a different object explicitly:
+
+```django
+{% cv_context_button "edit_detail" some_object %}
+```
+
+!!! note "Hidden when there is no access"
+    `cv_context_button` renders **nothing** when the user lacks access to the target or the
+    action is disabled. This differs from the default `{% cv_context_actions %}` container,
+    which renders inaccessible buttons as *disabled/greyed*. Reach for the manual tag when
+    you want the button to disappear entirely.
+
+### Gate surrounding markup by permission
+
+Use the `cv_context_has_permission` filter to render wrappers, headings, or separators only
+when the user may access a key:
+
+```django
+{% load crud_views %}
+
+{% if view|cv_context_has_permission:"edit_detail" %}
+    <h3>Edit</h3>
+    {% cv_context_button "edit_detail" %}
+{% endif %}
+```
+
+The filter checks access for `view`'s current object (or `None` for list-type views) and
+returns `False` for unknown keys.
+
+### Render a custom loop of buttons
+
+`view.cv_get_context_buttons` returns the resolved, **access-filtered** button contexts (so
+your loop never emits empty wrappers). Render each with `cv_render_context_button`:
+
+```django
+{% load crud_views %}
+
+{% for ctx in view.cv_get_context_buttons %}
+    <span class="my-wrap">{% cv_render_context_button ctx %}</span>
+{% endfor %}
+```
+
+By default it iterates the view's `cv_context_actions`. Pass an explicit key list from your
+own view method to control which buttons appear and in what order:
+
+```python
+class AuthorDetailView(DetailViewPermissionRequired):
+    cv_viewset = cv_author
+    cv_context_actions = ["edit_detail", "delete"]
+
+    def get_toolbar_buttons(self):
+        return self.cv_get_context_buttons(keys=["edit_detail", "delete"])
+```

--- a/docs/reference/context_buttons.md
+++ b/docs/reference/context_buttons.md
@@ -26,6 +26,8 @@ ContextButton(
     key_target="detail",           # target view key within the same viewset
     label_template=None,           # path to a Django template for the label
     label_template_code=None,      # inline Django template string for the label
+    template=None,                 # path to a Django template for the whole button
+    template_code=None,            # inline Django template string for the whole button
 )
 ```
 
@@ -35,8 +37,15 @@ ContextButton(
 | `key_target`          | `str \| None` | `None`   | Target view key within the same viewset          |
 | `label_template`      | `str \| None` | `None`   | Path to a Django template for the button label   |
 | `label_template_code` | `str \| None` | `None`   | Inline Django template string for the label      |
+| `template`            | `str \| None` | `None`   | Path to a Django template for the whole button   |
+| `template_code`       | `str \| None` | `None`   | Inline Django template string for the whole button |
 
 Access is checked via the target view's `cv_has_access(user, obj)`.
+
+When neither `template` nor `template_code` is set, the button uses the
+`CRUD_VIEWS_CONTEXT_BUTTON_TEMPLATE` setting (default
+`crud_views/tags/context_action.html`). For placing buttons by hand in a custom layout, see
+the [FAQ](../faq.md).
 
 ## ParentContextButton
 

--- a/src/crud_views/lib/settings.py
+++ b/src/crud_views/lib/settings.py
@@ -86,6 +86,13 @@ class CrudViewsSettings(BaseModel):
     def theme_path(self) -> str:
         return "crud_views"
 
+    @property
+    def context_button_template(self) -> str:
+        return from_settings(
+            "CRUD_VIEWS_CONTEXT_BUTTON_TEMPLATE",
+            default=f"{self.theme_path}/tags/context_action.html",
+        )
+
     def get_js(self, path: str) -> str:
         return f"{self.theme_path}/js/{path}"
 

--- a/src/crud_views/lib/view/base.py
+++ b/src/crud_views/lib/view/base.py
@@ -293,6 +293,22 @@ class CrudView(metaclass=CrudViewMetaClass):
                 return cb
         return None
 
+    def cv_get_context_buttons(self, keys: list[str] | None = None, obj=None) -> list[dict]:
+        """
+        Resolved, access-filtered context-button data for a custom template loop.
+        keys defaults to this view's cv_context_actions; obj defaults to the view's object.
+        """
+        keys = keys if keys is not None else (self.cv_context_actions or [])
+        if obj is None:
+            obj = getattr(self, "object", None)
+        result: list[dict] = []
+        for key in keys:
+            ctx = self.cv_get_context(key=key, obj=obj, user=self.request.user, request=self.request)
+            if not ctx or ctx.get("cv_action_enabled") is False or ctx.get("cv_access") is not True:
+                continue
+            result.append(ctx)
+        return result
+
     def cv_get_oid(self, key: str, obj: Model | None = None) -> str | None:
         """
         get unique object id

--- a/src/crud_views/lib/view/base.py
+++ b/src/crud_views/lib/view/base.py
@@ -324,6 +324,7 @@ class CrudView(metaclass=CrudViewMetaClass):
             cv_oid=self.cv_get_oid(key=key, obj=obj),
             cv_url=self.cv_get_url(key=key, obj=obj),
             cv_is_active=self.cv_viewset.get_router_name(key) == context.router_name,
+            cv_template=crud_views_settings.context_button_template,
         )
 
         # get target view class

--- a/src/crud_views/lib/view/buttons.py
+++ b/src/crud_views/lib/view/buttons.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .context import ViewContext
 from ..settings import crud_views_settings
@@ -14,6 +14,8 @@ class ContextButton(BaseModel):
     key_target: str | None = None
     label_template: str | None = None
     label_template_code: str | None = None
+    template: str | None = None
+    template_code: str | None = None
 
     @staticmethod
     def _resolve_container_key(viewset, key_target: str) -> str:
@@ -27,6 +29,14 @@ class ContextButton(BaseModel):
             return context.view.render_snippet(data, self.label_template)
         elif self.label_template_code:
             return context.view.render_snippet(data, template_code=self.label_template_code)
+
+    def _inject_template(self, data: dict) -> None:
+        if self.template_code:
+            data["cv_template_code"] = self.template_code
+        elif self.template:
+            data["cv_template"] = self.template
+        else:
+            data["cv_template"] = crud_views_settings.context_button_template
 
     def get_context(self, context: ViewContext) -> dict:
         key_target = self._resolve_container_key(context.view.cv_viewset, self.key_target)
@@ -53,6 +63,8 @@ class ContextButton(BaseModel):
         cv_action_label = self.render_label(data, context)
         if cv_action_label:
             data["cv_action_label"] = cv_action_label
+
+        self._inject_template(data)
 
         return data
 
@@ -101,6 +113,7 @@ class ParentContextButton(ContextButton):
             )
 
         data = cls.cv_get_dict(context=context, **dict_kwargs)
+        self._inject_template(data)
         return data
 
 
@@ -139,6 +152,8 @@ class ChildContextButton(ContextButton):
         if cv_action_label:
             data["cv_action_label"] = cv_action_label
 
+        self._inject_template(data)
+
         return data
 
 
@@ -148,6 +163,9 @@ class FilterContextButton(ContextButton):
     """
 
     key: str = "filter"
+    template: str | None = Field(
+        default_factory=lambda: f"{crud_views_settings.theme_path}/tags/context_action_filter.html"
+    )
 
     def get_context(self, context: ViewContext) -> dict:
         from ..views import ListViewTableFilterMixin
@@ -165,14 +183,9 @@ class FilterContextButton(ContextButton):
         list_url = context.view.cv_get_url(key=context.view.cv_key)
 
         data = dict()
-
-        # render action label
-        cv_action_label = "Filter"
-        if cv_action_label:
-            data["cv_action_label"] = cv_action_label
-
+        data["cv_action_label"] = "Filter"
         data["cv_icon_action"] = crud_views_settings.filter_icon
         data["cv_url"] = list_url
-        data["cv_template"] = f"{crud_views_settings.theme_path}/tags/context_action_filter.html"
+        self._inject_template(data)
 
         return data

--- a/src/crud_views/templatetags/crud_views.py
+++ b/src/crud_views/templatetags/crud_views.py
@@ -211,6 +211,15 @@ def cv_is_list(arg):
     return isinstance(arg, (list, tuple))
 
 
+@register.filter
+def cv_context_has_permission(view, key) -> bool:
+    try:
+        cls = view.cv_viewset.get_view_class(key)
+    except Exception:
+        return False
+    return bool(cls.cv_has_access(view.request.user, getattr(view, "object", None)))
+
+
 @register.inclusion_tag(f"{crud_views_settings.theme_path}/tags/card_action.html", takes_context=True)
 def cv_card_action(context, action, obj=None):
     view = cv_get_view(context)

--- a/src/crud_views/templatetags/crud_views.py
+++ b/src/crud_views/templatetags/crud_views.py
@@ -67,7 +67,10 @@ def cv_list_action_form(context, key, obj=None):
 def cv_context_action(context, key, obj=None):
     obj = None if not obj else obj  # fix empty string from template
     ctx = cv_get_context(context=context, key=key, obj=obj)
-    template = ctx.get("cv_template", f"{crud_views_settings.theme_path}/tags/context_action.html")
+    if ctx.get("cv_template_code"):
+        view = cv_get_view(context)
+        return view.render_snippet(ctx, template_code=ctx["cv_template_code"])
+    template = ctx.get("cv_template") or crud_views_settings.context_button_template
     return render_to_string(template, context=ctx, request=context["request"])
 
 

--- a/src/crud_views/templatetags/crud_views.py
+++ b/src/crud_views/templatetags/crud_views.py
@@ -94,6 +94,12 @@ def cv_context_button(context, key, obj=None):
     return _render_context_button(view, ctx)
 
 
+@register.simple_tag(takes_context=True)
+def cv_render_context_button(context, ctx) -> str:
+    view = cv_get_view(context)
+    return _render_context_button(view, ctx)
+
+
 @register.inclusion_tag(f"{crud_views_settings.theme_path}/tags/context_actions.html", takes_context=True)
 def cv_context_actions(context, obj=None):
     view: CrudView = cv_get_view(context)

--- a/src/crud_views/templatetags/crud_views.py
+++ b/src/crud_views/templatetags/crud_views.py
@@ -31,6 +31,15 @@ def cv_get_context(context, key, obj=None) -> dict:
     return context
 
 
+def _render_context_button(view, ctx) -> str:
+    if not ctx or ctx.get("cv_action_enabled") is False or ctx.get("cv_access") is not True:
+        return ""
+    if ctx.get("cv_template_code"):
+        return view.render_snippet(ctx, template_code=ctx["cv_template_code"])
+    template = ctx.get("cv_template") or crud_views_settings.context_button_template
+    return view.render_snippet(ctx, template=template)
+
+
 def _cv_config_context(context):
     request = context["request"]
     from django.middleware.csrf import get_token
@@ -72,6 +81,17 @@ def cv_context_action(context, key, obj=None):
         return view.render_snippet(ctx, template_code=ctx["cv_template_code"])
     template = ctx.get("cv_template") or crud_views_settings.context_button_template
     return render_to_string(template, context=ctx, request=context["request"])
+
+
+@register.simple_tag(takes_context=True)
+@ignore_exception(ViewSetKeyFoundError, default_value="")
+def cv_context_button(context, key, obj=None):
+    obj = None if not obj else obj  # fix empty string from template
+    view = cv_get_view(context)
+    if obj is None:
+        obj = getattr(view, "object", None)
+    ctx = cv_get_context(context=context, key=key, obj=obj)
+    return _render_context_button(view, ctx)
 
 
 @register.inclusion_tag(f"{crud_views_settings.theme_path}/tags/context_actions.html", takes_context=True)

--- a/superpowers/plans/2026-06-17-context-button-templating.md
+++ b/superpowers/plans/2026-06-17-context-button-templating.md
@@ -1,0 +1,603 @@
+# Context Button Templating & Manual Placement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let context buttons carry their own render template and be placed by hand anywhere in a template (by key, in a custom loop, and gated by a permission filter), so the same logical action can render with a different shape per view.
+
+**Architecture:** Add `template` / `template_code` to the base `ContextButton` (inherited by all subclasses), defaulting to a new `crud_views_settings.context_button_template`. Both branches of `CrudView.cv_get_context` inject a template so every rendered action carries one. Add three template-layer entry points — `{% cv_context_button key %}`, `{% cv_render_context_button ctx %}` + `view.cv_get_context_buttons`, and the `view|cv_context_has_permission:"key"` filter — that share a single render helper using the existing `CrudView.render_snippet`. The default `{% cv_context_actions %}` container is left behaviorally unchanged.
+
+**Tech Stack:** Python, Django (4.2/5.2/6.0), Pydantic (settings + button models), pytest. Two themes share templates under the `crud_views/` template namespace (`crud_views_settings.theme_path == "crud_views"`).
+
+## Global Constraints
+
+- Line length 120, double quotes, ruff format/check (per CLAUDE.md).
+- All `CrudView`/button additions keep the `cv_` prefix for public attributes and template entry points.
+- Backwards compatibility is mandatory: existing viewsets, views, the `{% cv_context_actions %}` container, and `{% cv_context_action %}` rendering must behave identically for existing keys.
+- Two render contracts are deliberate: the default container renders no-access buttons as *disabled*; the new manual API (`cv_context_button`, loop, filter) *hides* on no-access. Do not change the container's contract.
+- View-level `ContextButton` instances in `cv_context_actions` (issue #27) are explicitly out of scope.
+- Tests live in `tests/test1/`; run from the `tests/` directory.
+
+---
+
+### Task 1: `ContextButton` templating foundation
+
+Add the template fields, the settings default, and inject a template in both branches of `cv_get_context` so the existing container keeps working with the default and newly supports `template_code`.
+
+**Files:**
+- Modify: `src/crud_views/lib/settings.py` (add `context_button_template` property)
+- Modify: `src/crud_views/lib/view/buttons.py` (fields + `_inject_template`, wire into `ContextButton`, `ParentContextButton`, `ChildContextButton`, `FilterContextButton`)
+- Modify: `src/crud_views/lib/view/base.py:305-345` (`cv_get_context` view-key branch injects `cv_template`)
+- Modify: `src/crud_views/templatetags/crud_views.py:65-71` (`cv_context_action` honors `cv_template_code`, falls back to settings)
+- Test: `tests/test1/test_context_button_template.py` (new)
+
+**Interfaces:**
+- Produces:
+  - `crud_views_settings.context_button_template -> str` (default `"crud_views/tags/context_action.html"`, overridable via `CRUD_VIEWS_CONTEXT_BUTTON_TEMPLATE`)
+  - `ContextButton.template: str | None`, `ContextButton.template_code: str | None`
+  - `ContextButton._inject_template(self, data: dict) -> None` — sets `data["cv_template_code"]` if `template_code`, else `data["cv_template"]` from `template` or the settings default
+  - Every dict returned by `cv_get_context` for a renderable key now carries `cv_template` or `cv_template_code`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test1/test_context_button_template.py`:
+
+```python
+"""ContextButton template / template_code fields and the settings default."""
+
+import pytest
+
+from crud_views.lib.settings import crud_views_settings
+from crud_views.lib.view.buttons import ContextButton, FilterContextButton
+
+
+def test_settings_default_template():
+    assert crud_views_settings.context_button_template == "crud_views/tags/context_action.html"
+
+
+def test_settings_template_override(monkeypatch):
+    from django.conf import settings as dj_settings
+
+    monkeypatch.setattr(dj_settings, "CRUD_VIEWS_CONTEXT_BUTTON_TEMPLATE", "x/y.html", raising=False)
+    # property reads Django settings live
+    assert crud_views_settings.context_button_template == "x/y.html"
+
+
+def test_inject_template_default():
+    data = {}
+    ContextButton(key="edit", key_target="update")._inject_template(data)
+    assert data == {"cv_template": "crud_views/tags/context_action.html"}
+
+
+def test_inject_template_file():
+    data = {}
+    ContextButton(key="edit", key_target="update", template="app/edit.html")._inject_template(data)
+    assert data == {"cv_template": "app/edit.html"}
+
+
+def test_inject_template_code_wins():
+    data = {}
+    ContextButton(
+        key="edit", key_target="update", template="app/edit.html", template_code="<a>{{ cv_url }}</a>"
+    )._inject_template(data)
+    assert data == {"cv_template_code": "<a>{{ cv_url }}</a>"}
+
+
+def test_filter_button_default_template():
+    assert FilterContextButton().template == "crud_views/tags/context_action_filter.html"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tests && pytest test1/test_context_button_template.py -v`
+Expected: FAIL — `context_button_template` attribute missing / `ContextButton` has no `template` field.
+
+- [ ] **Step 3: Add the settings property**
+
+In `src/crud_views/lib/settings.py`, next to the existing `theme_path` property (around line 84), add:
+
+```python
+    @property
+    def context_button_template(self) -> str:
+        return from_settings(
+            "CRUD_VIEWS_CONTEXT_BUTTON_TEMPLATE",
+            default=f"{self.theme_path}/tags/context_action.html",
+        )
+```
+
+- [ ] **Step 4: Add fields + `_inject_template` to `ContextButton`**
+
+In `src/crud_views/lib/view/buttons.py`, add the import at the top:
+
+```python
+from pydantic import BaseModel, Field
+```
+
+Extend the base `ContextButton` fields (after `label_template_code`):
+
+```python
+    template: str | None = None
+    template_code: str | None = None
+```
+
+Add the helper method to `ContextButton` (after `render_label`):
+
+```python
+    def _inject_template(self, data: dict) -> None:
+        if self.template_code:
+            data["cv_template_code"] = self.template_code
+        elif self.template:
+            data["cv_template"] = self.template
+        else:
+            data["cv_template"] = crud_views_settings.context_button_template
+```
+
+Call `self._inject_template(data)` at the end of `get_context` in `ContextButton`, `ParentContextButton`, and `ChildContextButton` — immediately before `return data` (for `ContextButton`, after the label block; place it before `return data`).
+
+- [ ] **Step 5: Update `FilterContextButton`**
+
+In `FilterContextButton`, set the field default and drop the hardcoded `cv_template` line. Replace the class body so it reads:
+
+```python
+class FilterContextButton(ContextButton):
+    """
+    A context button that
+    """
+
+    key: str = "filter"
+    template: str | None = Field(
+        default_factory=lambda: f"{crud_views_settings.theme_path}/tags/context_action_filter.html"
+    )
+
+    def get_context(self, context: ViewContext) -> dict:
+        from ..views import ListViewTableFilterMixin
+
+        dict_kwargs = dict(cv_access=False)
+
+        # if view has no filter, no button is shown
+        if not isinstance(context.view, ListViewTableFilterMixin):
+            return dict_kwargs
+
+        # pinned filter is always visible -> no toggle button
+        if getattr(context.view, "cv_filter_pinned", False):
+            return dict_kwargs
+
+        list_url = context.view.cv_get_url(key=context.view.cv_key)
+
+        data = dict()
+        data["cv_action_label"] = "Filter"
+        data["cv_icon_action"] = crud_views_settings.filter_icon
+        data["cv_url"] = list_url
+        self._inject_template(data)
+
+        return data
+```
+
+- [ ] **Step 6: Inject `cv_template` in the view-key branch of `cv_get_context`**
+
+In `src/crud_views/lib/view/base.py`, in `cv_get_context` view-key branch, add `cv_template` to `dict_kwargs` (the dict around line 321):
+
+```python
+        dict_kwargs = dict(
+            cv_access=False,
+            cv_oid=self.cv_get_oid(key=key, obj=obj),
+            cv_url=self.cv_get_url(key=key, obj=obj),
+            cv_is_active=self.cv_viewset.get_router_name(key) == context.router_name,
+            cv_template=crud_views_settings.context_button_template,
+        )
+```
+
+Confirm `crud_views_settings` is imported in `base.py`; if not, add `from ..settings import crud_views_settings`.
+
+- [ ] **Step 7: Update `cv_context_action` to honor `template_code` and use the settings fallback**
+
+In `src/crud_views/templatetags/crud_views.py`, replace the body of `cv_context_action` (lines 65-71):
+
+```python
+@register.simple_tag(takes_context=True)
+@ignore_exception(ViewSetKeyFoundError, default_value="")
+def cv_context_action(context, key, obj=None):
+    obj = None if not obj else obj  # fix empty string from template
+    ctx = cv_get_context(context=context, key=key, obj=obj)
+    if ctx.get("cv_template_code"):
+        view = cv_get_view(context)
+        return view.render_snippet(ctx, template_code=ctx["cv_template_code"])
+    template = ctx.get("cv_template") or crud_views_settings.context_button_template
+    return render_to_string(template, context=ctx, request=context["request"])
+```
+
+(The file-template path keeps passing `request`, preserving current behavior; the settings fallback covers no-button dicts such as the inactive `FilterContextButton`.)
+
+- [ ] **Step 8: Run the new test + regression suite**
+
+Run: `cd tests && pytest test1/test_context_button_template.py test1/test_filter.py test1/test_filter_pinned.py test1/test_context_actions_isolation.py -v`
+Expected: PASS (new file passes; filter/container regressions still green).
+
+- [ ] **Step 9: Format, lint, commit**
+
+```bash
+task format && task check
+git add src/crud_views/lib/settings.py src/crud_views/lib/view/buttons.py src/crud_views/lib/view/base.py src/crud_views/templatetags/crud_views.py tests/test1/test_context_button_template.py
+git commit -m "feat(buttons): ContextButton template/template_code with settings default"
+```
+
+---
+
+### Task 2: `cv_context_button` by-key placement tag
+
+A tag that renders one button by key anywhere, hiding it when the user has no access or the action is disabled.
+
+**Files:**
+- Modify: `src/crud_views/templatetags/crud_views.py` (add `_render_context_button` helper + `cv_context_button` tag)
+- Test: `tests/test1/test_context_button_tag.py` (new)
+
+**Interfaces:**
+- Consumes: `cv_get_context` dicts carrying `cv_template`/`cv_template_code`, `cv_access`, `cv_action_enabled` (Task 1); `CrudView.render_snippet` (existing).
+- Produces:
+  - `_render_context_button(view, ctx) -> str` — returns `""` when `ctx` is falsy / `cv_action_enabled is False` / `cv_access is not True`; else renders `template_code` or `template` (falling back to settings default) via `render_snippet`.
+  - Template tag `{% cv_context_button key obj %}`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test1/test_context_button_tag.py`:
+
+```python
+"""{% cv_context_button %} renders one button by key, hiding on no-access."""
+
+import pytest
+from django.template import Context, Template
+from django.urls import reverse
+
+
+def _render(view, request, snippet):
+    tpl = Template("{% load crud_views %}" + snippet)
+    return tpl.render(Context({"view": view, "request": request})).strip()
+
+
+def _detail_view(client, cv_author, author):
+    url = reverse(cv_author.get_router_name("detail"), kwargs={"pk": author.pk})
+    resp = client.get(url)
+    assert resp.status_code == 200
+    return resp.context["view"], resp.context["request"]
+
+
+@pytest.mark.django_db
+def test_button_rendered_when_access(client_user_author_change, cv_author, author_douglas_adams):
+    view, request = _detail_view(client_user_author_change, cv_author, author_douglas_adams)
+    html = _render(view, request, "{% cv_context_button 'update' %}")
+    assert 'cv-key="update"' in html
+
+
+@pytest.mark.django_db
+def test_button_hidden_without_access(client_user_author_view, cv_author, author_douglas_adams):
+    view, request = _detail_view(client_user_author_view, cv_author, author_douglas_adams)
+    html = _render(view, request, "{% cv_context_button 'update' %}")
+    assert html == ""
+
+
+@pytest.mark.django_db
+def test_unknown_key_is_empty(client_user_author_change, cv_author, author_douglas_adams):
+    view, request = _detail_view(client_user_author_change, cv_author, author_douglas_adams)
+    html = _render(view, request, "{% cv_context_button 'does_not_exist' %}")
+    assert html == ""
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tests && pytest test1/test_context_button_tag.py -v`
+Expected: FAIL — `'cv_context_button'` is not a registered tag.
+
+- [ ] **Step 3: Add helper + tag**
+
+In `src/crud_views/templatetags/crud_views.py`, add after `cv_get_context` (near line 32) the shared helper:
+
+```python
+def _render_context_button(view, ctx) -> str:
+    if not ctx or ctx.get("cv_action_enabled") is False or ctx.get("cv_access") is not True:
+        return ""
+    if ctx.get("cv_template_code"):
+        return view.render_snippet(ctx, template_code=ctx["cv_template_code"])
+    template = ctx.get("cv_template") or crud_views_settings.context_button_template
+    return view.render_snippet(ctx, template=template)
+```
+
+Add the tag after `cv_context_action`:
+
+```python
+@register.simple_tag(takes_context=True)
+@ignore_exception(ViewSetKeyFoundError, default_value="")
+def cv_context_button(context, key, obj=None):
+    obj = None if not obj else obj  # fix empty string from template
+    ctx = cv_get_context(context=context, key=key, obj=obj)
+    view = cv_get_view(context)
+    return _render_context_button(view, ctx)
+```
+
+(`render_snippet` already returns a `mark_safe` string, so the tag output is not double-escaped.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd tests && pytest test1/test_context_button_tag.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+task format && task check
+git add src/crud_views/templatetags/crud_views.py tests/test1/test_context_button_tag.py
+git commit -m "feat(buttons): add {% cv_context_button %} manual placement tag"
+```
+
+---
+
+### Task 3: Custom-loop API — `cv_get_context_buttons` + `cv_render_context_button`
+
+Expose the resolved, access-filtered button list for custom loops, plus a tag to render a pre-resolved entry without re-resolving.
+
+**Files:**
+- Modify: `src/crud_views/lib/view/base.py` (add `cv_get_context_buttons` method, near `cv_get_context_button` ~line 289)
+- Modify: `src/crud_views/templatetags/crud_views.py` (add `cv_render_context_button` tag)
+- Test: `tests/test1/test_context_button_loop.py` (new)
+
+**Interfaces:**
+- Consumes: `_render_context_button` (Task 2); `cv_get_context` (Task 1).
+- Produces:
+  - `CrudView.cv_get_context_buttons(self, keys: list[str] | None = None, obj=None) -> list[dict]` — resolves each key (default `self.cv_context_actions`, in order; object defaults to `getattr(self, "object", None)`), filters out entries failing the hide contract, returns the resolved dicts.
+  - Template tag `{% cv_render_context_button ctx %}`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test1/test_context_button_loop.py`:
+
+```python
+"""cv_get_context_buttons (access-filtered list) + {% cv_render_context_button %}."""
+
+import pytest
+from django.template import Context, Template
+from django.urls import reverse
+
+
+def _detail_view(client, cv_author, author):
+    url = reverse(cv_author.get_router_name("detail"), kwargs={"pk": author.pk})
+    resp = client.get(url)
+    assert resp.status_code == 200
+    return resp.context["view"], resp.context["request"]
+
+
+@pytest.mark.django_db
+def test_list_filters_inaccessible(client_user_author_view, cv_author, author_douglas_adams):
+    # view-only user: 'update'/'delete' must be filtered out of the list
+    view, _ = _detail_view(client_user_author_view, cv_author, author_douglas_adams)
+    keys = [b.get("cv_key") for b in view.cv_get_context_buttons()]
+    assert "update" not in keys
+    assert "delete" not in keys
+
+
+@pytest.mark.django_db
+def test_explicit_keys_order(client_user_author_change, cv_author, author_douglas_adams):
+    view, _ = _detail_view(client_user_author_change, cv_author, author_douglas_adams)
+    buttons = view.cv_get_context_buttons(keys=["update", "detail"])
+    assert [b.get("cv_key") for b in buttons] == ["update", "detail"]
+
+
+@pytest.mark.django_db
+def test_render_tag_renders_entry(client_user_author_change, cv_author, author_douglas_adams):
+    view, request = _detail_view(client_user_author_change, cv_author, author_douglas_adams)
+    tpl = Template(
+        "{% load crud_views %}"
+        "{% for ctx in view.cv_get_context_buttons %}"
+        "<span>{% cv_render_context_button ctx %}</span>{% endfor %}"
+    )
+    html = tpl.render(Context({"view": view, "request": request}))
+    assert 'cv-key="update"' in html
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tests && pytest test1/test_context_button_loop.py -v`
+Expected: FAIL — `CrudView` has no `cv_get_context_buttons` / `cv_render_context_button` not registered.
+
+- [ ] **Step 3: Add the accessor method**
+
+In `src/crud_views/lib/view/base.py`, after `cv_get_context_button` (around line 294), add:
+
+```python
+    def cv_get_context_buttons(self, keys: list[str] | None = None, obj=None) -> list[dict]:
+        """
+        Resolved, access-filtered context-button data for a custom template loop.
+        keys defaults to this view's cv_context_actions; obj defaults to the view's object.
+        """
+        keys = keys if keys is not None else (self.cv_context_actions or [])
+        if obj is None:
+            obj = getattr(self, "object", None)
+        result: list[dict] = []
+        for key in keys:
+            ctx = self.cv_get_context(key=key, obj=obj, user=self.request.user, request=self.request)
+            if not ctx or ctx.get("cv_action_enabled") is False or ctx.get("cv_access") is not True:
+                continue
+            result.append(ctx)
+        return result
+```
+
+- [ ] **Step 4: Add the render tag**
+
+In `src/crud_views/templatetags/crud_views.py`, after `cv_context_button`:
+
+```python
+@register.simple_tag(takes_context=True)
+def cv_render_context_button(context, ctx) -> str:
+    view = cv_get_view(context)
+    return _render_context_button(view, ctx)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd tests && pytest test1/test_context_button_loop.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Format, lint, commit**
+
+```bash
+task format && task check
+git add src/crud_views/lib/view/base.py src/crud_views/templatetags/crud_views.py tests/test1/test_context_button_loop.py
+git commit -m "feat(buttons): cv_get_context_buttons accessor + {% cv_render_context_button %}"
+```
+
+---
+
+### Task 4: `cv_context_has_permission` filter
+
+A filter usable directly in `{% if %}` to gate surrounding markup by access to a key.
+
+**Files:**
+- Modify: `src/crud_views/templatetags/crud_views.py` (add `cv_context_has_permission` filter)
+- Test: `tests/test1/test_context_button_permission_filter.py` (new)
+
+**Interfaces:**
+- Consumes: `ViewSet.get_view_class(key)`, `CrudView.cv_has_access(user, obj)` (existing).
+- Produces: filter `cv_context_has_permission(view, key) -> bool` — `view.cv_viewset.get_view_class(key).cv_has_access(view.request.user, getattr(view, "object", None))`; returns `False` on unknown key.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test1/test_context_button_permission_filter.py`:
+
+```python
+"""view|cv_context_has_permission:'key' for {% if %} gating."""
+
+import pytest
+from django.template import Context, Template
+from django.urls import reverse
+
+
+def _detail_view(client, cv_author, author):
+    url = reverse(cv_author.get_router_name("detail"), kwargs={"pk": author.pk})
+    resp = client.get(url)
+    assert resp.status_code == 200
+    return resp.context["view"], resp.context["request"]
+
+
+def _render(view, request, key):
+    tpl = Template(
+        "{% load crud_views %}{% if view|cv_context_has_permission:'" + key + "' %}YES{% else %}NO{% endif %}"
+    )
+    return tpl.render(Context({"view": view, "request": request})).strip()
+
+
+@pytest.mark.django_db
+def test_true_for_permitted(client_user_author_change, cv_author, author_douglas_adams):
+    view, request = _detail_view(client_user_author_change, cv_author, author_douglas_adams)
+    assert _render(view, request, "update") == "YES"
+
+
+@pytest.mark.django_db
+def test_false_for_forbidden(client_user_author_view, cv_author, author_douglas_adams):
+    view, request = _detail_view(client_user_author_view, cv_author, author_douglas_adams)
+    assert _render(view, request, "update") == "NO"
+
+
+@pytest.mark.django_db
+def test_false_for_unknown_key(client_user_author_change, cv_author, author_douglas_adams):
+    view, request = _detail_view(client_user_author_change, cv_author, author_douglas_adams)
+    assert _render(view, request, "nope") == "NO"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tests && pytest test1/test_context_button_permission_filter.py -v`
+Expected: FAIL — `cv_context_has_permission` is not a registered filter.
+
+- [ ] **Step 3: Add the filter**
+
+In `src/crud_views/templatetags/crud_views.py`, next to the other `@register.filter` definitions (around line 180):
+
+```python
+@register.filter
+def cv_context_has_permission(view, key) -> bool:
+    try:
+        cls = view.cv_viewset.get_view_class(key)
+    except Exception:
+        return False
+    return bool(cls.cv_has_access(view.request.user, getattr(view, "object", None)))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd tests && pytest test1/test_context_button_permission_filter.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+task format && task check
+git add src/crud_views/templatetags/crud_views.py tests/test1/test_context_button_permission_filter.py
+git commit -m "feat(buttons): add view|cv_context_has_permission filter"
+```
+
+---
+
+### Task 5: Documentation
+
+Document the new fields, tags, filter, and the two render contracts in the reference docs.
+
+**Files:**
+- Modify: the context-button / template-tag reference page under `docs/` (locate with the grep in Step 1; likely `docs/reference/` or the context-actions page)
+
+- [ ] **Step 1: Locate the docs page**
+
+Run: `cd /home/alex/projects/alex/django-crud-views && grep -rln "cv_context_action\|context button\|context_buttons" docs/`
+Expected: one or more reference pages; pick the context-actions / buttons reference page.
+
+- [ ] **Step 2: Add a "Custom button rendering & placement" section**
+
+Document, with copy-paste examples:
+- `ContextButton(template=..., template_code=...)` and the `CRUD_VIEWS_CONTEXT_BUTTON_TEMPLATE` default.
+- Defining a variant button in the viewset (e.g. `edit_detail`) and trimming `cv_context_actions`.
+- `{% cv_context_button "edit_detail" %}` (hides on no-access).
+- The custom loop: `{% for ctx in view.cv_get_context_buttons %}{% cv_render_context_button ctx %}{% endfor %}`.
+- `{% if view|cv_context_has_permission:"edit_detail" %}…{% endif %}`.
+- The two render contracts table (container = disabled, manual API = hidden).
+
+Example block to include:
+
+```django
+{% load crud_views %}
+{% if view|cv_context_has_permission:"edit_detail" %}
+  <div class="toolbar">
+    {% cv_context_button "edit_detail" %}
+  </div>
+{% endif %}
+
+{% for ctx in view.cv_get_context_buttons %}
+  <span class="wrap">{% cv_render_context_button ctx %}</span>
+{% endfor %}
+```
+
+- [ ] **Step 3: Build docs to verify no broken references**
+
+Run: `task docs` (Ctrl-C after it serves cleanly) or `uv run mkdocs build`
+Expected: build succeeds, no warnings about the edited page.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/
+git commit -m "docs(buttons): document context button templating and manual placement"
+```
+
+---
+
+### Task 6: Full suite + final verification
+
+- [ ] **Step 1: Run the complete test suite**
+
+Run: `cd tests && pytest -q`
+Expected: all pass (existing count + the new tests across Tasks 1-4), no new failures.
+
+- [ ] **Step 2: Lint/format clean**
+
+Run: `task format && task check`
+Expected: no changes / no errors.
+
+- [ ] **Step 3: Review the branch diff**
+
+Run: `git log --oneline main..HEAD && git diff --stat main..HEAD`
+Expected: commits for Tasks 1-5, touching `settings.py`, `buttons.py`, `base.py`, `crud_views.py` (templatetags), four new test files, and docs.

--- a/superpowers/specs/2026-06-17-context-button-templating-design.md
+++ b/superpowers/specs/2026-06-17-context-button-templating-design.md
@@ -1,0 +1,240 @@
+# Context button templating & manual placement — design
+
+**Date:** 2026-06-17
+**Status:** approved (pending user review of this spec)
+
+## Goal
+
+Today, context buttons are defined once on a `ViewSet` (`context_buttons`) and rendered
+only through the automatic `{% cv_context_actions %}` container loop, which iterates a
+view's `cv_context_actions` keys. The button's *rendering template* is fixed — a button's
+shape can't differ between views (e.g. the `edit` button should look different in the
+detail view than elsewhere), and there's no way to place a single button by hand in a
+custom layout.
+
+This design adds three capabilities, all additive (the default container keeps working
+unchanged):
+
+1. **Per-button templating** — a `ContextButton` carries its own render template
+   (`template` / `template_code`), defaulting to a project-wide setting. Different
+   shapes are achieved by defining variant buttons in the viewset registry (e.g. an
+   `edit` button and an `edit_detail` button with a different template).
+2. **Manual placement** — a by-key tag and a custom-loop API so buttons can be dropped
+   anywhere in a template instead of only through the container loop.
+3. **Permission gating** — a filter to ask, in a template, whether the user may access a
+   given key, so surrounding markup (wrappers, headings, separators) can be conditional.
+
+The "different shape in the detail view" requirement is met by combining these: define a
+variant button in the viewset, trim `cv_context_actions`, and place the variant manually
+in the detail template.
+
+## Non-goals
+
+- **View-level button instances** (issue #27 — allowing `cv_context_actions` to contain
+  `ContextButton` instances, not just string keys). Considered and dropped: with registry
+  buttons templated and placeable by key, the user can keep `cv_context_actions` minimal
+  and place buttons manually, so view-level instances add surface area without new
+  capability here. The issue stays open for a future need.
+- **Changing the default container's no-access rendering.** The container keeps rendering
+  inaccessible buttons as *disabled/greyed*; existing themes depend on it. The new by-key
+  tag uses a *hide-on-no-access* contract instead. This divergence is deliberate (see
+  §"Two render contracts").
+
+## Current state (for context)
+
+- `ContextButton` (`src/crud_views/lib/view/buttons.py`) is a Pydantic model with
+  `key`, `key_target`, `label_template`, `label_template_code`. Subclasses:
+  `ParentContextButton`, `ChildContextButton`, `FilterContextButton`.
+- `ContextButton.get_context(context)` resolves the target view class, sets `cv_access`
+  (permission) and `cv_action_enabled` (contextual visibility), builds the data dict via
+  `cls.cv_get_dict(...)`, and renders the label.
+- `FilterContextButton.get_context` already hardcodes
+  `data["cv_template"] = f"{theme_path}/tags/context_action_filter.html"` (`buttons.py:176`)
+  — proof that a per-button template via `cv_template` already flows through the renderer.
+- `ViewSet.context_buttons` (`viewset/__init__.py:79`) holds the registry; default set is
+  `home`, `parent` (`ParentContextButton`), `filter` (`FilterContextButton`).
+- A view declares `cv_context_actions: List[str]` — ordered keys rendered top-right. Each
+  key is resolved by `CrudView.cv_get_context` (`view/base.py:305`): if it matches a
+  registry button (`cv_get_context_button`, `base.py:289`) that button's context is used;
+  otherwise the key is treated as a plain *view key* (nav button).
+- Template tag `cv_context_action` (`templatetags/crud_views.py:67`) renders one key:
+  `template = ctx.get("cv_template", f"{theme_path}/tags/context_action.html")` then
+  `render_to_string(template, ctx)`. The hardcoded fallback is the default template.
+- Container tag `cv_context_actions` (`crud_views.py:74`, template `tags/context_actions.html`)
+  loops `view.cv_context_actions` and emits `{% cv_context_action key object %}` for each.
+- `tags/context_action.html` renders a disabled/greyed button when `cv_access is False`
+  and nothing when `cv_action_enabled is False`.
+- `CrudView.render_snippet(data, template=None, template_code=None)` (`base.py:131`) is the
+  existing primitive that renders either a file template or an inline template string — the
+  render path this design reuses.
+- Themes: `crud_views` (Bootstrap 5) and `crud_views_plain`. Both ship the
+  `tags/context_action*.html` templates.
+
+## Design
+
+### 1. Templating on `ContextButton` (foundation)
+
+Add to the **base** `ContextButton` (inherited by all subclasses):
+
+```python
+template: str | None = None        # file template path for the whole button
+template_code: str | None = None   # inline template source for the whole button
+```
+
+These name the **button** template (the full anchor/markup), distinct from the existing
+`label_template` / `label_template_code`, which render only the label text inside it.
+
+`get_context()` injects the chosen template into the returned data dict, with this
+precedence:
+
+1. `self.template_code` set → `data["cv_template_code"] = self.template_code`
+2. else `self.template` set → `data["cv_template"] = self.template`
+3. else → `data["cv_template"] = crud_views_settings.context_button_template`
+   (the new default; see §Settings)
+
+`FilterContextButton` drops its hardcoded `data["cv_template"] = …` and instead sets its
+field default `template = f"{theme_path}/tags/context_action_filter.html"` (resolved from
+settings at construction, consistent with how the class already references `theme_path`).
+
+### 2. Settings change
+
+- New setting `CRUD_VIEWS_CONTEXT_BUTTON_TEMPLATE`, default
+  `f"{theme_path}/tags/context_action.html"` (the current hardcoded fallback), exposed as
+  `crud_views_settings.context_button_template`.
+- The **view-key branch** of `cv_get_context` (`base.py:321+`, the non-button path) also
+  sets `cv_template` to this default. With both branches injecting a template, every
+  rendered action carries one.
+- `cv_context_action` (the container's per-key tag) drops its hardcoded fallback string;
+  the default now lives once in settings (always injected, see above). It also learns to
+  honour `cv_template_code`: if `ctx.get("cv_template_code")` is set it renders inline via
+  `view.render_snippet(ctx, template_code=...)`, otherwise it renders the file template
+  `ctx["cv_template"]`. **Note** it keeps its existing disabled-on-no-access behavior — it
+  does *not* adopt the hide contract; only the new manual API hides (see §"Two render
+  contracts").
+
+### 3. By-key placement tag — `cv_context_button`
+
+New `simple_tag(takes_context=True)`:
+
+```django
+{% cv_context_button "edit_detail" %}
+{% cv_context_button "edit_detail" object %}
+```
+
+Behavior:
+- Resolve the key the same way the container does: `view.cv_get_context(key=key, obj=obj)`
+  (which finds a registry button or a view key).
+- Render-or-nothing per the **hide-on-no-access** contract: emit `""` when the resolved
+  context indicates the button is absent / `cv_action_enabled is False` / `cv_access is
+  not True`. Otherwise render the button via its template (see §4).
+- Wrapped with the existing `@ignore_exception(ViewSetKeyFoundError, default_value="")`
+  guard, matching `cv_context_action`, so an unknown key is silently empty.
+
+This is the core of the originally-sketched `cv_context_button(key)` tag.
+
+### 4. Render rules (shared helper)
+
+Both `cv_context_button` and the loop render the same way. A small module helper in the
+template-tags module:
+
+```python
+def _render_context_button(view, ctx) -> str:
+    if not ctx or ctx.get("cv_action_enabled") is False or ctx.get("cv_access") is not True:
+        return ""   # hide-on-no-access contract
+    if ctx.get("cv_template_code"):
+        return view.render_snippet(ctx, template_code=ctx["cv_template_code"])
+    return view.render_snippet(ctx, template=ctx["cv_template"])
+```
+
+Reuses `render_snippet` (already supports both file and inline). `cv_template_code` wins
+over `cv_template` when both are present.
+
+### 5. Custom-loop API
+
+Accessor on `CrudView`:
+
+```python
+def cv_get_context_buttons(self, keys: list[str] | None = None, obj=None) -> list[dict]:
+    """Resolved, access-filtered button contexts. keys defaults to cv_context_actions."""
+```
+
+- For each key, resolve via `cv_get_context`; **filter out** entries that fail the
+  hide-on-no-access contract (so a custom loop never produces empty wrapper markup).
+- Each returned dict carries its `cv_template` / `cv_template_code`.
+
+Companion tag to render an already-resolved entry (avoids re-resolving inside the loop):
+
+```django
+{% for ctx in view.cv_get_context_buttons %}
+  <div class="my-wrap">{% cv_render_context_button ctx %}</div>
+{% endfor %}
+```
+
+`cv_render_context_button` is a `simple_tag(takes_context=True)` that calls
+`_render_context_button(view, ctx)`.
+
+### 6. Permission-check filter — `cv_context_has_permission`
+
+Django filters can't access the template context, so the **view** is the piped value and
+the key is the argument, enabling direct use in `{% if %}`:
+
+```django
+{% if view|cv_context_has_permission:"edit_detail" %}
+  <h3>Edit</h3>
+  {% cv_context_button "edit_detail" %}
+{% endif %}
+```
+
+Implementation: resolve `cls = view.cv_viewset.get_view_class(key)` and return
+`cls.cv_has_access(view.request.user, view.object)` (object defaults to the view's current
+object; `None` for list-type views). Wraps the same `cv_has_access` gate the buttons use.
+Returns `False` on unknown key rather than raising.
+
+## Two render contracts (deliberate)
+
+| Placement | No access | No `cv_action_enabled` |
+|---|---|---|
+| `{% cv_context_actions %}` container (default, unchanged) | disabled/greyed button | hidden |
+| `{% cv_context_button %}` / loop / filter (new) | hidden | hidden |
+
+You reach for the manual API precisely when you want the hide behavior. The container is
+left untouched so existing themes don't break.
+
+## Themes
+
+Both `crud_views` and `crud_views_plain` are unaffected at the template level for the new
+tags — `cv_context_button` / `cv_render_context_button` reuse each button's own template
+(default = the theme's existing `tags/context_action.html`). No new theme template files
+are required by the core design; projects supply custom button templates as needed. The
+`context_button_template` setting resolves per active theme via `theme_path`.
+
+## Public API summary
+
+- `ContextButton.template`, `ContextButton.template_code` (new fields, all subclasses).
+- Setting `CRUD_VIEWS_CONTEXT_BUTTON_TEMPLATE` / `crud_views_settings.context_button_template`.
+- `CrudView.cv_get_context_buttons(keys=None, obj=None) -> list[dict]`.
+- Template tags: `{% cv_context_button key obj %}`, `{% cv_render_context_button ctx %}`.
+- Template filter: `view|cv_context_has_permission:"key"`.
+
+## Backwards compatibility
+
+- `cv_context_actions` semantics, the container tag, and `cv_context_action` rendering are
+  unchanged for existing keys (the settings default reproduces the old hardcoded template).
+- `FilterContextButton` output is unchanged (its default `template` equals the path it
+  used to hardcode).
+- All additions are opt-in; existing viewsets/views/templates render identically.
+
+## Testing (tests/test1)
+
+- `ContextButton.template` / `template_code` flow into `cv_template` / `cv_template_code`
+  with correct precedence and the settings default fallback.
+- `cv_context_button`: renders an accessible button; renders `""` for no-access, disabled
+  (`cv_action_enabled False`), and unknown key.
+- `cv_get_context_buttons`: returns only accessible entries, in `cv_context_actions` order
+  by default and in an explicit `keys` order when given.
+- `cv_render_context_button`: renders a pre-resolved ctx via file template and via
+  `template_code`.
+- `cv_context_has_permission`: `True` / `False` against a permitted vs. forbidden user
+  (reuse existing permission-based client fixtures); `False` on unknown key.
+- `FilterContextButton` still renders via the filter template (regression).
+- Default container behavior unchanged (regression).

--- a/tests/test1/test_context_button_loop.py
+++ b/tests/test1/test_context_button_loop.py
@@ -1,0 +1,53 @@
+"""cv_get_context_buttons (access-filtered list) + {% cv_render_context_button %}."""
+
+import pytest
+from django.template import Context, Template
+from django.urls import reverse
+
+from tests.lib.helper.user import user_viewset_permission
+
+
+@pytest.fixture
+def client_author_view_change(client, cv_author):
+    from django.contrib.auth.models import User
+
+    user = User.objects.create_user(username="user_author_view_change_loop", password="password")
+    user_viewset_permission(user, cv_author, "view")
+    user_viewset_permission(user, cv_author, "change")
+    client.force_login(user)
+    return client
+
+
+def _detail_view(client, cv_author, author):
+    url = reverse(cv_author.get_router_name("detail"), kwargs={"pk": author.pk})
+    resp = client.get(url)
+    assert resp.status_code == 200
+    return resp.context["view"], resp.context["request"]
+
+
+@pytest.mark.django_db
+def test_list_filters_inaccessible(client_user_author_view, cv_author, author_douglas_adams):
+    # view-only user: 'update'/'delete' must be filtered out of the list
+    view, _ = _detail_view(client_user_author_view, cv_author, author_douglas_adams)
+    keys = [b.get("cv_key") for b in view.cv_get_context_buttons()]
+    assert "update" not in keys
+    assert "delete" not in keys
+
+
+@pytest.mark.django_db
+def test_explicit_keys_order(client_author_view_change, cv_author, author_douglas_adams):
+    view, _ = _detail_view(client_author_view_change, cv_author, author_douglas_adams)
+    buttons = view.cv_get_context_buttons(keys=["update", "detail"])
+    assert [b.get("cv_key") for b in buttons] == ["update", "detail"]
+
+
+@pytest.mark.django_db
+def test_render_tag_renders_entry(client_author_view_change, cv_author, author_douglas_adams):
+    view, request = _detail_view(client_author_view_change, cv_author, author_douglas_adams)
+    tpl = Template(
+        "{% load crud_views %}"
+        "{% for ctx in view.cv_get_context_buttons %}"
+        "<span>{% cv_render_context_button ctx %}</span>{% endfor %}"
+    )
+    html = tpl.render(Context({"view": view, "request": request}))
+    assert 'cv-key="update"' in html

--- a/tests/test1/test_context_button_permission_filter.py
+++ b/tests/test1/test_context_button_permission_filter.py
@@ -1,0 +1,50 @@
+"""view|cv_context_has_permission:'key' for {% if %} gating."""
+
+import pytest
+from django.template import Context, Template
+from django.urls import reverse
+
+from tests.lib.helper.user import user_viewset_permission
+
+
+@pytest.fixture
+def client_author_view_change(client, cv_author):
+    from django.contrib.auth.models import User
+
+    user = User.objects.create_user(username="user_author_view_change_filter", password="password")
+    user_viewset_permission(user, cv_author, "view")
+    user_viewset_permission(user, cv_author, "change")
+    client.force_login(user)
+    return client
+
+
+def _detail_view(client, cv_author, author):
+    url = reverse(cv_author.get_router_name("detail"), kwargs={"pk": author.pk})
+    resp = client.get(url)
+    assert resp.status_code == 200
+    return resp.context["view"], resp.context["request"]
+
+
+def _render(view, request, key):
+    tpl = Template(
+        "{% load crud_views %}{% if view|cv_context_has_permission:'" + key + "' %}YES{% else %}NO{% endif %}"
+    )
+    return tpl.render(Context({"view": view, "request": request})).strip()
+
+
+@pytest.mark.django_db
+def test_true_for_permitted(client_author_view_change, cv_author, author_douglas_adams):
+    view, request = _detail_view(client_author_view_change, cv_author, author_douglas_adams)
+    assert _render(view, request, "update") == "YES"
+
+
+@pytest.mark.django_db
+def test_false_for_forbidden(client_user_author_view, cv_author, author_douglas_adams):
+    view, request = _detail_view(client_user_author_view, cv_author, author_douglas_adams)
+    assert _render(view, request, "update") == "NO"
+
+
+@pytest.mark.django_db
+def test_false_for_unknown_key(client_author_view_change, cv_author, author_douglas_adams):
+    view, request = _detail_view(client_author_view_change, cv_author, author_douglas_adams)
+    assert _render(view, request, "nope") == "NO"

--- a/tests/test1/test_context_button_tag.py
+++ b/tests/test1/test_context_button_tag.py
@@ -1,0 +1,51 @@
+"""{% cv_context_button %} renders one button by key, hiding on no-access."""
+
+import pytest
+from django.template import Context, Template
+from django.urls import reverse
+
+from tests.lib.helper.user import user_viewset_permission
+
+
+@pytest.fixture
+def client_author_view_change(client, cv_author):
+    from django.contrib.auth.models import User
+
+    user = User.objects.create_user(username="user_author_view_change", password="password")
+    user_viewset_permission(user, cv_author, "view")
+    user_viewset_permission(user, cv_author, "change")
+    client.force_login(user)
+    return client
+
+
+def _render(view, request, snippet):
+    tpl = Template("{% load crud_views %}" + snippet)
+    return tpl.render(Context({"view": view, "request": request})).strip()
+
+
+def _detail_view(client, cv_author, author):
+    url = reverse(cv_author.get_router_name("detail"), kwargs={"pk": author.pk})
+    resp = client.get(url)
+    assert resp.status_code == 200
+    return resp.context["view"], resp.context["request"]
+
+
+@pytest.mark.django_db
+def test_button_rendered_when_access(client_author_view_change, cv_author, author_douglas_adams):
+    view, request = _detail_view(client_author_view_change, cv_author, author_douglas_adams)
+    html = _render(view, request, "{% cv_context_button 'update' %}")
+    assert 'cv-key="update"' in html
+
+
+@pytest.mark.django_db
+def test_button_hidden_without_access(client_user_author_view, cv_author, author_douglas_adams):
+    view, request = _detail_view(client_user_author_view, cv_author, author_douglas_adams)
+    html = _render(view, request, "{% cv_context_button 'update' %}")
+    assert html == ""
+
+
+@pytest.mark.django_db
+def test_unknown_key_is_empty(client_user_author_view, cv_author, author_douglas_adams):
+    view, request = _detail_view(client_user_author_view, cv_author, author_douglas_adams)
+    html = _render(view, request, "{% cv_context_button 'does_not_exist' %}")
+    assert html == ""

--- a/tests/test1/test_context_button_template.py
+++ b/tests/test1/test_context_button_template.py
@@ -1,0 +1,40 @@
+"""ContextButton template / template_code fields and the settings default."""
+
+from crud_views.lib.settings import crud_views_settings
+from crud_views.lib.view.buttons import ContextButton, FilterContextButton
+
+
+def test_settings_default_template():
+    assert crud_views_settings.context_button_template == "crud_views/tags/context_action.html"
+
+
+def test_settings_template_override(monkeypatch):
+    from django.conf import settings as dj_settings
+
+    monkeypatch.setattr(dj_settings, "CRUD_VIEWS_CONTEXT_BUTTON_TEMPLATE", "x/y.html", raising=False)
+    # property reads Django settings live
+    assert crud_views_settings.context_button_template == "x/y.html"
+
+
+def test_inject_template_default():
+    data = {}
+    ContextButton(key="edit", key_target="update")._inject_template(data)
+    assert data == {"cv_template": "crud_views/tags/context_action.html"}
+
+
+def test_inject_template_file():
+    data = {}
+    ContextButton(key="edit", key_target="update", template="app/edit.html")._inject_template(data)
+    assert data == {"cv_template": "app/edit.html"}
+
+
+def test_inject_template_code_wins():
+    data = {}
+    ContextButton(
+        key="edit", key_target="update", template="app/edit.html", template_code="<a>{{ cv_url }}</a>"
+    )._inject_template(data)
+    assert data == {"cv_template_code": "<a>{{ cv_url }}</a>"}
+
+
+def test_filter_button_default_template():
+    assert FilterContextButton().template == "crud_views/tags/context_action_filter.html"


### PR DESCRIPTION
## Summary

Lets context buttons carry their own render template and be placed by hand anywhere in a template, so the same logical action can render with a different shape per view (e.g. a larger labelled edit button on the detail view, icon-only elsewhere).

Design spec: `superpowers/specs/2026-06-17-context-button-templating-design.md`
Implementation plan: `superpowers/plans/2026-06-17-context-button-templating.md`

## What's new

- **`ContextButton.template` / `template_code`** — template the whole button (not just the label). Defaults to the new `CRUD_VIEWS_CONTEXT_BUTTON_TEMPLATE` setting (default `crud_views/tags/context_action.html`). `FilterContextButton` now sets a default instead of hardcoding its template.
- **`{% cv_context_button "key" %}`** — place one button manually; object defaults to the view's object; renders **nothing** on no-access (vs. the container, which greys it out).
- **`view.cv_get_context_buttons(keys=None)` + `{% cv_render_context_button ctx %}`** — access-filtered custom-loop API.
- **`view|cv_context_has_permission:"key}"`** — filter to gate surrounding markup in `{% if %}`.

The default `{% cv_context_actions %}` container is behaviorally unchanged (two deliberate render contracts: container disables, manual API hides). View-level `ContextButton` instances (issue #27) remain out of scope.

## Docs

- New `docs/faq.md`: "How to template context buttons" and "I need to render a context button manually in a template".
- `docs/reference/context_buttons.md` table updated with the new fields.

## Tests

New TDD coverage in `tests/test1/`: `test_context_button_template.py`, `test_context_button_tag.py`, `test_context_button_loop.py`, `test_context_button_permission_filter.py`. Full suite: **367 passed, 1 skipped**; `ruff` clean; `mkdocs build` clean.