### PR TITLE
fix(example): register ParentDetailView so /parent/ list renders (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `ParentContextButton` now honors its own `label_template`/`label_template_code` like the other button types (`ContextButton`, `ChildContextButton`, `SiblingContextButton`), instead of silently rendering the target (parent) view's default action label. When no label is set it still falls back to that default. The label-rendering step is now shared via a `ContextButton._apply_label()` helper so no button subclass can omit it
 - `MessageMixin`'s error path could never fire (its `cv_get_message` ignored the requested attribute and it guarded on an undefined `cv_error_message`). The success/error message renderer now lives on `CrudView.cv_get_message(*, error=False)`, returns `None` when unconfigured instead of raising, and the dead `MessageMixin.action()` wrapper was removed.
 - bootstrap5 example: `CampaignWorkflowView` listed a non-existent `"edit"` context-action key, raising `ViewSetKeyFoundError` ("key edit not registered at campaign") and a 500 on the campaign workflow page. Corrected to `"update"`, the registered key.
+- bootstrap5 example: the `/parent/` list 500'd because `ParentTable.id` (a `UUIDLinkDetailColumn`) linked to a `detail` view the parent ViewSet never registered, raising `ViewSetKeyFoundError` ("key detail not registered at parent"). Added the missing `ParentDetailView`.
 
 ### Changed
 

--- a/examples/bootstrap5/app/views/formset/parent.py
+++ b/examples/bootstrap5/app/views/formset/parent.py
@@ -8,6 +8,7 @@ from crud_views.lib.table import Table, UUIDLinkDetailColumn
 from crud_views.lib.views import (
     ListViewTableMixin,
     ListViewPermissionRequired,
+    DetailViewPermissionRequired,
     RedirectChildView,
     CreateViewPermissionRequired,
     UpdateViewPermissionRequired,
@@ -41,6 +42,22 @@ class ParentListView(ListViewTableMixin, ListViewPermissionRequired):
     cv_list_actions = ["redirect_child", "update", "delete"]
 
     table_class = ParentTable
+
+
+class ParentDetailView(DetailViewPermissionRequired):
+    model = Parent
+    cv_viewset = cv_poly_parent_formset
+    cv_property_display = [
+        {
+            "title": _("Properties"),
+            "icon": "user-group",
+            "description": _("Parent attributes"),
+            "properties": [
+                "id",
+                "name",
+            ],
+        },
+    ]
 
 
 class ParentCreateView(CrispyModelViewMixin, CreateViewPermissionRequired):


### PR DESCRIPTION
## Summary

The bootstrap5 example's `/parent/` list raised HTTP 500. `ParentTable.id` is a `UUIDLinkDetailColumn`, which links each row's id to the parent ViewSet's **`detail`** view — but the parent ViewSet (`cv_poly_parent_formset`) registered only list/create/update/delete/redirect_child, so rendering the table raised:

```
crud_views.lib.exceptions.ViewSetKeyFoundError: key detail not registered at parent
```

Fix: add a `ParentDetailView(DetailViewPermissionRequired)`, mirroring the existing `BarDetailView` pattern (`cv_property_display` showing `id`/`name`).

This is a pre-existing example-app bug, independent of the recent formsets work.

## Verification

Reproduced and confirmed against the example app settings with a logged-in admin (`HTTP_HOST=127.0.0.1`):
- `GET /parent/` → **200** (was 500)
- `GET /parent/<pk>/detail/` → **200** (newly registered)
- `ruff format --check` + `ruff check`: clean
- `manage.py check`: no issues

Closes #56

https://claude.ai/code/session_01KqgEeiK2iZ7nGDw92LvqnF