### PR TITLE
fix(buttons): honor ParentContextButton label_template_code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Guardian: a custom `ContextButton` whose `key` differs from its `key_target` and that targets a child viewset's `create` view is no longer always rendered as "no access" on list pages. The Guardian list mixin now resolves the button's `key_target` before re-deriving create access, so any create button (not just the built-in `"create"`) gets the parent-object permission check — enabling, e.g., a second differently-styled create button on the same page
 - `ParentContextButton`: a parent button targeting an object-permission-gated parent view (e.g. the parent's `detail`) is no longer wrongly hidden on object-less child pages (list/card). Access is now checked against the resolved **parent object** (via `cv_get_parent_object()`) rather than the current view's object, so the button reflects whether the user can access that parent — the same gate as opening the parent detail page directly. The default `parent`→list button is unaffected
+- `ParentContextButton` now honors its own `label_template`/`label_template_code` like the other button types (`ContextButton`, `ChildContextButton`, `SiblingContextButton`), instead of silently rendering the target (parent) view's default action label. When no label is set it still falls back to that default. The label-rendering step is now shared via a `ContextButton._apply_label()` helper so no button subclass can omit it
 
 ## 0.6.0
 

--- a/src/crud_views/lib/view/buttons.py
+++ b/src/crud_views/lib/view/buttons.py
@@ -31,6 +31,16 @@ class ContextButton(BaseModel):
         elif self.label_template_code:
             return context.view.render_snippet(data, template_code=self.label_template_code)
 
+    def _apply_label(self, data: dict, context: ViewContext) -> None:
+        """Override the seeded default label when this button declares its own label_template[_code].
+
+        render_label() returns None when neither is set, so the target view's default label
+        (already in data) is preserved. Shared by every button subclass so none can forget it.
+        """
+        cv_action_label = self.render_label(data, context)
+        if cv_action_label:
+            data["cv_action_label"] = cv_action_label
+
     def _inject_template(self, data: dict) -> None:
         if self.template_code:
             data["cv_template_code"] = self.template_code
@@ -61,9 +71,7 @@ class ContextButton(BaseModel):
         data = cls.cv_get_dict(context=context, **dict_kwargs)
 
         # render action label
-        cv_action_label = self.render_label(data, context)
-        if cv_action_label:
-            data["cv_action_label"] = cv_action_label
+        self._apply_label(data, context)
 
         self._inject_template(data)
 
@@ -123,6 +131,9 @@ class ParentContextButton(ContextButton):
             )
 
         data = cls.cv_get_dict(context=context, **dict_kwargs)
+
+        self._apply_label(data, context)
+
         self._inject_template(data)
         return data
 
@@ -158,9 +169,7 @@ class ChildContextButton(ContextButton):
 
         data = cls.cv_get_dict(context=context, **dict_kwargs)
 
-        cv_action_label = self.render_label(data, context)
-        if cv_action_label:
-            data["cv_action_label"] = cv_action_label
+        self._apply_label(data, context)
 
         self._inject_template(data)
 
@@ -207,9 +216,7 @@ class SiblingContextButton(ContextButton):
 
         data = cls.cv_get_dict(context=context, **dict_kwargs)
 
-        cv_action_label = self.render_label(data, context)
-        if cv_action_label:
-            data["cv_action_label"] = cv_action_label
+        self._apply_label(data, context)
 
         self._inject_template(data)
 

--- a/tests/test1/app/views.py
+++ b/tests/test1/app/views.py
@@ -596,6 +596,9 @@ cv_guardian_book = GuardianViewSet(
     + [
         ContextButton(key="create_button", key_target="create"),  # key != key_target
         ParentContextButton(key="publisher_detail", key_target="detail"),  # → object-gated parent detail
+        ParentContextButton(
+            key="publisher_detail_labeled", key_target="detail", label_template_code="Publisher Home"
+        ),  # → parent detail with a custom label
     ],
 )
 

--- a/tests/test1/test_guardian.py
+++ b/tests/test1/test_guardian.py
@@ -494,6 +494,36 @@ def test_parent_detail_button_unresolvable_parent_hidden(user_guardian, publishe
     assert ctx["cv_access"] is False
 
 
+# ── ParentContextButton label rendering ───────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_parent_button_renders_custom_label(user_guardian, publisher_a):
+    """A ParentContextButton with label_template_code renders that label, like its sibling classes."""
+    view = _make_book_list_view(user_guardian, publisher_a)
+    ctx = view.cv_get_context(key="publisher_detail_labeled", obj=None, user=user_guardian)
+    assert ctx["cv_action_label"] == "Publisher Home"
+
+
+@pytest.mark.django_db
+def test_parent_button_without_label_uses_target_default(user_guardian, publisher_a):
+    """Regression: a ParentContextButton with no label field falls back to the target view's default label."""
+    view = _make_book_list_view(user_guardian, publisher_a)
+    ctx = view.cv_get_context(key="publisher_detail", obj=None, user=user_guardian)
+    # falls back to the parent detail view's default action label, not the custom one
+    assert ctx["cv_action_label"]
+    assert ctx["cv_action_label"] != "Publisher Home"
+
+
+@pytest.mark.django_db
+def test_sibling_classes_render_custom_label_like_parent(user_guardian, publisher_a):
+    """Cross-check: ContextButton renders label_template_code so ParentContextButton must match it."""
+    view = _make_book_list_view(user_guardian, publisher_a)
+    ctx = view.cv_get_context(key="create_button", obj=None, user=user_guardian)
+    # create_button has no custom label → default; key point is the render path is exercised and non-empty
+    assert ctx["cv_action_label"]
+
+
 # ── ContextButton key != key_target targeting child create ────────────────────
 
 


### PR DESCRIPTION
## Summary

`ParentContextButton` ignored its own `label_template`/`label_template_code` and always rendered the target (parent) view's default action label — e.g. **"Show Publisher »None« detail."** on an object-less child list page, instead of the requested label. Its siblings (`ContextButton`, `ChildContextButton`, `SiblingContextButton`) all honor these fields, so a button read differently depending only on its class.

Root cause: `ParentContextButton.get_context()` built `data` and injected the template but never called `render_label()`, so `cv_get_dict()`'s seeded default `cv_action_label` was never overwritten.

## Changes

- `buttons.py`: `ParentContextButton.get_context()` now applies the label-render step. Lifted the block (previously duplicated in four `get_context()` methods) into a shared `ContextButton._apply_label()` helper so no subclass can omit it. When no label is set, `render_label()` returns `None` and the target view's default label is preserved (existing fallback).
- Tests: `ParentContextButton` with `label_template_code` renders that text; regression with no label falls back to the target default; cross-check on the shared render path.
- CHANGELOG note under Unreleased → Fixed.

This is independent of the access fix in #49 (`140f281`): even when the parent button is correctly visible, its text was wrong.

## Verification

- Full suite: **394 passed, 1 skipped**
- `ruff check` + `ruff format --check`: clean

Implements `superpowers/instructions/0005-context-button-parent-label.md`.

https://claude.ai/code/session_01KqgEeiK2iZ7nGDw92LvqnF