### PR TITLE
refactor(formsets): rename PolymorphicFormSetMixin to PolymorphicFormSetsViewMixin (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 - `MessageMixin`'s error path could never fire (its `cv_get_message` ignored the requested attribute and it guarded on an undefined `cv_error_message`). The success/error message renderer now lives on `CrudView.cv_get_message(*, error=False)`, returns `None` when unconfigured instead of raising, and the dead `MessageMixin.action()` wrapper was removed.
 - bootstrap5 example: `CampaignWorkflowView` listed a non-existent `"edit"` context-action key, raising `ViewSetKeyFoundError` ("key edit not registered at campaign") and a 500 on the campaign workflow page. Corrected to `"update"`, the registered key.
 
+### Changed
+
+- Renamed `crud_views.lib.formsets.mixins.PolymorphicFormSetMixin` to `PolymorphicFormSetsViewMixin`; the old name collided with django-polymorphic's `Polymorphic*FormSet` classes. This formsets API is semi-private, so the rename ships without a deprecation shim — update any `from crud_views.lib.formsets.mixins import PolymorphicFormSetMixin` imports to the new name.
+
 ## 0.6.0
 
 ### Added

--- a/examples/bootstrap5/app/views/formset/__init__.py
+++ b/examples/bootstrap5/app/views/formset/__init__.py
@@ -13,7 +13,7 @@ from app.models.poly import Poly, PolyOne, PolyTwo, PolyTwoChoice, PolyThree, Po
 from crud_views.lib.crispy import Column4, CrispyModelViewMixin, Column8
 from crud_views.lib.crispy.form import CrispyForm, CrispyModelForm
 from crud_views.lib.formsets import FormSet, FormSets, InlineFormSet
-from crud_views.lib.formsets.mixins import PolymorphicFormSetMixin
+from crud_views.lib.formsets.mixins import PolymorphicFormSetsViewMixin
 from crud_views_polymorphic.lib import (
     PolymorphicCreateSelectView,
     PolymorphicCreateViewPermissionRequired,
@@ -136,7 +136,7 @@ class PolyCreateSelectView(CrispyModelViewMixin, PolymorphicCreateSelectView):
 
 
 class PolyCreateView(
-    CrispyModelViewMixin, CreateViewParentMixin, PolymorphicFormSetMixin, PolymorphicCreateViewPermissionRequired
+    CrispyModelViewMixin, CreateViewParentMixin, PolymorphicFormSetsViewMixin, PolymorphicCreateViewPermissionRequired
 ):
     model = Poly
     cv_viewset = cv_poly_formset
@@ -161,7 +161,7 @@ class PolyCreateView(
             PolyAnswerNumber.objects.create(poly=self.object)
 
 
-class PolyUpdateView(CrispyModelViewMixin, PolymorphicFormSetMixin, PolymorphicUpdateViewPermissionRequired):
+class PolyUpdateView(CrispyModelViewMixin, PolymorphicFormSetsViewMixin, PolymorphicUpdateViewPermissionRequired):
     model = Poly
     cv_viewset = cv_poly_formset
     cv_formsets_required: bool = False

--- a/src/crud_views/lib/formsets/mixins.py
+++ b/src/crud_views/lib/formsets/mixins.py
@@ -154,8 +154,7 @@ class FormSetMixin(FormSetMixinBase):
         return self.cv_formsets.clone(cv_view=self)  # noqa
 
 
-# Naming collides with django-polymorphic's formset classes, see issue #30
-class PolymorphicFormSetMixin(FormSetMixinBase):
+class PolymorphicFormSetsViewMixin(FormSetMixinBase):
     cv_polymorphic_formsets: Dict[Type[Model], FormSets]
 
     @classmethod

--- a/tests/test1/test_formsets_bugs.py
+++ b/tests/test1/test_formsets_bugs.py
@@ -4,7 +4,7 @@ Regression tests for formsets subsystem bugs found in the 2026-06-10 audit:
 - H1: XFormSet.save() must raise when a form has no matching XForm
       (was: `assert Exception(...)` which never raises)
 - M1: FormSet.init() inner loop must not corrupt the `index` parameter
-- M2: PolymorphicFormSetMixin.cv_get_formsets() returns None for models
+- M2: PolymorphicFormSetsViewMixin.cv_get_formsets() returns None for models
       without formsets (was: contradictory ValueError)
 - M3: the formset AJAX template endpoint rejects garbage input with 400
 """
@@ -94,9 +94,9 @@ def test_init_index_parameter_not_corrupted_by_child_loop():
 
 def test_polymorphic_formsets_missing_model_returns_none():
     """M2: a polymorphic model without formsets is okay and yields None."""
-    from crud_views.lib.formsets.mixins import PolymorphicFormSetMixin
+    from crud_views.lib.formsets.mixins import PolymorphicFormSetsViewMixin
 
-    class FakeView(PolymorphicFormSetMixin):
+    class FakeView(PolymorphicFormSetsViewMixin):
         cv_polymorphic_formsets = {}
         polymorphic_model = Book
 


### PR DESCRIPTION
## Summary

Renames `crud_views.lib.formsets.mixins.PolymorphicFormSetMixin` → `PolymorphicFormSetsViewMixin`. The old name collided with django-polymorphic's `Polymorphic*FormSet` classes (issue #30).

The formsets API is semi-private — the mixin was never re-exported from the package `__init__` — so the rename ships **without a deprecation shim**, as the issue allows.

## Changes

- `src/crud_views/lib/formsets/mixins.py` — class definition renamed; dropped the obsolete "naming collides" comment
- `examples/bootstrap5/app/views/formset/__init__.py` — import + `PolyCreateView` / `PolyUpdateView` usages
- `tests/test1/test_formsets_bugs.py` — import, subclass, docstring
- `CHANGELOG.md` — new "Changed" entry with migration note

`CHANGELOG.md` line 46 and `AUDIT.md` keep the old name intentionally (historical records).

## Verification

- `pytest`: 403 passed, 1 skipped
- `ruff format --check` and `ruff check`: clean

Closes #30

https://claude.ai/code/session_01KqgEeiK2iZ7nGDw92LvqnF