### PR TITLE
fix(guardian): resolve key_target for context-button create access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Pinned filter: set `cv_filter_pinned = True` on a filtered `ListView`/`CardListView` (or the global `CRUD_VIEWS_FILTER_PINNED` setting, default `False`) to render the filter always-open and hide the filter toggle button. Filter field values are still persisted to the session via `cv_filter_persistence`; only the now-irrelevant expanded/collapsed state is dropped (bootstrap5 renders the filter without its collapse wrapper; the plain theme is unaffected)
 - `cv_is_active` is now populated for all context buttons (previously only view-key buttons), so `{% cv_context_button %}` highlights when it points at the current page. Matched by URL router name.
 
+### Fixed
+
+- Guardian: a custom `ContextButton` whose `key` differs from its `key_target` and that targets a child viewset's `create` view is no longer always rendered as "no access" on list pages. The Guardian list mixin now resolves the button's `key_target` before re-deriving create access, so any create button (not just the built-in `"create"`) gets the parent-object permission check — enabling, e.g., a second differently-styled create button on the same page
+
 ## 0.6.0
 
 ### Added

--- a/src/crud_views_guardian/lib/mixins.py
+++ b/src/crud_views_guardian/lib/mixins.py
@@ -130,8 +130,13 @@ class GuardianQuerysetMixin:
         ctx = super().cv_get_context(key=key, obj=obj, user=user, request=request)
 
         if obj is None and key is not None and self.cv_viewset.has_parent:
-            if self.cv_viewset.is_view_registered(key):
-                target_cls = self.cv_viewset.get_view_class(key)
+            # A custom ContextButton may target the create view via key_target while
+            # using a different key (e.g. a second, differently-styled create button).
+            # Resolve key_target so the create-access re-derivation finds the view.
+            context_button = self.cv_get_context_button(key)
+            target_key = context_button.key_target if context_button and context_button.key_target else key
+            if self.cv_viewset.is_view_registered(target_key):
+                target_cls = self.cv_viewset.get_view_class(target_key)
             else:
                 target_cls = None
             if target_cls and getattr(target_cls, "cv_permission", None) == "add":

--- a/superpowers/instructions/0003-context-button-create-access.md
+++ b/superpowers/instructions/0003-context-button-create-access.md
@@ -1,0 +1,125 @@
+# Context Button Create Access
+
+A custom `ContextButton` that targets a child viewset's `create` view is rendered as
+"no access" (hidden/disabled) — even for a user who is allowed to create — whenever its
+`key` differs from its `key_target`. The built-in `"create"` button works for the same
+user on the same page, because its key happens to equal the view key.
+
+Example that reproduces it (a child viewset, create gated by Guardian):
+
+```python
+cv_projekt_note = GuardianViewSet(
+    model=ProjektNote,
+    name="projekt_note",
+    parent=ParentViewSet(name="projekt"),
+    context_buttons=context_buttons_default() + [
+        ContextButton(key="create_button", key_target="create"),  # key != key_target
+    ],
+)
+```
+
+```django
+{% cv_context_button "create" %}          {# works #}
+{% cv_context_button "create_button" %}   {# always "no access" #}
+```
+
+The viewset config is correct — this is a gap in how Guardian create-access is resolved
+for context buttons.
+
+## Why it happens
+
+For a child viewset, `GuardianCreateView.cv_has_access(user, obj)`
+(`crud_views_guardian/lib/views.py`) returns `False` when `obj is None` — which is the
+case on a list page, where a create button has no object. The real per-object decision
+needs the parent object and is delegated to
+`cv_create_has_access(user, rendering_view, parent_obj)`.
+
+That delegation lives in exactly one place: the Guardian list mixin's `cv_get_context()`
+override (`crud_views_guardian/lib/mixins.py`). It looks the target view up by the
+**literal `key`** passed to the tag:
+
+```python
+if obj is None and key is not None and self.cv_viewset.has_parent:
+    if self.cv_viewset.is_view_registered(key):          # keyed on `key`, not key_target
+        target_cls = self.cv_viewset.get_view_class(key)
+    ...
+        ctx["cv_access"] = target_cls.cv_create_has_access(user, self, parent_obj)
+```
+
+Both buttons go through the same `view.cv_get_context(key=...)`, but:
+
+- `key="create"` is **not** a registered context button, so `super()` takes the
+  "key is a view" branch; the override then sees `is_view_registered("create")` is true
+  and re-derives access via `cv_create_has_access(...)`. → works.
+- `key="create_button"` **is** a registered context button, so `super()` returns
+  `ContextButton.get_context()` (`crud_views/lib/view/buttons.py`), whose only access check
+  is `cls.cv_has_access(user, None)` → `False` (it has no `cv_create_has_access` path).
+  Then the override skips it, because `is_view_registered("create_button")` is false. →
+  always denied.
+
+So: the create-access re-derivation keys off the button **key** instead of the button's
+**`key_target`**, and the generic `ContextButton.get_context()` has no create-access path
+of its own. Any `ContextButton` whose key ≠ view key (more generally, any one targeting a
+child `create` via `key_target`) never gets the parent-object check.
+
+## What it should do
+
+`{% cv_context_button "create_button" %}` must produce the same `cv_access` and
+`cv_action_enabled` as `{% cv_context_button "create" %}` for the same user, page, and
+parent object — without regressing top-level (no-parent) create buttons or non-create
+buttons.
+
+## Ideas
+
+- **Preferred (small):** in `crud_views_guardian/lib/mixins.py`, resolve the button's
+  `key_target` before the target-view lookup:
+
+  ```python
+  context_button = self.cv_get_context_button(key)
+  target_key = context_button.key_target if context_button and context_button.key_target else key
+  if self.cv_viewset.is_view_registered(target_key):
+      target_cls = self.cv_viewset.get_view_class(target_key)
+  else:
+      target_cls = None
+  ```
+
+  Fixes the reported case and any `ContextButton` pointing at a child create via
+  `key_target`. Stays Guardian-specific (correct — `cv_create_has_access` is a Guardian
+  concept). Limitation: only covers buttons rendered through a view that uses the Guardian
+  list mixin (i.e. list pages); a create button on a sibling/parent detail page would still
+  not be covered.
+
+- **Longer-term (cleaner):** give `CrudView` a single `cv_button_has_access(user,
+  rendering_view, obj)` hook, defaulting to `cv_has_access(user, obj)`.
+  `GuardianCreateView` overrides it to resolve the parent from `rendering_view` and call
+  `cv_create_has_access(...)`. Then `ContextButton.get_context()` and the "key is a view"
+  branch in `base.py` both call the hook, and the Guardian list-mixin special case can be
+  deleted. Access for a button is then decided in one place, regardless of which view
+  renders it. Bigger blast radius: touches core `crud_views` button rendering and the
+  access-check contract, so it needs a compat shim for downstream `cv_has_access`
+  overrides and a parent-resolution helper usable without the list mixin.
+
+- **Avoid:** documenting "just reuse `key="create"`" as the only answer — it blocks
+  legitimate cases such as a second, differently-styled create button on the same page,
+  which is exactly what surfaced this.
+
+## Tests
+
+In `tests/test1/`, using the Author→Book Guardian fixtures (book is a child viewset):
+add `ContextButton(key="create_button", key_target="create")` to the book viewset and
+assert that on the book list page `"create_button"` and the built-in `"create"` yield the
+same `cv_access` — both visible for a user with parent create permission, both hidden
+without it — and the same `cv_action_enabled`. Also: unresolvable parent → denied, no
+exception; top-level (no-parent) create access unchanged.
+
+## Relevant source
+
+- `crud_views/lib/view/buttons.py` — `ContextButton.get_context()`: generic access via
+  `cv_has_access`, no create path.
+- `crud_views/lib/view/base.py` — `cv_get_context()` / `cv_get_context_button()`: the
+  context-button vs. "key is a view" branching.
+- `crud_views_guardian/lib/mixins.py` — list-mixin `cv_get_context()` override: the only
+  create-access re-derivation (currently keyed on `key`).
+- `crud_views_guardian/lib/views.py` — `GuardianCreateView.cv_has_access` (`obj is None →
+  False`) and `cv_create_has_access`.
+- `crud_views/templatetags/crud_views.py` — `cv_context_button` → `view.cv_get_context`.

--- a/superpowers/instructions/0004-context-button-access-create-TODO.md
+++ b/superpowers/instructions/0004-context-button-access-create-TODO.md
@@ -1,0 +1,75 @@
+# Context Button Access — Unified `cv_button_has_access` Hook (TODO / Approach B)
+
+> Deferred follow-up to the create-access fix shipped via Approach A
+> (`superpowers/specs/2026-06-18-context-button-create-access-design.md`).
+> Approach A resolves the button's `key_target` inside the Guardian list mixin and
+> fully covers list pages. This TODO captures the cleaner, uniform refactor for a
+> future iteration.
+
+## Goal
+
+Decide a context button's access in **one place**, regardless of which view renders
+it, so the Guardian list-mixin special case can be deleted and access is uniform
+across list / detail / sibling / child / parent render paths.
+
+## Sketch
+
+1. **`crud_views/lib/view/base.py`** — add a classmethod hook on `CrudView`:
+
+   ```python
+   @classmethod
+   def cv_button_has_access(cls, user, rendering_view, obj):
+       return cls.cv_has_access(user, obj)
+   ```
+
+   Swap the access check in the "key is a view" branch (`base.py:359`) to call it.
+
+2. **`crud_views/lib/view/buttons.py`** — replace `cls.cv_has_access(...)` at the
+   **4 button sites** (lines ~53, 110, 146, 191 — `ContextButton`,
+   `ParentContextButton`, `ChildContextButton`, `SiblingContextButton`), each
+   passing `context.view` as `rendering_view`.
+
+3. **`crud_views_guardian/lib/views.py`** — `GuardianCreateView` overrides
+   `cv_button_has_access` to resolve the parent from
+   `rendering_view.cv_get_parent_object()` and call `cv_create_has_access(...)`.
+
+4. **`crud_views_guardian/lib/mixins.py`** — delete the `GuardianQuerysetMixin.cv_get_context`
+   override entirely (the create-access re-derivation moves into the hook).
+
+## Why this is bigger than it looks (the wrinkles)
+
+- **`cv_action_enabled` is a separate gate.** The deleted mixin override re-derives
+  **both** `cv_access` *and* `cv_action_enabled` with the resolved parent object. The
+  `cv_button_has_access` hook only covers access. Each button computes
+  `cv_action_enabled` independently with `context.object` (= `None` on a list, e.g.
+  `buttons.py:50`). So this refactor must **also** introduce a parallel
+  `cv_button_action_enabled(user, rendering_view, obj)` hook (or fold both into one
+  combined hook) — otherwise the create button's enabled state regresses on list
+  pages.
+
+- **Compat shim.** Downstream code overriding `cv_has_access` (5 definitions in-tree,
+  plus user subclasses) keeps working because the default hook delegates to
+  `cv_has_access`. But `GuardianCreateView` button behavior then lives across both
+  `cv_button_has_access` **and** `cv_has_access` "Case 3" — keep them coherent, or
+  collapse Case 3 into the hook.
+
+- **Parent-resolution helper.** `cv_get_parent_object()` must be safe to call from an
+  arbitrary `rendering_view` that may have no parent / no matching URL kwargs
+  (catch `Http404`/`KeyError`, fall back to denied), mirroring the current override.
+
+- **Blast radius.** This touches core button rendering for **all themes and all
+  button types**, not just Guardian/create. Regression-test all 4 button types
+  across base, Guardian, and plain themes.
+
+## When to pick this up
+
+Only once a **real** non-list, no-object render path needs create-access that
+Approach A doesn't cover. Until then, Approach A is sufficient and far lower risk.
+
+## Acceptance
+
+- All Approach A tests still pass unchanged.
+- The Guardian list-mixin `cv_get_context` override is gone, with no regression to
+  `cv_access` or `cv_action_enabled` on list, detail, sibling, child, or parent
+  pages.
+- Top-level (no-parent) create access unchanged.

--- a/superpowers/plans/2026-06-18-context-button-create-access.md
+++ b/superpowers/plans/2026-06-18-context-button-create-access.md
@@ -1,0 +1,269 @@
+# Context Button Create Access Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a custom `ContextButton` whose `key != key_target` and targets a child viewset's `create` view resolve create-access correctly on Guardian list pages, identical to the built-in `"create"` button.
+
+**Architecture:** Single-method change in `GuardianQuerysetMixin.cv_get_context`
+(`src/crud_views_guardian/lib/mixins.py`). Before looking up the target view by
+`key`, resolve the registered button's `key_target` and look up by that instead. The
+existing `cv_permission == "add"` guard, parent-object resolution, and
+`cv_access` / `cv_action_enabled` overwrite are unchanged.
+
+**Tech Stack:** Python, Django, django-guardian, pytest. Tests run from `tests/`.
+
+## Global Constraints
+
+- Line length: 120 characters (ruff).
+- Quote style: double quotes.
+- `cv_` prefix on all `CrudView` attributes; view keys: `list`/`detail`/`create`/`update`/`delete`.
+- Tests live in `tests/test1/`; run with `cd tests && pytest`.
+- No change to core `crud_views`; no change to the `cv_has_access` contract.
+- Spec: `superpowers/specs/2026-06-18-context-button-create-access-design.md`.
+- Deferred Approach B (do NOT implement here): `superpowers/instructions/0004-context-button-access-create-TODO.md`.
+
+---
+
+## File Structure
+
+- `tests/test1/app/views.py` — add a `create_button` `ContextButton` to the existing
+  child Guardian viewset `cv_guardian_book` so the new behavior can be exercised.
+- `tests/test1/test_guardian.py` — add a new test section asserting `"create_button"`
+  and `"create"` produce identical `cv_access` / `cv_action_enabled`, plus
+  unresolvable-parent and top-level-unchanged cases. Reuses the existing
+  `_make_book_list_view` helper (defined at `test1/test_guardian.py:370`).
+- `src/crud_views_guardian/lib/mixins.py` — the one-method fix in
+  `GuardianQuerysetMixin.cv_get_context` (lines 132-148).
+
+This is a single, coherent fix with one test cycle → one task.
+
+---
+
+### Task 1: Resolve `key_target` for create-button access in the Guardian list mixin
+
+**Files:**
+- Modify: `tests/test1/app/views.py:587-594` (add `context_buttons` to `cv_guardian_book`)
+- Modify: `src/crud_views_guardian/lib/mixins.py:132-148`
+- Test: `tests/test1/test_guardian.py` (append a new section after line 438)
+
+**Interfaces:**
+- Consumes (existing, do not redefine):
+  - `self.cv_get_context_button(key) -> ContextButton | None` (`base.py:293`)
+  - `ContextButton.key_target: str | None` (`buttons.py:14`)
+  - `self.cv_viewset.is_view_registered(key) -> bool`, `self.cv_viewset.get_view_class(key)`
+  - `target_cls.cv_create_has_access(user, rendering_view, parent_obj) -> bool` (`views.py:125`)
+  - `target_cls.cv_action_enabled(user, obj) -> bool`
+  - `self.cv_get_parent_object()` (raises `Http404`/`KeyError` when unresolvable)
+  - Test helper `_make_book_list_view(user_guardian, publisher_a)` (`test_guardian.py:370`)
+  - Test helper `user_guardian_object_perm(user, viewset, perm, obj)` (imported at `test_guardian.py:3`)
+  - Test helper `user_viewset_permission(user, viewset, perm)` (`tests/lib/helper/user.py`)
+- Produces: no new public API. Behavior change only: `cv_get_context(key=<button
+  whose key_target targets child create>, obj=None)` now returns the same
+  `cv_access` / `cv_action_enabled` as `cv_get_context(key="create", obj=None)`.
+
+---
+
+- [ ] **Step 1: Add the `create_button` context button to the child Guardian viewset**
+
+In `tests/test1/app/views.py`, ensure `ContextButton` and `context_buttons_default`
+are imported (the file already imports from `crud_views.lib.viewset`; add the button
+import). Near the top imports add:
+
+```python
+from crud_views.lib.view import ContextButton
+from crud_views.lib.viewset import context_buttons_default
+```
+
+Then change the `cv_guardian_book` definition (currently `views.py:587-594`) to:
+
+```python
+cv_guardian_book = GuardianViewSet(
+    model=Book,
+    name="guardian_book",
+    parent=ParentViewSet(name="guardian_publisher", attribute="publisher"),
+    icon_header="fa-regular fa-address-book",
+    cv_guardian_parent_permission="view",
+    cv_guardian_parent_create_permission="change",
+    context_buttons=context_buttons_default() + [
+        ContextButton(key="create_button", key_target="create"),  # key != key_target
+    ],
+)
+```
+
+> Note: `ViewSet`/`ParentViewSet` are already imported (`views.py:40`). If
+> `context_buttons_default` is already importable via an existing `crud_views.lib.viewset`
+> import line, extend that line instead of adding a new one.
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `tests/test1/test_guardian.py` (after line 438):
+
+```python
+# ── ContextButton key != key_target targeting child create ────────────────────
+
+
+@pytest.mark.django_db
+def test_create_button_matches_create_with_parent_perm(user_guardian, cv_guardian_publisher, publisher_a):
+    """create_button (key != key_target) matches built-in create when parent perm is granted."""
+    user_guardian_object_perm(user_guardian, cv_guardian_publisher, "change", publisher_a)
+    view = _make_book_list_view(user_guardian, publisher_a)
+    create = view.cv_get_context(key="create", obj=None, user=user_guardian)
+    button = view.cv_get_context(key="create_button", obj=None, user=user_guardian)
+    assert create["cv_access"] is True
+    assert button["cv_access"] == create["cv_access"]
+    assert button["cv_action_enabled"] == create["cv_action_enabled"]
+
+
+@pytest.mark.django_db
+def test_create_button_matches_create_without_parent_perm(user_guardian, publisher_a):
+    """create_button is hidden, exactly like built-in create, without parent perm."""
+    view = _make_book_list_view(user_guardian, publisher_a)
+    create = view.cv_get_context(key="create", obj=None, user=user_guardian)
+    button = view.cv_get_context(key="create_button", obj=None, user=user_guardian)
+    assert create["cv_access"] is False
+    assert button["cv_access"] == create["cv_access"]
+    assert button["cv_action_enabled"] == create["cv_action_enabled"]
+
+
+@pytest.mark.django_db
+def test_create_button_unresolvable_parent_denied(user_guardian):
+    """Unresolvable parent → create_button denied, no exception raised."""
+    from unittest.mock import MagicMock
+    from django.test import RequestFactory
+    from tests.test1.app.views import GuardianBookListView, cv_guardian_book
+
+    rf = RequestFactory()
+    request = rf.get("/guardian_publisher/999999/guardian_book/")
+    request.user = user_guardian
+    resolver_match = MagicMock()
+    resolver_match.url_name = cv_guardian_book.get_router_name("list")
+    request.resolver_match = resolver_match
+
+    view = GuardianBookListView()
+    view.request = request
+    view.args = []
+    view.kwargs = {"guardian_publisher_pk": "999999"}  # no such publisher
+
+    ctx = view.cv_get_context(key="create_button", obj=None, user=user_guardian)
+    assert ctx["cv_access"] is False
+
+
+@pytest.mark.django_db
+def test_top_level_create_unchanged_by_key_target_fix(user_guardian, cv_guardian_author):
+    """Top-level (no-parent) create access is unaffected — the override's has_parent guard skips it."""
+    from unittest.mock import MagicMock
+    from django.contrib.auth.models import User
+    from django.test import RequestFactory
+    from tests.lib.helper.user import user_viewset_permission
+    from tests.test1.app.views import GuardianAuthorListView, cv_guardian_author as author_vs
+
+    rf = RequestFactory()
+    request = rf.get("/guardian_author/")
+    request.user = user_guardian
+    resolver_match = MagicMock()
+    resolver_match.url_name = author_vs.get_router_name("list")
+    request.resolver_match = resolver_match
+
+    view = GuardianAuthorListView()
+    view.request = request
+    view.args = []
+    view.kwargs = {}
+
+    # without model-level add perm → denied
+    denied = view.cv_get_context(key="create", obj=None, user=user_guardian)
+    assert denied["cv_access"] is False
+
+    # with model-level add perm → granted (refetch user to bust the perm cache)
+    user_viewset_permission(user_guardian, cv_guardian_author, "add")
+    granted_user = User.objects.get(pk=user_guardian.pk)
+    request.user = granted_user
+    granted = view.cv_get_context(key="create", obj=None, user=granted_user)
+    assert granted["cv_access"] is True
+```
+
+- [ ] **Step 3: Run the new tests and confirm the create-button tests FAIL**
+
+Run: `cd tests && pytest test1/test_guardian.py -k "create_button or top_level_create_unchanged" -v`
+
+Expected: `test_create_button_matches_create_with_parent_perm` FAILS
+(`button["cv_access"]` is `False` while `create["cv_access"]` is `True`).
+`test_create_button_matches_create_without_parent_perm`,
+`test_create_button_unresolvable_parent_denied`, and
+`test_top_level_create_unchanged_by_key_target_fix` PASS (they already hold pre-fix —
+they lock in non-regression).
+
+- [ ] **Step 4: Apply the fix in the Guardian list mixin**
+
+In `src/crud_views_guardian/lib/mixins.py`, inside `GuardianQuerysetMixin.cv_get_context`,
+replace the lookup block (currently lines 132-136):
+
+```python
+        if obj is None and key is not None and self.cv_viewset.has_parent:
+            if self.cv_viewset.is_view_registered(key):
+                target_cls = self.cv_viewset.get_view_class(key)
+            else:
+                target_cls = None
+```
+
+with:
+
+```python
+        if obj is None and key is not None and self.cv_viewset.has_parent:
+            # A custom ContextButton may target the create view via key_target while
+            # using a different key (e.g. a second, differently-styled create button).
+            # Resolve key_target so the create-access re-derivation finds the view.
+            context_button = self.cv_get_context_button(key)
+            target_key = context_button.key_target if context_button and context_button.key_target else key
+            if self.cv_viewset.is_view_registered(target_key):
+                target_cls = self.cv_viewset.get_view_class(target_key)
+            else:
+                target_cls = None
+```
+
+Leave the rest of the method (the `cv_permission == "add"` guard, parent resolution,
+and the `ctx["cv_access"]` / `ctx["cv_action_enabled"]` overwrite) unchanged.
+
+- [ ] **Step 5: Run the new tests and confirm they all PASS**
+
+Run: `cd tests && pytest test1/test_guardian.py -k "create_button or top_level_create_unchanged" -v`
+
+Expected: all four tests PASS.
+
+- [ ] **Step 6: Run the full Guardian suite + lint to confirm no regression**
+
+Run: `cd tests && pytest test1/test_guardian.py -q`
+Expected: all pass (the pre-existing `cv_get_context` tests at lines 391-438 included).
+
+Run: `task check && task format` (from repo root)
+Expected: ruff check passes; format leaves the changed files clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/crud_views_guardian/lib/mixins.py tests/test1/app/views.py tests/test1/test_guardian.py
+git commit -m "fix(guardian): resolve key_target for context-button create access
+
+A custom ContextButton whose key != key_target and targets a child
+viewset's create view was always rendered as no-access on list pages,
+because the Guardian list mixin looked the target view up by the literal
+key. Resolve the button's key_target before the lookup so create-access
+is re-derived for any create button, not just the built-in 'create'.
+
+Claude-Session: https://claude.ai/code/session_01XAzMTw15SVe5rfyrRyNC9i"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- "create_button == create with parent perm (access + action_enabled)" → Step 2 test 1. ✓
+- "create_button == create without parent perm" → Step 2 test 2. ✓
+- "unresolvable parent → denied, no exception" → Step 2 test 3. ✓
+- "top-level create access unchanged" → Step 2 test 4. ✓
+- "resolve key_target before lookup" fix → Step 4. ✓
+- "no core crud_views change; cv_has_access contract unchanged" → only mixin + tests touched. ✓
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases" — every step has concrete code and exact commands. ✓
+
+**Type consistency:** `cv_get_context_button` returns `ContextButton | None`; `key_target` is `str | None`; `is_view_registered`/`get_view_class` keyed on the resolved `target_key`; test helpers `_make_book_list_view`, `user_guardian_object_perm`, `user_viewset_permission` match existing signatures in `test_guardian.py`. ✓

--- a/superpowers/specs/2026-06-18-context-button-create-access-design.md
+++ b/superpowers/specs/2026-06-18-context-button-create-access-design.md
@@ -1,0 +1,135 @@
+# Context Button Create Access — Design
+
+## Problem
+
+A custom `ContextButton` that targets a child viewset's `create` view renders as
+"no access" (hidden/disabled) on a list page — even for a user who is allowed to
+create — whenever its `key` differs from its `key_target`. The built-in `"create"`
+button works for the same user on the same page, because its key happens to equal
+the view key.
+
+Reproduction (child viewset, create gated by Guardian):
+
+```python
+cv_projekt_note = GuardianViewSet(
+    model=ProjektNote,
+    name="projekt_note",
+    parent=ParentViewSet(name="projekt"),
+    context_buttons=context_buttons_default() + [
+        ContextButton(key="create_button", key_target="create"),  # key != key_target
+    ],
+)
+```
+
+```django
+{% cv_context_button "create" %}          {# works #}
+{% cv_context_button "create_button" %}   {# always "no access" #}
+```
+
+The viewset config is correct — this is a gap in how Guardian create-access is
+resolved for context buttons.
+
+## Root cause
+
+For a child create on a list page, `obj is None`, so
+`GuardianCreateView.cv_has_access(user, None)` returns `False` by design
+(`crud_views_guardian/lib/views.py`, "Case 2"). The real per-object decision needs
+the parent object and is delegated to `cv_create_has_access(user, rendering_view,
+parent_obj)`.
+
+That delegation lives in exactly one place: `GuardianQuerysetMixin.cv_get_context()`
+(`crud_views_guardian/lib/mixins.py`). It re-derives `cv_access` and
+`cv_action_enabled` after `super().cv_get_context()` has built the button dict — but
+it looks the target view up by the **literal `key`** passed to the tag:
+
+```python
+if obj is None and key is not None and self.cv_viewset.has_parent:
+    if self.cv_viewset.is_view_registered(key):   # keyed on `key`, not key_target
+        target_cls = self.cv_viewset.get_view_class(key)
+    ...
+        ctx["cv_access"] = target_cls.cv_create_has_access(user, self, parent_obj)
+        ctx["cv_action_enabled"] = target_cls.cv_action_enabled(user, parent_obj)
+```
+
+Both buttons reach the same override, but:
+
+- `key="create"` is **not** a registered context button, so `super()` takes the
+  "key is a view" branch; the override then sees `is_view_registered("create")` is
+  true and re-derives access. → works.
+- `key="create_button"` **is** a registered context button, so `super()` returns
+  `ContextButton.get_context()`, whose only access check is `cls.cv_has_access(user,
+  None)` → `False`. The override then skips it, because
+  `is_view_registered("create_button")` is false. → always denied.
+
+So the re-derivation keys off the button **`key`** instead of the button's
+**`key_target`**.
+
+Note: a create button on a *parent/child detail page* already works today, because
+there `obj` is the parent instance and `GuardianCreateView.cv_has_access` "Case 3"
+performs the per-object check directly. The gap is specific to **list pages** where
+`obj is None`.
+
+## Approach (chosen)
+
+Resolve the button's `key_target` before the target-view lookup in
+`GuardianQuerysetMixin.cv_get_context()`.
+
+```python
+if obj is None and key is not None and self.cv_viewset.has_parent:
+    context_button = self.cv_get_context_button(key)
+    target_key = context_button.key_target if context_button and context_button.key_target else key
+    if self.cv_viewset.is_view_registered(target_key):
+        target_cls = self.cv_viewset.get_view_class(target_key)
+    else:
+        target_cls = None
+    # unchanged below: cv_permission == "add" guard, parent resolution,
+    # and the cv_access / cv_action_enabled overwrite
+```
+
+Everything downstream is unchanged. `super().cv_get_context()` has already built the
+dict with the correct URL, label, and template against the create view class; the
+override overwrites only the two access fields (`cv_access`, `cv_action_enabled`).
+The result for `"create_button"` becomes identical to `"create"`.
+
+### Why this is safe
+
+- No change to core `crud_views`; no change to the `cv_has_access` contract; no
+  downstream impact.
+- Bare `key="create"` still works (`context_button` is `None` → `target_key = key`).
+- Guarded by the existing `obj is None and self.cv_viewset.has_parent` condition.
+- `cv_action_enabled` is already re-derived alongside `cv_access` in the existing
+  override, so there is no separate enabled-state regression.
+
+### Scope / limitation
+
+Covers any `ContextButton` (or subclass) rendered through a view using the Guardian
+list mixin whose `key_target` points at a child create. A create button on a
+*non-list, no-object* view is not covered by this fix — but that case is currently
+hypothetical (parent/child detail pages already work via Case 3). The broader,
+uniform solution is captured separately as a future TODO (Approach B,
+`superpowers/instructions/0004-context-button-access-create-TODO.md`).
+
+## Tests
+
+In `tests/test1/`, using the Author→Book Guardian fixtures (Book is a child
+viewset). Add `ContextButton(key="create_button", key_target="create")` to the Book
+viewset and assert, on the Book list page:
+
+- `"create_button"` and the built-in `"create"` yield the **same** `cv_access` —
+  both visible for a user with parent create permission, both hidden without it.
+- `"create_button"` and `"create"` yield the **same** `cv_action_enabled`.
+- Unresolvable parent → denied, no exception raised.
+- Top-level (no-parent) create access is unchanged.
+
+## Relevant source
+
+- `crud_views_guardian/lib/mixins.py` — `GuardianQuerysetMixin.cv_get_context()`:
+  the only create-access re-derivation (the single method changed).
+- `crud_views/lib/view/base.py` — `cv_get_context()` / `cv_get_context_button()`:
+  the context-button vs. "key is a view" branching.
+- `crud_views/lib/view/buttons.py` — `ContextButton.get_context()`: generic access
+  via `cv_has_access`, no create path.
+- `crud_views_guardian/lib/views.py` — `GuardianCreateView.cv_has_access`
+  (`obj is None → False`, Case 3 for parent obj) and `cv_create_has_access`.
+- `crud_views/templatetags/crud_views.py` — `cv_context_button` →
+  `view.cv_get_context`.

--- a/tests/test1/app/views.py
+++ b/tests/test1/app/views.py
@@ -37,7 +37,8 @@ from crud_views_polymorphic.lib import (
 )
 from crud_views_polymorphic.lib.create_select import PolymorphicContentTypeForm
 from crud_views_polymorphic.lib.delete import PolymorphicDeleteViewPermissionRequired
-from crud_views.lib.viewset import ViewSet, ParentViewSet
+from crud_views.lib.viewset import ViewSet, ParentViewSet, context_buttons_default
+from crud_views.lib.view import ContextButton
 from crud_views_guardian.lib.viewset import GuardianViewSet
 from crud_views_guardian.lib.views import (
     GuardianListViewPermissionRequired,
@@ -591,6 +592,10 @@ cv_guardian_book = GuardianViewSet(
     icon_header="fa-regular fa-address-book",
     cv_guardian_parent_permission="view",
     cv_guardian_parent_create_permission="change",
+    context_buttons=context_buttons_default()
+    + [
+        ContextButton(key="create_button", key_target="create"),  # key != key_target
+    ],
 )
 
 

--- a/tests/test1/test_guardian.py
+++ b/tests/test1/test_guardian.py
@@ -438,6 +438,88 @@ def test_cv_get_context_respects_cv_create_has_access_override(user_guardian, pu
         GuardianBookCreateView.cv_create_has_access = original
 
 
+# ── ContextButton key != key_target targeting child create ────────────────────
+
+
+@pytest.mark.django_db
+def test_create_button_matches_create_with_parent_perm(user_guardian, cv_guardian_publisher, publisher_a):
+    """create_button (key != key_target) matches built-in create when parent perm is granted."""
+    user_guardian_object_perm(user_guardian, cv_guardian_publisher, "change", publisher_a)
+    view = _make_book_list_view(user_guardian, publisher_a)
+    create = view.cv_get_context(key="create", obj=None, user=user_guardian)
+    button = view.cv_get_context(key="create_button", obj=None, user=user_guardian)
+    assert create["cv_access"] is True
+    assert button["cv_access"] == create["cv_access"]
+    assert button["cv_action_enabled"] == create["cv_action_enabled"]
+
+
+@pytest.mark.django_db
+def test_create_button_matches_create_without_parent_perm(user_guardian, publisher_a):
+    """create_button is hidden, exactly like built-in create, without parent perm."""
+    view = _make_book_list_view(user_guardian, publisher_a)
+    create = view.cv_get_context(key="create", obj=None, user=user_guardian)
+    button = view.cv_get_context(key="create_button", obj=None, user=user_guardian)
+    assert create["cv_access"] is False
+    assert button["cv_access"] == create["cv_access"]
+    assert button["cv_action_enabled"] == create["cv_action_enabled"]
+
+
+@pytest.mark.django_db
+def test_create_button_unresolvable_parent_denied(user_guardian):
+    """Unresolvable parent → create_button denied, no exception raised."""
+    from unittest.mock import MagicMock
+    from django.test import RequestFactory
+    from tests.test1.app.views import GuardianBookListView, cv_guardian_book
+
+    rf = RequestFactory()
+    request = rf.get("/guardian_publisher/999999/guardian_book/")
+    request.user = user_guardian
+    resolver_match = MagicMock()
+    resolver_match.url_name = cv_guardian_book.get_router_name("list")
+    request.resolver_match = resolver_match
+
+    view = GuardianBookListView()
+    view.request = request
+    view.args = []
+    view.kwargs = {"guardian_publisher_pk": "999999"}  # no such publisher
+
+    ctx = view.cv_get_context(key="create_button", obj=None, user=user_guardian)
+    assert ctx["cv_access"] is False
+
+
+@pytest.mark.django_db
+def test_top_level_create_unchanged_by_key_target_fix(user_guardian, cv_guardian_author):
+    """Top-level (no-parent) create access is unaffected — the override's has_parent guard skips it."""
+    from unittest.mock import MagicMock
+    from django.contrib.auth.models import User
+    from django.test import RequestFactory
+    from tests.lib.helper.user import user_viewset_permission
+    from tests.test1.app.views import GuardianAuthorListView, cv_guardian_author as author_vs
+
+    rf = RequestFactory()
+    request = rf.get("/guardian_author/")
+    request.user = user_guardian
+    resolver_match = MagicMock()
+    resolver_match.url_name = author_vs.get_router_name("list")
+    request.resolver_match = resolver_match
+
+    view = GuardianAuthorListView()
+    view.request = request
+    view.args = []
+    view.kwargs = {}
+
+    # without model-level add perm → denied
+    denied = view.cv_get_context(key="create", obj=None, user=user_guardian)
+    assert denied["cv_access"] is False
+
+    # with model-level add perm → granted (refetch user to bust the perm cache)
+    user_viewset_permission(user_guardian, cv_guardian_author, "add")
+    granted_user = User.objects.get(pk=user_guardian.pk)
+    request.user = granted_user
+    granted = view.cv_get_context(key="create", obj=None, user=granted_user)
+    assert granted["cv_access"] is True
+
+
 # ── GuardianManageView ────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

A custom `ContextButton` whose `key` differs from its `key_target` and that targets a child viewset's `create` view was always rendered as "no access" on Guardian list pages — even for a user allowed to create. The built-in `"create"` button worked for the same user on the same page only because its key happens to equal the view key.

```python
context_buttons=context_buttons_default() + [
    ContextButton(key="create_button", key_target="create"),  # key != key_target
]
```

```django
{% cv_context_button "create" %}          {# worked #}
{% cv_context_button "create_button" %}   {# always "no access" #}
```

## Root cause

For a child create on a list page `obj is None`, so `GuardianCreateView.cv_has_access(user, None)` returns `False` by design; the real per-object decision is delegated to `cv_create_has_access(user, view, parent_obj)` in `GuardianQuerysetMixin.cv_get_context`. That re-derivation looked the target view up by the **literal `key`** — which, for a registered context button, is not a registered view — so it was skipped and access stayed denied.

## Fix

Resolve the button's `key_target` before the target-view lookup (one method, `crud_views_guardian/lib/mixins.py`). The existing `cv_permission == "add"` guard, parent resolution, and `cv_access`/`cv_action_enabled` overwrite are unchanged. No change to core `crud_views` or the `cv_has_access` contract.

## Tests

New cases in `tests/test1/test_guardian.py` (Guardian Publisher→Book child fixtures): `create_button` now matches built-in `create` for `cv_access` and `cv_action_enabled`, both with and without parent permission; unresolvable parent → denied without raising; top-level (no-parent) create access unchanged. The parity test fails before the fix and passes after. Full suite: 387 passed, 1 skipped; `ruff check` clean.

## Follow-up (not in this PR)

Approach B — a unified core `cv_button_has_access` hook — is documented as a deferred TODO in `superpowers/instructions/0004-context-button-access-create-TODO.md`.

## Design / plan

- Spec: `superpowers/specs/2026-06-18-context-button-create-access-design.md`
- Plan: `superpowers/plans/2026-06-18-context-button-create-access.md`

https://claude.ai/code/session_01XAzMTw15SVe5rfyrRyNC9i