### PR TITLE
test(workflow): regression guard for workflow success message (#52)

### DIFF
--- a/tests/test1/test_workflow.py
+++ b/tests/test1/test_workflow.py
@@ -3,6 +3,7 @@ Tests for crud_views_workflow: WorkflowModelMixin, WorkflowView, WorkflowForm.
 """
 
 import pytest
+from django.contrib.messages import get_messages
 from django.test.client import Client
 
 from tests.test1.app.models import Campaign, CampaignState
@@ -255,6 +256,28 @@ def test_workflow_view_post_activate(client_user_campaign_change: Client, campai
     assert response.status_code == 302
     campaign_new.refresh_from_db()
     assert campaign_new.state == CampaignState.ACTIVE
+
+
+@pytest.mark.django_db
+def test_workflow_view_post_emits_success_message(client_user_campaign_change: Client, campaign_new):
+    """
+    A WorkflowView that mixes in MessageMixin (as CampaignWorkflowView does) emits its
+    configured success message after a transition. MessageMixin precedes WorkflowView in the
+    MRO, so its cv_form_valid_hook wraps WorkflowView's transition processing and then emits.
+    Regression guard for GitHub #52 (reported as "message never emitted" — it is emitted under
+    the documented MessageMixin opt-in, exactly like Create/Update/Delete views).
+    """
+    pk = campaign_new.pk
+    response = client_user_campaign_change.post(
+        f"/campaign/{pk}/workflow/",
+        {
+            "transition": "wf_activate",
+            "comment": "",
+        },
+    )
+    assert response.status_code == 302
+    messages = [m.message for m in get_messages(response.wsgi_request)]
+    assert f"Successfully processed workflow step on »{campaign_new}«" in messages
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Follow-up to #52.

## TL;DR — #52 is not a bug

While reviewing PR #51 we flagged that `WorkflowView` sets `cv_message_template_code` but "never emits it." On investigation that's incorrect: the message **is** emitted under the documented usage.

## Evidence

POSTing a real transition to `CampaignWorkflowView` (which mixes in `MessageMixin`, the documented pattern):

```
STATUS 302
MESSAGES ['Successfully processed workflow step on »Test Campaign«']
```

## Why

MRO. `CampaignWorkflowView(CrispyModelViewMixin, MessageMixin, WorkflowViewPermissionRequired)` places `MessageMixin` **before** `WorkflowView`, so `MessageMixin.cv_form_valid_hook` is the entry point: it calls `super().cv_form_valid_hook()` (which flows into `WorkflowView`'s transition-processing hook) and then emits the message. `WorkflowView` not calling `super()` is harmless — the only thing below it is `CustomFormView`'s no-op base hook.

This is the **same opt-in pattern** as `CreateView` / `UpdateView` / `DeleteView`: the library base declares `cv_message_template[_code]`; emitting requires the consumer to add `MessageMixin`. A bare `WorkflowView` without `MessageMixin` stays silent — correct and consistent.

## This PR

Adds `test_workflow_view_post_emits_success_message` asserting the message is emitted on a transition — a regression guard so this behavior isn't mistaken for dead config again. No production change.

Closes #52.

https://claude.ai/code/session_01KqgEeiK2iZ7nGDw92LvqnF