### PR TITLE
fix(buttons): check ParentContextButton access against the parent object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Guardian: a custom `ContextButton` whose `key` differs from its `key_target` and that targets a child viewset's `create` view is no longer always rendered as "no access" on list pages. The Guardian list mixin now resolves the button's `key_target` before re-deriving create access, so any create button (not just the built-in `"create"`) gets the parent-object permission check — enabling, e.g., a second differently-styled create button on the same page
+- `ParentContextButton`: a parent button targeting an object-permission-gated parent view (e.g. the parent's `detail`) is no longer wrongly hidden on object-less child pages (list/card). Access is now checked against the resolved **parent object** (via `cv_get_parent_object()`) rather than the current view's object, so the button reflects whether the user can access that parent — the same gate as opening the parent detail page directly. The default `parent`→list button is unaffected
 
 ## 0.6.0
 

--- a/src/crud_views/lib/view/buttons.py
+++ b/src/crud_views/lib/view/buttons.py
@@ -1,3 +1,4 @@
+from django.http import Http404
 from django.urls import reverse
 from pydantic import BaseModel, Field
 
@@ -103,11 +104,20 @@ class ParentContextButton(ContextButton):
         # get the url for the target key
         dict_kwargs.update(cv_url=cv_url)
 
-        # button visibility — independent of access/permission
-        dict_kwargs["cv_action_enabled"] = cls.cv_action_enabled(context.view.request.user, context.object)
+        # the button links UP to the parent, so access is governed by the PARENT
+        # object — not context.object (the child instance, or None on a list page).
+        parent_obj = None
+        if hasattr(context.view, "cv_get_parent_object"):
+            try:
+                parent_obj = context.view.cv_get_parent_object()
+            except (Http404, KeyError):
+                parent_obj = None
 
-        # check permission
-        if cls.cv_has_access(context.view.request.user, context.object):
+        # button visibility — independent of access/permission
+        dict_kwargs["cv_action_enabled"] = cls.cv_action_enabled(context.view.request.user, parent_obj)
+
+        # check permission against the parent object
+        if cls.cv_has_access(context.view.request.user, parent_obj):
             dict_kwargs.update(
                 cv_access=True,
             )
@@ -161,6 +171,10 @@ class SiblingContextButton(ContextButton):
     """
     A context button on a child view that links to a sibling collection — another child of
     the same parent — reusing the parent PK already present in the current URL.
+
+    Collection-only: a sibling button has no specific sibling object in scope, so object-gated
+    sibling views (detail/update/delete) are unsupported — access is checked with obj=None,
+    which is correct only for collection targets (list/card, whose access is unconditional).
     """
 
     sibling_name: str

--- a/superpowers/instructions/0004-context-button-access-create-TODO.md
+++ b/superpowers/instructions/0004-context-button-access-create-TODO.md
@@ -57,6 +57,13 @@ across list / detail / sibling / child / parent render paths.
   arbitrary `rendering_view` that may have no parent / no matching URL kwargs
   (catch `Http404`/`KeyError`, fall back to denied), mirroring the current override.
 
+- **`SiblingContextButton` is NOT a "resolve the shared parent" case (correction
+  2026-06-18).** It navigates to a sibling *collection* and has no specific sibling
+  object in scope, so it can only meaningfully target collection views (`list`/`card`),
+  whose access is unconditional. The unified `cv_button_has_access` hook must do **no**
+  object resolution for sibling buttons — passing `None` is correct. Only create
+  (→ parent) and parent-detail (→ parent) need a resolved object.
+
 - **Blast radius.** This touches core button rendering for **all themes and all
   button types**, not just Guardian/create. Regression-test all 4 button types
   across base, Guardian, and plain themes.

--- a/superpowers/plans/2026-06-18-context-button-parent-object-access.md
+++ b/superpowers/plans/2026-06-18-context-button-parent-object-access.md
@@ -1,0 +1,316 @@
+# Context Button Parent-Object Access Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a `ParentContextButton` that targets an object-permission-gated parent view (e.g. parent `detail`) reflect the user's access to the **parent object** on object-less child pages, instead of being wrongly hidden.
+
+**Architecture:** Single-method change in `ParentContextButton.get_context()`
+(`src/crud_views/lib/view/buttons.py`). The parent PK is already read from the view's
+kwargs to build the URL; load the parent **instance** from the same source via the
+existing core helper `cv_get_parent_object()` and check `cv_has_access` /
+`cv_action_enabled` against it. Purely core `crud_views` — no Guardian-side change.
+
+**Tech Stack:** Python, Django, django-guardian, pytest. Tests run from `tests/`.
+
+## Global Constraints
+
+- Line length: 120 characters (ruff). Quote style: double quotes.
+- No change to core `crud_views` access **contract** (`cv_has_access` signature
+  unchanged); the only behavior change is *which object* `ParentContextButton` passes.
+- `SiblingContextButton` behavior is **unchanged** — collection-only, no governing
+  object; passing `None` stays correct. Only its docstring is clarified.
+- Approach B (unified `cv_button_has_access` hook) is **not** implemented here.
+- Tests live in `tests/test1/`; run with `cd tests && pytest`.
+- Spec: `superpowers/specs/2026-06-18-context-button-parent-object-access-design.md`.
+
+---
+
+## File Structure
+
+- `src/crud_views/lib/view/buttons.py` — the fix in `ParentContextButton.get_context()`
+  (add `Http404` import; resolve parent object; check access against it) **and** a
+  one-line docstring clarification on `SiblingContextButton`.
+- `tests/test1/app/views.py` — add a `ParentContextButton(key="publisher_detail",
+  key_target="detail")` to the existing child Guardian viewset `cv_guardian_book`.
+- `tests/test1/test_guardian.py` — new test section asserting the parent-detail button
+  reflects parent-object `view` permission; default `parent`→list button regression;
+  unresolvable-parent case. Reuses the existing `_make_book_list_view` helper
+  (`test_guardian.py:370`).
+- `superpowers/instructions/0004-context-button-access-create-TODO.md` — add a
+  correction note: `SiblingContextButton` is not a "resolve the shared parent" case.
+
+One coherent fix with one test cycle → one task (doc edits folded in).
+
+---
+
+### Task 1: Check `ParentContextButton` access against the parent object
+
+**Files:**
+- Modify: `src/crud_views/lib/view/buttons.py` (imports; `ParentContextButton.get_context`
+  lines 106-113; `SiblingContextButton` docstring lines 161-164)
+- Modify: `tests/test1/app/views.py` (import `ParentContextButton`; extend
+  `cv_guardian_book.context_buttons`, lines 41 and 595-598)
+- Modify: `superpowers/instructions/0004-context-button-access-create-TODO.md` (after line 58)
+- Test: `tests/test1/test_guardian.py` (append a new section after line 438)
+
+**Interfaces:**
+- Consumes (existing, do not redefine):
+  - `context.view.cv_get_parent_object() -> Model` (`base.py:411`) — raises
+    `Http404` (bad PK) or `KeyError` (missing kwarg).
+  - `cls.cv_has_access(user, obj) -> bool`, `cls.cv_action_enabled(user, obj) -> bool`.
+  - `from crud_views.lib.view import ContextButton, ParentContextButton`.
+  - `context_buttons_default()` (`crud_views.lib.viewset`).
+  - Test helpers: `_make_book_list_view(user_guardian, publisher_a)`
+    (`test_guardian.py:370`), `user_guardian_object_perm(user, viewset, perm, obj)`
+    (imported at `test_guardian.py:3`).
+- Produces: no new public API. Behavior change only — `ParentContextButton`
+  `cv_access` / `cv_action_enabled` are now evaluated against the resolved parent
+  object instead of `context.object`.
+
+---
+
+- [ ] **Step 1: Add the `Http404` import to `buttons.py`**
+
+In `src/crud_views/lib/view/buttons.py`, the current import block (lines 1-5) is:
+
+```python
+from django.urls import reverse
+from pydantic import BaseModel, Field
+
+from .context import ViewContext
+from ..settings import crud_views_settings
+```
+
+Add the `Http404` import:
+
+```python
+from django.http import Http404
+from django.urls import reverse
+from pydantic import BaseModel, Field
+
+from .context import ViewContext
+from ..settings import crud_views_settings
+```
+
+- [ ] **Step 2: Add the test fixture — a parent-detail button on the child viewset**
+
+In `tests/test1/app/views.py`, extend the button import (line 41):
+
+```python
+from crud_views.lib.view import ContextButton, ParentContextButton
+```
+
+Then extend `cv_guardian_book.context_buttons` (lines 595-598) to:
+
+```python
+    context_buttons=context_buttons_default()
+    + [
+        ContextButton(key="create_button", key_target="create"),  # key != key_target
+        ParentContextButton(key="publisher_detail", key_target="detail"),  # → object-gated parent detail
+    ],
+```
+
+- [ ] **Step 3: Write the failing tests**
+
+Append to `tests/test1/test_guardian.py` (after line 438):
+
+```python
+# ── ParentContextButton targeting an object-gated parent view ─────────────────
+
+
+@pytest.mark.django_db
+def test_parent_detail_button_visible_with_parent_view_perm(user_guardian, cv_guardian_publisher, publisher_a):
+    """A ParentContextButton → parent detail is visible when the user can view the parent object."""
+    user_guardian_object_perm(user_guardian, cv_guardian_publisher, "view", publisher_a)
+    view = _make_book_list_view(user_guardian, publisher_a)
+    ctx = view.cv_get_context(key="publisher_detail", obj=None, user=user_guardian)
+    assert ctx["cv_access"] is True
+
+
+@pytest.mark.django_db
+def test_parent_detail_button_hidden_without_parent_view_perm(user_guardian, publisher_a):
+    """A ParentContextButton → parent detail is hidden when the user cannot view the parent object."""
+    view = _make_book_list_view(user_guardian, publisher_a)
+    ctx = view.cv_get_context(key="publisher_detail", obj=None, user=user_guardian)
+    assert ctx["cv_access"] is False
+
+
+@pytest.mark.django_db
+def test_default_parent_button_visible_regardless_of_object_perm(user_guardian, cv_guardian_publisher, publisher_a):
+    """Regression: the default parent→list button stays visible with and without parent view perm."""
+    view = _make_book_list_view(user_guardian, publisher_a)
+    # without perm — parent list access is unconditional
+    without = view.cv_get_context(key="parent", obj=None, user=user_guardian)
+    assert without["cv_access"] is True
+    # with perm — still visible
+    user_guardian_object_perm(user_guardian, cv_guardian_publisher, "view", publisher_a)
+    with_perm = view.cv_get_context(key="parent", obj=None, user=user_guardian)
+    assert with_perm["cv_access"] is True
+
+
+@pytest.mark.django_db
+def test_parent_detail_button_unresolvable_parent_hidden(user_guardian, publisher_a):
+    """Unresolvable parent PK → parent-detail button hidden, no exception raised."""
+    from unittest.mock import MagicMock
+    from django.test import RequestFactory
+    from tests.test1.app.views import GuardianBookListView, cv_guardian_book
+
+    rf = RequestFactory()
+    request = rf.get("/guardian_publisher/999999/guardian_book/")
+    request.user = user_guardian
+    resolver_match = MagicMock()
+    resolver_match.url_name = cv_guardian_book.get_router_name("list")
+    request.resolver_match = resolver_match
+
+    view = GuardianBookListView()
+    view.request = request
+    view.args = []
+    view.kwargs = {"guardian_publisher_pk": "999999"}  # no such publisher
+
+    ctx = view.cv_get_context(key="publisher_detail", obj=None, user=user_guardian)
+    assert ctx["cv_access"] is False
+```
+
+- [ ] **Step 4: Run the new tests and confirm the access tests FAIL**
+
+Run: `cd tests && pytest test1/test_guardian.py -k "parent_detail or default_parent_button" -v`
+
+Expected: `test_parent_detail_button_visible_with_parent_view_perm` FAILS
+(`cv_access` is `False` — access is checked against `context.object` = `None`, so the
+object-gated parent detail denies). `test_parent_detail_button_hidden_without_parent_view_perm`,
+`test_default_parent_button_visible_regardless_of_object_perm`, and
+`test_parent_detail_button_unresolvable_parent_hidden` PASS (they already hold pre-fix
+— they lock in non-regression).
+
+- [ ] **Step 5: Apply the fix in `ParentContextButton.get_context()`**
+
+In `src/crud_views/lib/view/buttons.py`, replace the access block (lines 106-113):
+
+```python
+        # button visibility — independent of access/permission
+        dict_kwargs["cv_action_enabled"] = cls.cv_action_enabled(context.view.request.user, context.object)
+
+        # check permission
+        if cls.cv_has_access(context.view.request.user, context.object):
+            dict_kwargs.update(
+                cv_access=True,
+            )
+```
+
+with:
+
+```python
+        # the button links UP to the parent, so access is governed by the PARENT
+        # object — not context.object (the child instance, or None on a list page).
+        parent_obj = None
+        if hasattr(context.view, "cv_get_parent_object"):
+            try:
+                parent_obj = context.view.cv_get_parent_object()
+            except (Http404, KeyError):
+                parent_obj = None
+
+        # button visibility — independent of access/permission
+        dict_kwargs["cv_action_enabled"] = cls.cv_action_enabled(context.view.request.user, parent_obj)
+
+        # check permission against the parent object
+        if cls.cv_has_access(context.view.request.user, parent_obj):
+            dict_kwargs.update(
+                cv_access=True,
+            )
+```
+
+- [ ] **Step 6: Run the new tests and confirm they all PASS**
+
+Run: `cd tests && pytest test1/test_guardian.py -k "parent_detail or default_parent_button" -v`
+Expected: all four tests PASS.
+
+- [ ] **Step 7: Clarify the `SiblingContextButton` docstring**
+
+In `src/crud_views/lib/view/buttons.py`, replace the `SiblingContextButton` docstring
+(lines 161-164):
+
+```python
+    """
+    A context button on a child view that links to a sibling collection — another child of
+    the same parent — reusing the parent PK already present in the current URL.
+    """
+```
+
+with:
+
+```python
+    """
+    A context button on a child view that links to a sibling collection — another child of
+    the same parent — reusing the parent PK already present in the current URL.
+
+    Collection-only: a sibling button has no specific sibling object in scope, so object-gated
+    sibling views (detail/update/delete) are unsupported — access is checked with obj=None,
+    which is correct only for collection targets (list/card, whose access is unconditional).
+    """
+```
+
+- [ ] **Step 8: Add the correction note to the Approach B TODO**
+
+In `superpowers/instructions/0004-context-button-access-create-TODO.md`, after the
+"Parent-resolution helper" bullet (ends at line 58), insert a new bullet under
+"## Why this is bigger than it looks (the wrinkles)":
+
+```markdown
+- **`SiblingContextButton` is NOT a "resolve the shared parent" case (correction
+  2026-06-18).** It navigates to a sibling *collection* and has no specific sibling
+  object in scope, so it can only meaningfully target collection views (`list`/`card`),
+  whose access is unconditional. The unified `cv_button_has_access` hook must do **no**
+  object resolution for sibling buttons — passing `None` is correct. Only create
+  (→ parent) and parent-detail (→ parent) need a resolved object.
+```
+
+- [ ] **Step 9: Run the full Guardian suite + lint to confirm no regression**
+
+Run: `cd tests && pytest test1/test_guardian.py -q`
+Expected: all pass (the pre-existing `cv_get_context` tests included).
+
+Run: `cd tests && pytest -q`
+Expected: full suite green (the change touches a core button type rendered across
+many tests).
+
+Run: `ruff check src/crud_views/lib/view/buttons.py tests/test1/app/views.py tests/test1/test_guardian.py`
+then `ruff format src/crud_views/lib/view/buttons.py tests/test1/app/views.py tests/test1/test_guardian.py`
+Expected: checks pass; format leaves the changed files clean.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/crud_views/lib/view/buttons.py tests/test1/app/views.py tests/test1/test_guardian.py \
+  superpowers/instructions/0004-context-button-access-create-TODO.md
+git commit -m "fix(buttons): check ParentContextButton access against the parent object
+
+A ParentContextButton targeting an object-permission-gated parent view
+(e.g. parent detail) was hidden on object-less child pages because access
+was checked against context.object (the child, or None on a list) instead
+of the parent object the button links to. Resolve the parent instance via
+cv_get_parent_object() and check against it. SiblingContextButton is
+collection-only and unchanged (docstring clarified).
+
+Claude-Session: https://claude.ai/code/session_01XAzMTw15SVe5rfyrRyNC9i"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- "ParentContextButton checks access against the parent object" → Steps 1, 5. ✓
+- "with parent view perm → visible; without → hidden" → Step 3 tests 1-2. ✓
+- "default parent→list button stays visible in both cases" → Step 3 test 3. ✓
+- "unresolvable parent → hidden, no exception" → Step 3 test 4. ✓
+- "no Guardian-side change" → only `buttons.py` + tests + docs touched. ✓
+- "SiblingContextButton unchanged, docstring clarified" → Step 7. ✓
+- "TODO correction note" → Step 8. ✓
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases" — every step has concrete code and exact commands. ✓
+
+**Type consistency:** `cv_get_parent_object()` returns a `Model` and raises
+`Http404`/`KeyError`; `cv_has_access(user, obj)` / `cv_action_enabled(user, obj)`
+signatures unchanged; `ParentContextButton` / `ContextButton` imported from
+`crud_views.lib.view`; test helpers `_make_book_list_view`, `user_guardian_object_perm`
+match existing signatures in `test_guardian.py`. ✓

--- a/superpowers/specs/2026-06-18-context-button-parent-object-access-design.md
+++ b/superpowers/specs/2026-06-18-context-button-parent-object-access-design.md
@@ -1,0 +1,152 @@
+# Context Button Parent-Object Access — Design
+
+## Problem
+
+A `ParentContextButton` that targets an **object-permission-gated parent view**
+(e.g. the parent's `detail`) disappears on an **object-less** child page (a list or
+card view) — even for a user who is allowed to view that parent. The built-in
+`parent` button works only because it targets the parent's `list` view, whose access
+check is unconditionally `True`.
+
+Reproduction (child viewset under Guardian):
+
+```python
+context_buttons=context_buttons_default() + [
+    ParentContextButton(key="projekt_detail", key_target="detail"),  # → parent DETAIL
+]
+```
+
+```django
+{% cv_context_button "parent" %}          {# works — targets parent LIST #}
+{% cv_context_button "projekt_detail" %}  {# always "no access" — targets parent DETAIL #}
+```
+
+This is the second instance of the family fixed in
+[0003 — Context Button Create Access](../instructions/0003-context-button-create-access.md)
+(shipped in PR #48): a context button's access is checked **without the object the
+access depends on**.
+
+## Root cause
+
+`ParentContextButton.get_context()` (`src/crud_views/lib/view/buttons.py`) checks
+access against the **current view's object**:
+
+```python
+dict_kwargs["cv_action_enabled"] = cls.cv_action_enabled(context.view.request.user, context.object)
+if cls.cv_has_access(context.view.request.user, context.object):
+    dict_kwargs.update(cv_access=True)
+```
+
+A `ParentContextButton` links **up** to the parent's view, so access is governed by
+the **parent object** — not `context.object`, which is the child instance (or `None`
+on a list page). The check is therefore conceptually wrong; it only ever "worked"
+because the default `parent` button targets the parent `list` view, whose
+`cv_has_access` returns `True` regardless of the object passed
+(`GuardianQuerysetMixin`). The moment the button targets an object-gated parent view
+(`GuardianObjectPermissionMixin.cv_has_access(user, None) → False`), it collapses to
+denied, and `_render_context_button()`
+(`src/crud_views/templatetags/crud_views.py`) renders `""` for any button whose
+`cv_access is not True`.
+
+The parent **PK** is already read from `context.view.kwargs` to build the button's
+URL, but the parent **instance** is never loaded for the access check — even though
+the framework has a core helper for exactly that:
+`CrudView.cv_get_parent_object()` (`src/crud_views/lib/view/base.py`), which loads
+the immediate parent via `get_object_or_404(parent_model, pk=...)`.
+
+## Approach (chosen)
+
+Targeted fix (Approach A), consistent with the merged 0003 (#48). Correct the check
+to use the object it should always have used — the parent instance — entirely within
+core `crud_views`.
+
+In `ParentContextButton.get_context()`, replace the two `context.object` checks with:
+
+```python
+# the button links UP to the parent, so access is governed by the PARENT object —
+# not context.object (the child instance, or None on a list page).
+parent_obj = None
+if hasattr(context.view, "cv_get_parent_object"):
+    try:
+        parent_obj = context.view.cv_get_parent_object()
+    except (Http404, KeyError):
+        parent_obj = None
+
+dict_kwargs["cv_action_enabled"] = cls.cv_action_enabled(context.view.request.user, parent_obj)
+if cls.cv_has_access(context.view.request.user, parent_obj):
+    dict_kwargs.update(cv_access=True)
+```
+
+`Http404` is imported from `django.http`. `cv_get_parent_object()` is the existing
+core helper.
+
+### Why this is correct and safe
+
+- **No Guardian-side change.** `GuardianObjectPermissionMixin.cv_has_access(user,
+  parent_obj)` already performs the right per-object check when given the parent
+  instance. Unlike 0003 (which lived in the Guardian list mixin), this fix is purely
+  in core `crud_views` and benefits every theme and permission backend uniformly.
+- **Default `parent`→list button unchanged.** The parent list view's `cv_has_access`
+  returns `True` regardless of object, so passing `parent_obj` instead of `None`
+  changes nothing there. One uniform path; no `key_target` special-casing.
+- **Graceful degradation.** An unresolvable parent PK in kwargs makes
+  `cv_get_parent_object()` raise `Http404`; it is caught → `parent_obj = None` → an
+  object-gated parent view denies → the button is hidden, no exception raised.
+- **One extra DB query** per parent-button render (`get_object_or_404`). Acceptable;
+  cache on the view if it ever shows up in profiling.
+
+## Non-goals
+
+- **`SiblingContextButton` is deliberately unchanged — it is collection-only, with no
+  governing object.** A `SiblingContextButton` navigates to a *sibling collection*
+  (another child of the same parent) and has no specific sibling object in scope. The
+  shared parent does not identify a sibling instance, so there is no sensible object
+  to check an object-gated sibling *view* against — which is also why such a button
+  only meaningfully targets `list`/`card` (access `True`). Passing `None` is correct
+  for sibling buttons. This corrects the "sibling → shared parent" assumption in the
+  0003 Approach-B TODO and in the parent-object instruction; see the documentation
+  changes below.
+- **The unified `cv_button_has_access` hook (Approach B) stays deferred.** This is the
+  second instance of the family, which strengthens the eventual case for B, but B's
+  blast radius (core button rendering for all button types, a parallel
+  `cv_action_enabled` hook, a compat shim for downstream `cv_has_access` overrides)
+  is not warranted yet.
+
+## Documentation changes
+
+- `src/crud_views/lib/view/buttons.py` — add a clarifying line to
+  `SiblingContextButton`'s docstring: it links to a sibling *collection*;
+  object-gated sibling views are unsupported because no sibling object is in scope.
+- `superpowers/instructions/0004-context-button-access-create-TODO.md` — add a
+  correction under the sibling bullet recording that `SiblingContextButton` is **not**
+  a "resolve the shared parent" case; the unified hook must do no object resolution
+  for sibling buttons. Only create (→ parent) and parent-detail (→ parent) need a
+  resolved object.
+
+## Tests
+
+In `tests/test1/`, using the real Publisher→Book Guardian fixtures (Book is a child
+of Publisher) and the existing `_make_book_list_view` harness in `test_guardian.py`:
+
+- Add `ParentContextButton(key="publisher_detail", key_target="detail")` to
+  `cv_guardian_book`. On the book **list** page (`obj=None`):
+  - user **with** object `view` permission on the publisher → `publisher_detail`
+    button visible (`cv_access is True`),
+  - user **without** it → `publisher_detail` hidden (`cv_access is False`).
+- Regression: the default `parent` button (→ publisher list) stays visible
+  (`cv_access is True`) in **both** cases.
+- Unresolvable parent (bad/missing PK in kwargs) → `publisher_detail` hidden
+  (`cv_access is False`), no exception raised.
+
+## Relevant source
+
+- `src/crud_views/lib/view/buttons.py` — `ParentContextButton.get_context()` (the
+  method changed); `SiblingContextButton` (docstring clarified, behavior unchanged).
+- `src/crud_views/lib/view/base.py` — `cv_get_parent_object()` (core helper to load
+  the parent instance).
+- `src/crud_views_guardian/lib/mixins.py` — `GuardianObjectPermissionMixin.cv_has_access`
+  (`obj is None → False`; correct per-object check when given the parent instance)
+  vs. `GuardianQuerysetMixin.cv_has_access` (always `True`, why the default
+  parent→list button works).
+- `src/crud_views/templatetags/crud_views.py` — `_render_context_button()` (renders
+  `""` when `cv_access is not True`).

--- a/tests/test1/app/views.py
+++ b/tests/test1/app/views.py
@@ -38,7 +38,7 @@ from crud_views_polymorphic.lib import (
 from crud_views_polymorphic.lib.create_select import PolymorphicContentTypeForm
 from crud_views_polymorphic.lib.delete import PolymorphicDeleteViewPermissionRequired
 from crud_views.lib.viewset import ViewSet, ParentViewSet, context_buttons_default
-from crud_views.lib.view import ContextButton
+from crud_views.lib.view import ContextButton, ParentContextButton
 from crud_views_guardian.lib.viewset import GuardianViewSet
 from crud_views_guardian.lib.views import (
     GuardianListViewPermissionRequired,
@@ -595,6 +595,7 @@ cv_guardian_book = GuardianViewSet(
     context_buttons=context_buttons_default()
     + [
         ContextButton(key="create_button", key_target="create"),  # key != key_target
+        ParentContextButton(key="publisher_detail", key_target="detail"),  # → object-gated parent detail
     ],
 )
 

--- a/tests/test1/test_guardian.py
+++ b/tests/test1/test_guardian.py
@@ -438,6 +438,62 @@ def test_cv_get_context_respects_cv_create_has_access_override(user_guardian, pu
         GuardianBookCreateView.cv_create_has_access = original
 
 
+# ── ParentContextButton targeting an object-gated parent view ─────────────────
+
+
+@pytest.mark.django_db
+def test_parent_detail_button_visible_with_parent_view_perm(user_guardian, cv_guardian_publisher, publisher_a):
+    """A ParentContextButton → parent detail is visible when the user can view the parent object."""
+    user_guardian_object_perm(user_guardian, cv_guardian_publisher, "view", publisher_a)
+    view = _make_book_list_view(user_guardian, publisher_a)
+    ctx = view.cv_get_context(key="publisher_detail", obj=None, user=user_guardian)
+    assert ctx["cv_access"] is True
+
+
+@pytest.mark.django_db
+def test_parent_detail_button_hidden_without_parent_view_perm(user_guardian, publisher_a):
+    """A ParentContextButton → parent detail is hidden when the user cannot view the parent object."""
+    view = _make_book_list_view(user_guardian, publisher_a)
+    ctx = view.cv_get_context(key="publisher_detail", obj=None, user=user_guardian)
+    assert ctx["cv_access"] is False
+
+
+@pytest.mark.django_db
+def test_default_parent_button_visible_regardless_of_object_perm(user_guardian, cv_guardian_publisher, publisher_a):
+    """Regression: the default parent→list button stays visible with and without parent view perm."""
+    view = _make_book_list_view(user_guardian, publisher_a)
+    # without perm — parent list access is unconditional
+    without = view.cv_get_context(key="parent", obj=None, user=user_guardian)
+    assert without["cv_access"] is True
+    # with perm — still visible
+    user_guardian_object_perm(user_guardian, cv_guardian_publisher, "view", publisher_a)
+    with_perm = view.cv_get_context(key="parent", obj=None, user=user_guardian)
+    assert with_perm["cv_access"] is True
+
+
+@pytest.mark.django_db
+def test_parent_detail_button_unresolvable_parent_hidden(user_guardian, publisher_a):
+    """Unresolvable parent PK → parent-detail button hidden, no exception raised."""
+    from unittest.mock import MagicMock
+    from django.test import RequestFactory
+    from tests.test1.app.views import GuardianBookListView, cv_guardian_book
+
+    rf = RequestFactory()
+    request = rf.get("/guardian_publisher/999999/guardian_book/")
+    request.user = user_guardian
+    resolver_match = MagicMock()
+    resolver_match.url_name = cv_guardian_book.get_router_name("list")
+    request.resolver_match = resolver_match
+
+    view = GuardianBookListView()
+    view.request = request
+    view.args = []
+    view.kwargs = {"guardian_publisher_pk": "999999"}  # no such publisher
+
+    ctx = view.cv_get_context(key="publisher_detail", obj=None, user=user_guardian)
+    assert ctx["cv_access"] is False
+
+
 # ── ContextButton key != key_target targeting child create ────────────────────
 
 


### PR DESCRIPTION
## Problem

A `ParentContextButton` targeting an object-permission-gated parent view (e.g. the parent's `detail`) disappears on an object-less child page (list/card), even for a user allowed to view that parent. The built-in `parent` button works only because it targets the parent's `list` view, whose access check is unconditionally `True`.

```django
{% cv_context_button "parent" %}            {# works — targets parent LIST #}
{% cv_context_button "publisher_detail" %}  {# always "no access" — targets parent DETAIL #}
```

Second instance of the family fixed in #48 — a context button's access checked **without the object the access depends on**.

## Root cause

`ParentContextButton.get_context()` checked `cv_has_access(user, context.object)`. The button links **up** to the parent, so access is governed by the **parent object** — not `context.object` (the child instance, or `None` on a list). It only "worked" for the default button because the parent `list` view ignores the object. The parent **PK** was already read from `view.kwargs` to build the URL, but the parent **instance** was never loaded for the access check.

## Fix

Resolve the parent instance via the existing core helper `cv_get_parent_object()` and check `cv_has_access`/`cv_action_enabled` against it (one method, `src/crud_views/lib/view/buttons.py`). Purely core `crud_views` — `GuardianObjectPermissionMixin.cv_has_access` already does the right per-object check when given the parent. Unresolvable parent PK → `Http404` caught → `None` → denied, no exception. The default `parent`→list button is unaffected (list access is object-independent).

## Scope decisions

- `SiblingContextButton` is **collection-only** (no specific sibling object in scope) and is left unchanged — docstring clarified, and a correction note added to the Approach-B TODO so the "sibling → shared parent" assumption doesn't resurface.
- The unified `cv_button_has_access` hook (Approach B) stays deferred.

## Tests

New cases in `tests/test1/test_guardian.py` (Publisher→Book Guardian fixtures): parent-detail button visible with parent `view` perm / hidden without; default `parent`→list button stays visible regardless (regression); unresolvable parent → hidden, no exception. The visible-with-perm test fails before the fix and passes after. Full suite: 391 passed, 1 skipped; `ruff check` clean.

## Design / plan

- Spec: `superpowers/specs/2026-06-18-context-button-parent-object-access-design.md`
- Plan: `superpowers/plans/2026-06-18-context-button-parent-object-access.md`

https://claude.ai/code/session_01XAzMTw15SVe5rfyrRyNC9i