### PR TITLE
feat: view-level context buttons + FilterContextButton label (#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Django CRUD Views - Changelog
 
+## Unreleased
+
+### Added
+
+- View-level context buttons: set `cv_context_buttons` on a `CrudView` (a list of `ContextButton`s) to define buttons for a single view instead of the whole ViewSet. View-level buttons override ViewSet-level ones with the same `key`; they render only when the key is listed in `cv_context_actions`, matching existing button behavior.
+- `FilterContextButton` now honors `label_template` / `label_template_code`, so the filter toggle's label (default `Filter`) can be customized like any other context button.
+
 ## 0.7.1
 
 ### Added

--- a/docs/reference/context_buttons.md
+++ b/docs/reference/context_buttons.md
@@ -9,7 +9,10 @@ default set is provided by `context_buttons_default()`:
 
 - **`home`** — links to the list view of the current viewset
 - **`parent`** — links up to the parent viewset's list view (only rendered when a parent exists)
-- **`filter`** — toggles the filter form (only rendered when the view uses `ListViewTableFilterMixin`). The `filter` button's label (default `Filter`) can be customized with `label_template` / `label_template_code` like any other button.
+- **`filter`** — toggles the filter form (only rendered when the view uses `ListViewTableFilterMixin`)
+
+The `filter` button's label (default `Filter`) can be customized with `label_template` /
+`label_template_code`, like any other button.
 
 Views reference these buttons by key via `cv_context_actions`. Keys that don't match a context
 button are resolved as sibling view keys (e.g. `"update"`, `"delete"`, `"create"`).

--- a/docs/reference/context_buttons.md
+++ b/docs/reference/context_buttons.md
@@ -9,7 +9,7 @@ default set is provided by `context_buttons_default()`:
 
 - **`home`** — links to the list view of the current viewset
 - **`parent`** — links up to the parent viewset's list view (only rendered when a parent exists)
-- **`filter`** — toggles the filter form (only rendered when the view uses `ListViewTableFilterMixin`)
+- **`filter`** — toggles the filter form (only rendered when the view uses `ListViewTableFilterMixin`). The `filter` button's label (default `Filter`) can be customized with `label_template` / `label_template_code` like any other button.
 
 Views reference these buttons by key via `cv_context_actions`. Keys that don't match a context
 button are resolved as sibling view keys (e.g. `"update"`, `"delete"`, `"create"`).
@@ -218,6 +218,33 @@ cv_author = ViewSet(
     ],
 )
 ```
+
+## View-level Context Buttons
+
+By default, context buttons are defined on the **ViewSet** (`context_buttons`) and shared by
+every view in it. To define a button on a **single view**, set `cv_context_buttons` on the
+`CrudView` — a list of the same `ContextButton` types.
+
+```python
+from crud_views.lib.view import ChildContextButton
+from crud_views.lib.views import DetailViewPermissionRequired
+
+class BookDetailView(DetailViewPermissionRequired):
+    cv_viewset = cv_book
+    cv_context_actions = ["update", "delete", "reviews"]   # "reviews" listed -> it renders
+    cv_context_buttons = [                                  # defines "reviews" for this view only
+        ChildContextButton(key="reviews", child_name="review", label_template_code="Reviews"),
+    ]
+```
+
+Two rules:
+
+- **Rendering is unchanged:** a button appears only when its `key` is listed in
+  `cv_context_actions`. `cv_context_buttons` only *defines* buttons; `cv_context_actions`
+  controls what renders and in what order.
+- **View overrides ViewSet:** if a view-level button has the same `key` as a ViewSet-level
+  button, the view-level one wins for that view. Declare a same-key button in
+  `cv_context_buttons` to customize a single view without touching the ViewSet.
 
 ## Manual Placement (Template Tags)
 

--- a/skills/django-crud-views/SKILL.md
+++ b/skills/django-crud-views/SKILL.md
@@ -322,6 +322,9 @@ Context buttons are normally defined on the ViewSet and shared by all its views.
 button on a single view, set `cv_context_buttons` on the `CrudView`:
 
 ```python
+from crud_views.lib.view import ChildContextButton
+
+
 class BookDetailView(DetailViewPermissionRequired):
     cv_viewset = cv_book
     cv_context_actions = ["update", "delete", "reviews"]   # list the key to render it

--- a/skills/django-crud-views/SKILL.md
+++ b/skills/django-crud-views/SKILL.md
@@ -316,6 +316,24 @@ class BookListView(ListViewPermissionRequired):
 Renders nothing on a view without a parent. Access is checked model-level on the sibling
 view (no parent object is consulted).
 
+### View-level context buttons (cv_context_buttons)
+
+Context buttons are normally defined on the ViewSet and shared by all its views. To define a
+button on a single view, set `cv_context_buttons` on the `CrudView`:
+
+```python
+class BookDetailView(DetailViewPermissionRequired):
+    cv_viewset = cv_book
+    cv_context_actions = ["update", "delete", "reviews"]   # list the key to render it
+    cv_context_buttons = [
+        ChildContextButton(key="reviews", child_name="review", label_template_code="Reviews"),
+    ]
+```
+
+- A button renders only when its `key` is in `cv_context_actions` (definition vs. rendering
+  stay separate).
+- A view-level button overrides a ViewSet-level button with the same `key`, for that view only.
+
 ---
 
 ## Filtering

--- a/skills/django-crud-views/references/api-reference.md
+++ b/skills/django-crud-views/references/api-reference.md
@@ -379,6 +379,8 @@ SiblingContextButton(
 
 Renders nothing on a parentless view; access checked model-level on the sibling view.
 
+A single view can also define its own buttons via `cv_context_buttons` (a list of `ContextButton`s); view-level buttons override ViewSet-level ones with the same key. Buttons still render only when their key is listed in `cv_context_actions`.
+
 ---
 
 ## Mixins

--- a/src/crud_views/lib/view/base.py
+++ b/src/crud_views/lib/view/base.py
@@ -41,6 +41,7 @@ class CrudView(metaclass=CrudViewMetaClass):
     cv_list_actions: List[str] | None = None  # actions for the list view
     cv_list_action_method: str = "get"  # method to call for list actions
     cv_context_actions: List[str] | None = None  # context actions for the view (top right)
+    cv_context_buttons: List[ContextButton] | None = None  # view-level context button definitions (issue #27)
     cv_home_key: str | None = "list"  # home url, defaults to list
     cv_success_key: str | None = "list"  # success url, defaults to list
     cv_cancel_key: str | None = "list"  # cancel url, defaults to list
@@ -308,7 +309,10 @@ class CrudView(metaclass=CrudViewMetaClass):
         return ViewContext(**kwargs)
 
     def cv_get_context_button(self, key: str) -> ContextButton | None:
-        # view-level context buttons are not supported yet, see issue #27
+        # view-level buttons take precedence over ViewSet-level buttons (issue #27)
+        for cb in self.cv_context_buttons or []:
+            if cb.key == key:
+                return cb
         for cb in self.cv_viewset.context_buttons:
             if cb.key == key:
                 return cb

--- a/src/crud_views/lib/view/buttons.py
+++ b/src/crud_views/lib/view/buttons.py
@@ -252,6 +252,7 @@ class FilterContextButton(ContextButton):
         data["cv_action_label"] = "Filter"
         data["cv_icon_action"] = crud_views_settings.filter_icon
         data["cv_url"] = list_url
+        self._apply_label(data, context)
         self._inject_template(data)
 
         return data

--- a/superpowers/plans/2026-06-24-view-level-context-buttons.md
+++ b/superpowers/plans/2026-06-24-view-level-context-buttons.md
@@ -1,0 +1,371 @@
+# View-level Context Buttons Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a `CrudView` declare its own context buttons via a new `cv_context_buttons` attribute (overriding ViewSet-level buttons on key collision), and make `FilterContextButton`'s label templatable.
+
+**Architecture:** Purely additive. Part A adds a `cv_context_buttons: List[ContextButton] | None = None` attribute to `CrudView` and makes `cv_get_context_button` check it before the ViewSet's list. Rendering is unchanged — a button still only renders when its key is in `cv_context_actions` — so no template changes. Part B routes `FilterContextButton`'s label through the shared `_apply_label` helper.
+
+**Tech Stack:** Python 3.12+, Django 4.2–6.0, Pydantic v2 (button classes), pytest (tests/test1 project).
+
+**Spec:** `superpowers/specs/2026-06-24-view-level-context-buttons-design.md` (issue #27, target v0.8.0).
+
+## Global Constraints
+
+- Line length 120, double quotes, ruff-formatted (pre-commit runs `ruff format` + `ruff check`).
+- All `CrudView` class attributes use the `cv_` prefix.
+- New mutable-collection class attributes default to `None`, never `[]` (audit finding M6 — shared mutable class lists).
+- No new third-party dependencies; no new Django system checks (deferred to issue #28).
+- Tests live in `tests/test1/`, run with `cd tests && pytest`. Fixture conventions: `cv_<model>` ViewSets, `client_user_<model>_<perm>` clients, `user_viewset_permission(user, viewset, perm)` helper.
+- Backwards compatible: defaults reproduce current behavior exactly.
+
+---
+
+### Task 1: View-level button attribute + resolution (Part A)
+
+**Files:**
+- Modify: `src/crud_views/lib/view/base.py:43` (add attribute) and `src/crud_views/lib/view/base.py:310-315` (`cv_get_context_button`)
+- Test: `tests/test1/test_view_level_context_button.py` (create)
+
+**Interfaces:**
+- Consumes: `ContextButton` (already imported in `base.py`; `key` attribute, `label_template_code` field), `CrudView.cv_get_context_button(key)`, `CrudView.cv_get_context_buttons(keys=None, obj=None)`, `self.cv_viewset.context_buttons` (list of `ContextButton`).
+- Produces: `CrudView.cv_context_buttons: List[ContextButton] | None` (default `None`). `cv_get_context_button(key)` now returns the first matching view-level button, else the first matching ViewSet-level button, else `None`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test1/test_view_level_context_button.py`:
+
+```python
+"""View-level context buttons: CrudView.cv_context_buttons defines buttons; view overrides ViewSet."""
+
+import pytest
+from django.urls import reverse
+
+from crud_views.lib.view.buttons import ContextButton
+
+
+def _book_list_view(client, publisher):
+    from tests.test1.app.views import cv_book
+
+    url = reverse(cv_book.get_router_name("list"), kwargs={"publisher_pk": publisher.pk})
+    resp = client.get(url)
+    assert resp.status_code == 200
+    return resp.context["view"]
+
+
+@pytest.mark.django_db
+def test_view_level_overrides_viewset(client_user_book_view, cv_book, publisher_penguin, book_hitchhiker):
+    view = _book_list_view(client_user_book_view, publisher_penguin)
+    # ViewSet provides a default "home" button
+    assert view.cv_get_context_button("home").key == "home"
+    override = ContextButton(key="home", key_target="list", label_template_code="VIEWLEVEL")
+    view.cv_context_buttons = [override]
+    # view-level button with the same key wins (identity check)
+    assert view.cv_get_context_button("home") is override
+
+
+@pytest.mark.django_db
+def test_falls_back_to_viewset(client_user_book_view, cv_book, publisher_penguin, book_hitchhiker):
+    view = _book_list_view(client_user_book_view, publisher_penguin)
+    view.cv_context_buttons = [ContextButton(key="custom", key_target="list")]
+    # a key not defined at view level falls back to the ViewSet's buttons
+    assert view.cv_get_context_button("home").key == "home"
+
+
+@pytest.mark.django_db
+def test_none_default_unchanged(client_user_book_view, cv_book, publisher_penguin, book_hitchhiker):
+    view = _book_list_view(client_user_book_view, publisher_penguin)
+    assert view.cv_context_buttons is None
+    assert view.cv_get_context_button("home").key == "home"
+    assert view.cv_get_context_button("does_not_exist") is None
+
+
+@pytest.mark.django_db
+def test_explicit_render_only_listed_keys(client_user_book_view, cv_book, publisher_penguin, book_hitchhiker):
+    view = _book_list_view(client_user_book_view, publisher_penguin)
+    view.cv_context_buttons = [ContextButton(key="custom", key_target="list", label_template_code="UNLISTED")]
+
+    # "custom" defined but NOT in cv_context_actions -> not rendered
+    view.cv_context_actions = ["home"]
+    labels = [c.get("cv_action_label") for c in view.cv_get_context_buttons()]
+    assert "UNLISTED" not in labels
+
+    # listing the key in cv_context_actions renders it
+    view.cv_context_actions = ["home", "custom"]
+    labels = [c.get("cv_action_label") for c in view.cv_get_context_buttons()]
+    assert "UNLISTED" in labels
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd tests && pytest test1/test_view_level_context_button.py -v`
+Expected: FAIL — `test_view_level_overrides_viewset` and `test_explicit_render_only_listed_keys` fail because `cv_get_context_button` ignores `cv_context_buttons` (setting `view.cv_context_buttons` has no effect yet). `test_none_default_unchanged` may error on `view.cv_context_buttons` if the attribute does not exist.
+
+- [ ] **Step 3: Add the attribute**
+
+In `src/crud_views/lib/view/base.py`, immediately after the `cv_context_actions` line (line 43):
+
+```python
+    cv_context_actions: List[str] | None = None  # context actions for the view (top right)
+    cv_context_buttons: List[ContextButton] | None = None  # view-level context button definitions (issue #27)
+```
+
+(`List` and `ContextButton` are already imported in this module.)
+
+- [ ] **Step 4: Update the resolution method**
+
+Replace `cv_get_context_button` (`base.py:310-315`):
+
+```python
+    def cv_get_context_button(self, key: str) -> ContextButton | None:
+        # view-level buttons take precedence over ViewSet-level buttons (issue #27)
+        for cb in self.cv_context_buttons or []:
+            if cb.key == key:
+                return cb
+        for cb in self.cv_viewset.context_buttons:
+            if cb.key == key:
+                return cb
+        return None
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd tests && pytest test1/test_view_level_context_button.py -v`
+Expected: PASS (4 passed)
+
+- [ ] **Step 6: Run the full context-button suite to check for regressions**
+
+Run: `cd tests && pytest test1/ -k "context_button or context_actions" -q`
+Expected: PASS (all existing context-button tests still green)
+
+- [ ] **Step 7: Format and commit**
+
+```bash
+uv run ruff format src/crud_views/lib/view/base.py tests/test1/test_view_level_context_button.py
+git add src/crud_views/lib/view/base.py tests/test1/test_view_level_context_button.py
+git commit -m "feat: view-level context buttons via cv_context_buttons (#27)"
+```
+
+---
+
+### Task 2: FilterContextButton label templating (Part B)
+
+**Files:**
+- Modify: `src/crud_views/lib/view/buttons.py:236-257` (`FilterContextButton.get_context`)
+- Test: `tests/test1/test_context_button_template.py` (append)
+
+**Interfaces:**
+- Consumes: `ContextButton._apply_label(data, context)` (already defined at `buttons.py:34`; overrides `data["cv_action_label"]` when `label_template`/`label_template_code` is set, no-op otherwise), `FilterContextButton`, `CrudView.cv_get_view_context()` → `ViewContext`, `PublisherListView` (a `ListViewTableFilterMixin` view in the test app), fixture `client_user_publisher_view`, `cv_publisher`.
+- Produces: `FilterContextButton.get_context` now honors `label_template`/`label_template_code`, defaulting to `"Filter"`.
+
+- [ ] **Step 1: Write the failing tests**
+
+First add these imports to the **top** of `tests/test1/test_context_button_template.py` (after
+the existing imports on lines 1-4), so they are not flagged as mid-file imports (ruff E402):
+
+```python
+import pytest
+from django.urls import reverse
+```
+
+Then append the helper and tests to the end of the file:
+
+```python
+def _publisher_list_view(client, cv_publisher):
+    url = reverse(cv_publisher.get_router_name("list"))
+    resp = client.get(url)
+    assert resp.status_code == 200
+    return resp.context["view"]
+
+
+@pytest.mark.django_db
+def test_filter_button_default_label(client_user_publisher_view, cv_publisher):
+    view = _publisher_list_view(client_user_publisher_view, cv_publisher)
+    ctx = FilterContextButton().get_context(view.cv_get_view_context())
+    assert ctx["cv_action_label"] == "Filter"
+
+
+@pytest.mark.django_db
+def test_filter_button_templated_label(client_user_publisher_view, cv_publisher):
+    view = _publisher_list_view(client_user_publisher_view, cv_publisher)
+    ctx = FilterContextButton(label_template_code="Suchen").get_context(view.cv_get_view_context())
+    assert ctx["cv_action_label"] == "Suchen"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd tests && pytest test1/test_context_button_template.py -k filter_button -v`
+Expected: `test_filter_button_templated_label` FAILS — label stays `"Filter"` because `FilterContextButton.get_context` does not call `_apply_label`. `test_filter_button_default_label` may already pass.
+
+- [ ] **Step 3: Wire the label helper**
+
+In `src/crud_views/lib/view/buttons.py`, in `FilterContextButton.get_context`, add the `_apply_label` call after setting the default label (between the `cv_url` assignment and `_inject_template`):
+
+```python
+        data = dict()
+        data["cv_action_label"] = "Filter"
+        data["cv_icon_action"] = crud_views_settings.filter_icon
+        data["cv_url"] = list_url
+        self._apply_label(data, context)
+        self._inject_template(data)
+
+        return data
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd tests && pytest test1/test_context_button_template.py -k filter_button -v`
+Expected: PASS (3 passed — the two new tests plus the existing `test_filter_button_default_template`)
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+uv run ruff format src/crud_views/lib/view/buttons.py tests/test1/test_context_button_template.py
+git add src/crud_views/lib/view/buttons.py tests/test1/test_context_button_template.py
+git commit -m "feat: support label templating on FilterContextButton (#27)"
+```
+
+---
+
+### Task 3: Documentation, skill & CHANGELOG
+
+**Files:**
+- Modify: `docs/reference/context_buttons.md` (add a "View-level context buttons" section)
+- Modify: `skills/django-crud-views/SKILL.md` (add a `cv_context_buttons` subsection after `SiblingContextButton`, ~line 311)
+- Modify: `skills/django-crud-views/references/api-reference.md` (note `cv_context_buttons` in the context-button catalog, ~line 308)
+- Modify: `CHANGELOG.md` (add an `Unreleased` section with two `Added` entries)
+
+**Interfaces:**
+- Consumes: nothing (docs only).
+- Produces: published documentation of the Task 1 + Task 2 behavior.
+
+- [ ] **Step 1: Add the reference section**
+
+In `docs/reference/context_buttons.md`, add a new section (place it before "## Manual Placement (Template Tags)"):
+
+```markdown
+## View-level Context Buttons
+
+By default, context buttons are defined on the **ViewSet** (`context_buttons`) and shared by
+every view in it. To define a button on a **single view**, set `cv_context_buttons` on the
+`CrudView` — a list of the same `ContextButton` types.
+
+```python
+from crud_views.lib.view import ChildContextButton
+from crud_views.lib.views import DetailViewPermissionRequired
+
+class BookDetailView(DetailViewPermissionRequired):
+    cv_viewset = cv_book
+    cv_context_actions = ["update", "delete", "reviews"]   # "reviews" listed -> it renders
+    cv_context_buttons = [                                  # defines "reviews" for this view only
+        ChildContextButton(key="reviews", child_name="review", label_template_code="Reviews"),
+    ]
+```
+
+Two rules:
+
+- **Rendering is unchanged:** a button appears only when its `key` is listed in
+  `cv_context_actions`. `cv_context_buttons` only *defines* buttons; `cv_context_actions`
+  controls what renders and in what order.
+- **View overrides ViewSet:** if a view-level button has the same `key` as a ViewSet-level
+  button, the view-level one wins for that view. Declare a same-key button in
+  `cv_context_buttons` to customize a single view without touching the ViewSet.
+```
+
+Then, in the `FilterContextButton` discussion (the default-buttons list near the top mentions
+`filter`), note that its label is now templatable: add a sentence —
+"The `filter` button's label (default `Filter`) can be customized with `label_template` /
+`label_template_code` like any other button."
+
+- [ ] **Step 2: Add the skill subsection**
+
+In `skills/django-crud-views/SKILL.md`, after the `SiblingContextButton` parameters block
+(~line 311), add:
+
+```markdown
+### View-level context buttons (cv_context_buttons)
+
+Context buttons are normally defined on the ViewSet and shared by all its views. To define a
+button on a single view, set `cv_context_buttons` on the `CrudView`:
+
+```python
+class BookDetailView(DetailViewPermissionRequired):
+    cv_viewset = cv_book
+    cv_context_actions = ["update", "delete", "reviews"]   # list the key to render it
+    cv_context_buttons = [
+        ChildContextButton(key="reviews", child_name="review", label_template_code="Reviews"),
+    ]
+```
+
+- A button renders only when its `key` is in `cv_context_actions` (definition vs. rendering
+  stay separate).
+- A view-level button overrides a ViewSet-level button with the same `key`, for that view only.
+```
+
+- [ ] **Step 3: Note it in the api-reference catalog**
+
+In `skills/django-crud-views/references/api-reference.md`, in the context-button section
+(~line 308), append a line after the description of `context_buttons`:
+
+```markdown
+A single view can also define its own buttons via `cv_context_buttons` (a list of `ContextButton`s); view-level buttons override ViewSet-level ones with the same key. Buttons still render only when their key is listed in `cv_context_actions`.
+```
+
+- [ ] **Step 4: Add the CHANGELOG entries**
+
+In `CHANGELOG.md`, add a new section directly under the `# Django CRUD Views - Changelog`
+title (above `## 0.7.1`):
+
+```markdown
+## Unreleased
+
+### Added
+
+- View-level context buttons: set `cv_context_buttons` on a `CrudView` (a list of `ContextButton`s) to define buttons for a single view instead of the whole ViewSet. View-level buttons override ViewSet-level ones with the same `key`; they render only when the key is listed in `cv_context_actions`, matching existing button behavior.
+- `FilterContextButton` now honors `label_template` / `label_template_code`, so the filter toggle's label (default `Filter`) can be customized like any other context button.
+```
+
+- [ ] **Step 5: Verify the docs build (strict, same as CI)**
+
+Run: `uv run --with-requirements docs/requirements.txt mkdocs build --strict`
+Expected: "Documentation built" with no warnings; then `rm -rf site`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/reference/context_buttons.md skills/django-crud-views/SKILL.md skills/django-crud-views/references/api-reference.md CHANGELOG.md
+git commit -m "docs: document view-level context buttons and filter label (#27)"
+```
+
+---
+
+### Task 4: Full-suite verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the whole test suite**
+
+Run: `cd tests && pytest -q`
+Expected: all pass (previous baseline was 410 passed, 1 skipped; this adds 6 tests → ~416 passed, 1 skipped).
+
+- [ ] **Step 2: Lint check (matches CI)**
+
+Run: `uv run ruff format --check . && uv run ruff check .`
+Expected: no changes needed, no errors.
+
+- [ ] **Step 3: Confirm clean tree**
+
+Run: `git status --short`
+Expected: empty (all work committed across Tasks 1–3).
+
+---
+
+## Notes for the implementer
+
+- Do **not** edit either `context_actions.html` template — the explicit rendering model means
+  the existing `{% for key in view.cv_context_actions %}` loop is unchanged. If you find
+  yourself editing a template, re-read the spec's "Rendering pipeline impact" section.
+- Do **not** add a `cv_has_access` check to `FilterContextButton` — that was explicitly scoped
+  out (a filter toggle is not access-controlled).
+- The `cv_context_buttons` default MUST be `None`, not `[]` (audit M6: shared mutable class
+  attributes). Tests assert `view.cv_context_buttons is None` by default.

--- a/superpowers/specs/2026-06-24-audit-followup-roadmap-design.md
+++ b/superpowers/specs/2026-06-24-audit-followup-roadmap-design.md
@@ -1,0 +1,101 @@
+# Audit Follow-up Roadmap
+
+*Date: 2026-06-24 · Scope: roadmap only · Audited baseline: v0.7.1 (main)*
+
+## What this document is
+
+A **prioritization and release-sequencing roadmap** for the open follow-up issues left
+behind by the 2026-06-10 repository audit (`AUDIT.md`). It records *what order to tackle them
+in and why* — it is **not** an implementation spec.
+
+Each release named below gets its **own** brainstorm → spec → plan → implementation cycle when
+work on it begins. This document is the durable decision record those per-release specs link
+back to; it deliberately does not design any issue's API or enumerate its sub-tasks.
+
+## Background
+
+`AUDIT.md` (Phase 4) is marked **ALL MILESTONES COMPLETE** (2026-06-10). Milestones 0–3 were
+delivered across PRs #20–#36, and the leftover work was triaged into GitHub issues #27–#34.
+Since then #29, #30, #32 (and the related #52, #56) have shipped. What remains open from the
+audit lineage, plus the formsets follow-up split out of #29:
+
+- **#27** — Support view-level context buttons in `cv_get_context_button` (+ `FilterContextButton` polish)
+- **#28** — Expand Django system checks
+- **#31** — Workflow: configurable transaction behavior around transitions
+- **#33** — Harden `ViewSet.default_permissions` codename parsing
+- **#34** — Deprecate `CrispyModelViewMixin` alias
+- **#55** — Formsets: revisit `parent_form` handling / remove placeholder parent-required validation
+
+All six are S–M effort, low–medium risk. None are blockers; the library is healthy.
+
+## Decisions driving this roadmap
+
+1. **Ranking lens: user-facing value first.** Effort and risk are tie-breakers, not the
+   primary sort.
+2. **Output is a roadmap, not code.** No implementation this cycle.
+3. **Small, focused, themed releases** — matching the project's existing cadence
+   (0.6 → 0.7 → 0.7.1) and CHANGELOG-driven release flow.
+
+## Value-first ranking
+
+| Rank | Issue | User-facing value | Effort | Risk | Rationale |
+|------|-------|-------------------|--------|------|-----------|
+| 1 | **#27** view-level context buttons (+`FilterContextButton` polish) | High | M | Low-Med | Real ergonomics win — declare buttons per-view, not just per-ViewSet; completes the `lib/view/base.py:276` stub. Continues the context-button subsystem recently extended with `SiblingContextButton` and `cv_context_url`. |
+| 2 | **#28** expand Django system checks | High | M-L | Low | System checks are a documented selling point; catching misconfig at startup saves adopters debugging time. Caveat: a *basket* of ~7 sub-checks — needs scoping. |
+| 3 | **#55** formsets `parent_form` cleanup | Med | S | Low | Removes an always-on, untested validation and the `"Child TODO requires…"` placeholder a real formset user could hit. Direction already decided (Option 1 in the #55 issue). |
+| 4 | **#34** deprecate `CrispyModelViewMixin` alias | Med | S | Low | User-facing (public name in docs/examples/downstream) but "negative" value — warns rather than delights. API hygiene before eventual removal. |
+| 5 | **#31** workflow transaction config | Med (narrow) | S-M | Med | Genuine value but workflow-extension audience only, so narrower reach. The transaction-semantics + hook-placement change is the most behavior-sensitive of the six. |
+| 6 | **#33** harden `default_permissions` codename parsing | Low | S | Low-Med | Mostly invisible — only bites edge-case model names where the model string appears inside an action. Pure internal robustness. |
+
+## Release plan
+
+Four small, themed releases, in value-first order:
+
+| Release | Theme | Issues | Bump | Notes |
+|---------|-------|--------|------|-------|
+| **v0.8.0** | Context buttons | #27 | minor | Headline feature: view-level context buttons + `FilterContextButton` label/permission polish. Self-contained in the context-button subsystem. |
+| **v0.9.0** | Startup safety | #28 (scoped) | minor | Scope to high-value sub-checks: `cv_extends` template check, formsets/polymorphic config checks, reactivate E203 `ContextActionCheck`, workflow dependency checks. Leave low-value items (e.g. per-theme AppConfig wiring) as stretch. Split into 0.9/0.10 only if it grows. |
+| **v0.10.0** | Hardening & cleanup | #55 + #34 + #33 | minor | Bundle the three small, low-risk items: remove the `parent_form` placeholder validation (Option 1), add the `CrispyModelViewMixin` deprecation warning + docs, harden codename parsing. |
+| **v0.11.0** | Workflow transactions | #31 | minor | Isolated **on purpose**: the only Medium-risk item (transaction semantics + hook placement) and workflow-only audience — gets its own focused release + CHANGELOG note rather than riding in the cleanup batch. |
+
+### Packaging sub-decisions
+
+- **#31 is isolated** into its own release because of its risk profile, not its size.
+- **#28 ships as one scoped release**, not pre-split — with an explicit out to split if it balloons.
+- **#55/#34/#33 are batched** because each is S-effort and low-risk; one cleanup release is more efficient than three.
+
+### Alternative considered (rejected)
+
+Collapse to **two** releases: `v0.8.0 = #27 + cleanup bundle (#55/#34/#33)`,
+`v0.9.0 = #28 + #31`. Rejected: fewer cycles but larger changelogs, and it lets #31's risk
+ride alongside the system-checks work instead of being isolated.
+
+## Per-release dependencies and notes for the future specs
+
+- **#27** — when specced, decide the precedence between view-level and ViewSet-level buttons
+  (the stub at `base.py:276` currently only consults ViewSet-level), and whether
+  `FilterContextButton` gains label templating + a permission check.
+- **#28** — the per-release spec should enumerate exactly which checks ship and their stable
+  IDs; coordinate with the existing check ID scheme (E1xx/E2xx).
+- **#31** — behavior change: the per-release spec must define the config surface (setting vs.
+  per-view attribute) and call the transaction-behavior change out in the CHANGELOG; re-evaluate
+  whether transition logic moves from `cv_form_valid_hook` to `cv_form_valid`.
+- **#34** — deprecation must use a proper `DeprecationWarning` + docs note; do not remove the
+  alias in the same release.
+- **#55** — direction is pre-decided (Option 1: remove the rule, keep `parent_form` as a
+  documented extension point). The per-release spec just needs the doc + comment wording.
+- **#33** — consider relocating the property and whether to make the cached DB lookup lazy
+  (relates to audit task 3.6).
+
+## Non-goals
+
+- No implementation, no API design, no code in this cycle.
+- Version numbers above are the *intended* sequence; they are not commitments and may absorb
+  unrelated patch releases (e.g. a v0.7.x bugfix) in between.
+- Issues already closed (#29/#30/#32) and non-audit work are out of scope.
+
+## Definition of done (for this roadmap)
+
+This document is committed, the six open issues are accounted for with a target release and
+rank, and the sequence is approved by the maintainer. Execution proceeds release-by-release,
+each starting its own brainstorm/spec/plan cycle.

--- a/superpowers/specs/2026-06-24-view-level-context-buttons-design.md
+++ b/superpowers/specs/2026-06-24-view-level-context-buttons-design.md
@@ -1,0 +1,179 @@
+# View-level context buttons (+ FilterContextButton label) — design
+
+**Date:** 2026-06-24
+**Status:** approved (pending user review of this spec)
+**Issue:** #27 · **Target release:** v0.8.0 · **Roadmap:** `2026-06-24-audit-followup-roadmap-design.md`
+
+## Goal
+
+Let a `CrudView` declare its own context buttons, instead of only referencing buttons defined
+on the shared `ViewSet`. This completes the stubbed `cv_get_context_button` (which today only
+consults `ViewSet.context_buttons` and carries the comment
+`# view-level context buttons are not supported yet, see issue #27`) and lets a single view
+customize or add a button without polluting the whole ViewSet's button list.
+
+Bundled with it: a small `FilterContextButton` polish so its label can be templated like every
+other button.
+
+Two parts:
+
+- **Part A — view-level buttons.** New `cv_context_buttons` attribute on `CrudView`; view-level
+  definitions override ViewSet-level on key collision.
+- **Part B — FilterContextButton label.** Route its label through the shared `_apply_label`
+  path so `label_template` / `label_template_code` work.
+
+Out of scope (per scope decision): adding a permission check to `FilterContextButton` — a
+filter toggle is not access-controlled (the data behind it is gated by the list view), so a
+`cv_has_access` check is YAGNI.
+
+## Current state (for context)
+
+- `CrudView.cv_get_context_button(key)` (`src/crud_views/lib/view/base.py:310`) iterates only
+  `self.cv_viewset.context_buttons` and returns the first match or `None`.
+- `CrudView.cv_get_context(key, ...)` (`base.py:342`) calls `cv_get_context_button(key)`; if a
+  button is found it delegates to `button.get_context(context)`, otherwise it treats the key as
+  a sibling view.
+- `cv_context_actions: List[str] | None = None` (`base.py:43`) is the per-view list of keys
+  that **renders** in the header. Both theme templates
+  (`src/crud_views/templates/crud_views/tags/context_actions.html` and the
+  `crud_views_plain` copy) iterate `view.cv_context_actions` and emit `{% cv_context_action key %}`
+  per key. `cv_get_context_buttons(keys=None)` (`base.py:317`, the custom-loop helper) also
+  defaults its keys to `cv_context_actions`.
+- `ContextButton` and subclasses live in `src/crud_views/lib/view/buttons.py` and are exported
+  from `crud_views.lib.view`. The shared `_apply_label(data, context)` (`buttons.py:34`)
+  overrides the seeded default label when a button sets `label_template[_code]`; every button
+  subclass calls it in its `get_context` tail — except `FilterContextButton`.
+- `FilterContextButton.get_context` (`buttons.py:236`) hardcodes `data["cv_action_label"] = "Filter"`
+  and returns without calling `_apply_label`, so its label is not templatable. It uses its own
+  template (`tags/context_action_filter.html`) and performs no `cv_has_access` check.
+
+## Design decisions (resolved during brainstorm)
+
+1. **Rendering model: explicit (define-only).** `cv_context_buttons` only *defines* buttons;
+   nothing renders until the button's key appears in `cv_context_actions`. This keeps the
+   existing definition-vs-rendering separation and means **no template changes**. (The
+   alternative — auto-rendering view buttons by appending them to the effective key list — was
+   considered and rejected for conflating definition with rendering.)
+2. **Precedence: view overrides ViewSet.** `cv_get_context_button` checks the view's list
+   first, then falls back to the ViewSet's. A view-level button with the same key as a ViewSet
+   button replaces it for that one view.
+3. **FilterContextButton:** label templating only; no permission check.
+
+## Design
+
+### Part A — view-level buttons
+
+**New attribute on `CrudView`** (`lib/view/base.py`, near `cv_context_actions` at line 43):
+
+```python
+cv_context_buttons: List[ContextButton] | None = None  # view-level context button definitions
+```
+
+The `None` default (not `[]`) deliberately mirrors `cv_context_actions` and avoids a shared
+mutable class-attribute list — the trap the audit flagged in finding M6.
+
+**Resolution change** in `cv_get_context_button` (`base.py:310`):
+
+```python
+def cv_get_context_button(self, key: str) -> ContextButton | None:
+    # view-level buttons take precedence over ViewSet-level (issue #27)
+    for cb in self.cv_context_buttons or []:
+        if cb.key == key:
+            return cb
+    for cb in self.cv_viewset.context_buttons:
+        if cb.key == key:
+            return cb
+    return None
+```
+
+The `# not supported yet` comment is removed.
+
+**Usage:**
+
+```python
+class BookDetailView(DetailViewPermissionRequired):
+    cv_viewset = cv_book
+    cv_context_actions = ["update", "delete", "reviews"]   # "reviews" listed → it renders
+    cv_context_buttons = [                                  # defines "reviews" for this view only
+        ChildContextButton(key="reviews", child_name="review", label_template_code="Reviews"),
+    ]
+```
+
+Override example: declaring a `cv_context_buttons` entry whose `key` matches an existing
+ViewSet button (e.g. `"parent"`) replaces the ViewSet's definition for that view; the key is
+already in `cv_context_actions`, so rendering is unchanged.
+
+### Part B — FilterContextButton label
+
+In `FilterContextButton.get_context` (`buttons.py:236`), keep `"Filter"` as the seeded default,
+then call the shared label helper before returning:
+
+```python
+data["cv_action_label"] = "Filter"          # default when no label_template[_code] is set
+data["cv_icon_action"] = crud_views_settings.filter_icon
+data["cv_url"] = list_url
+self._apply_label(data, context)             # NEW — honor label_template / label_template_code
+self._inject_template(data)
+return data
+```
+
+No `cv_has_access` check is added.
+
+## Rendering pipeline impact
+
+Effectively none. Because rendering still flows through `cv_context_actions`, both theme
+templates are untouched and `cv_get_context_buttons` is untouched. The only behavioral change
+is the lookup inside `cv_get_context_button` (Part A) and the label line in
+`FilterContextButton` (Part B).
+
+## Errors / edges
+
+- A key in `cv_context_actions` that matches no button (view-level or ViewSet-level) resolves
+  as a sibling view key, exactly as today — no behavior change.
+- `cv_context_buttons = None` (the default) behaves identically to the current code.
+- No new Django system check (validation of `cv_context_buttons` keys / duplicate-key handling
+  belongs to the #28 "expand system checks" release, not here).
+
+## Exports
+
+No new exports. `cv_context_buttons` reuses the existing `ContextButton` family already
+exported from `crud_views.lib.view`.
+
+## Testing (tests/test1)
+
+- A view declaring a `cv_context_buttons` entry **renders** that button when its key is in
+  `cv_context_actions`, and does **not** render it when the key is absent (explicit-model
+  assertion).
+- A view-level button **overrides** a same-key ViewSet button — assert the view's definition
+  wins (e.g. a distinguishable label or target).
+- Fallback: a view with `cv_context_buttons = None`/unset still resolves ViewSet-level buttons
+  unchanged.
+- Access filtering still applies: a view-level button whose target denies access is hidden
+  (`cv_access` not `True`).
+- `FilterContextButton` with `label_template_code` renders the custom label; with no label set
+  it still renders `"Filter"`.
+- Exercise both bootstrap5 and plain themes where the rendered markup differs.
+
+Reuse existing `tests/test1` models/fixtures (`cv_author`/`cv_book` and the parent-child
+chains already present); no new model is required for Part A.
+
+## Documentation, skill & CHANGELOG
+
+- **`docs/reference/context_buttons.md`** — add a "View-level context buttons" section:
+  the `cv_context_buttons` attribute, the view-overrides-ViewSet rule, and the requirement to
+  list the key in `cv_context_actions` to render. Note `FilterContextButton`'s now-templatable
+  label where filter buttons are discussed.
+- **`skills/django-crud-views/SKILL.md`** — add a `cv_context_buttons` subsection in the
+  context-buttons area (after the `SiblingContextButton` section, ~line 311) showing a
+  view-level declaration and the override use-case.
+- **`skills/django-crud-views/references/api-reference.md`** — note `cv_context_buttons` in the
+  context-button catalog (~line 308).
+- **`CHANGELOG.md`** — `Added`: view-level context buttons via `cv_context_buttons`;
+  `FilterContextButton` label templating.
+
+## Backwards compatibility
+
+Purely additive. The new attribute defaults to `None` (current behavior); the resolution
+change only adds a higher-precedence lookup that is empty by default. The `FilterContextButton`
+change preserves the `"Filter"` default and only activates when a label template is set. No
+existing views, viewsets, or templates change behavior.

--- a/tests/test1/test_context_button_template.py
+++ b/tests/test1/test_context_button_template.py
@@ -1,5 +1,8 @@
 """ContextButton template / template_code fields and the settings default."""
 
+import pytest
+from django.urls import reverse
+
 from crud_views.lib.settings import crud_views_settings
 from crud_views.lib.view.buttons import ContextButton, FilterContextButton
 
@@ -38,3 +41,24 @@ def test_inject_template_code_wins():
 
 def test_filter_button_default_template():
     assert FilterContextButton().template == "crud_views/tags/context_action_filter.html"
+
+
+def _publisher_list_view(client, cv_publisher):
+    url = reverse(cv_publisher.get_router_name("list"))
+    resp = client.get(url)
+    assert resp.status_code == 200
+    return resp.context["view"]
+
+
+@pytest.mark.django_db
+def test_filter_button_default_label(client_user_publisher_view, cv_publisher):
+    view = _publisher_list_view(client_user_publisher_view, cv_publisher)
+    ctx = FilterContextButton().get_context(view.cv_get_view_context())
+    assert ctx["cv_action_label"] == "Filter"
+
+
+@pytest.mark.django_db
+def test_filter_button_templated_label(client_user_publisher_view, cv_publisher):
+    view = _publisher_list_view(client_user_publisher_view, cv_publisher)
+    ctx = FilterContextButton(label_template_code="Suchen").get_context(view.cv_get_view_context())
+    assert ctx["cv_action_label"] == "Suchen"

--- a/tests/test1/test_view_level_context_button.py
+++ b/tests/test1/test_view_level_context_button.py
@@ -1,0 +1,58 @@
+"""View-level context buttons: CrudView.cv_context_buttons defines buttons; view overrides ViewSet."""
+
+import pytest
+from django.urls import reverse
+
+from crud_views.lib.view.buttons import ContextButton
+
+
+def _book_list_view(client, publisher):
+    from tests.test1.app.views import cv_book
+
+    url = reverse(cv_book.get_router_name("list"), kwargs={"publisher_pk": publisher.pk})
+    resp = client.get(url)
+    assert resp.status_code == 200
+    return resp.context["view"]
+
+
+@pytest.mark.django_db
+def test_view_level_overrides_viewset(client_user_book_view, cv_book, publisher_penguin, book_hitchhiker):
+    view = _book_list_view(client_user_book_view, publisher_penguin)
+    # ViewSet provides a default "home" button
+    assert view.cv_get_context_button("home").key == "home"
+    override = ContextButton(key="home", key_target="list", label_template_code="VIEWLEVEL")
+    view.cv_context_buttons = [override]
+    # view-level button with the same key wins (identity check)
+    assert view.cv_get_context_button("home") is override
+
+
+@pytest.mark.django_db
+def test_falls_back_to_viewset(client_user_book_view, cv_book, publisher_penguin, book_hitchhiker):
+    view = _book_list_view(client_user_book_view, publisher_penguin)
+    view.cv_context_buttons = [ContextButton(key="custom", key_target="list")]
+    # a key not defined at view level falls back to the ViewSet's buttons
+    assert view.cv_get_context_button("home").key == "home"
+
+
+@pytest.mark.django_db
+def test_none_default_unchanged(client_user_book_view, cv_book, publisher_penguin, book_hitchhiker):
+    view = _book_list_view(client_user_book_view, publisher_penguin)
+    assert view.cv_context_buttons is None
+    assert view.cv_get_context_button("home").key == "home"
+    assert view.cv_get_context_button("does_not_exist") is None
+
+
+@pytest.mark.django_db
+def test_explicit_render_only_listed_keys(client_user_book_view, cv_book, publisher_penguin, book_hitchhiker):
+    view = _book_list_view(client_user_book_view, publisher_penguin)
+    view.cv_context_buttons = [ContextButton(key="custom", key_target="list", label_template_code="UNLISTED")]
+
+    # "custom" defined but NOT in cv_context_actions -> not rendered
+    view.cv_context_actions = ["home"]
+    labels = [c.get("cv_action_label") for c in view.cv_get_context_buttons()]
+    assert "UNLISTED" not in labels
+
+    # listing the key in cv_context_actions renders it
+    view.cv_context_actions = ["home", "custom"]
+    labels = [c.get("cv_action_label") for c in view.cv_get_context_buttons()]
+    assert "UNLISTED" in labels


### PR DESCRIPTION
Implements issue #27 (roadmap v0.8.0).

## What changed

**Part A — view-level context buttons.** New `cv_context_buttons: List[ContextButton] | None = None` attribute on `CrudView`. `cv_get_context_button` now resolves view-level buttons first, falling back to the ViewSet's — so a view-level button **overrides** a ViewSet-level one with the same `key`. Rendering is unchanged: a button still renders only when its key is listed in `cv_context_actions` (definition vs. rendering stay separate), so no templates were touched. Default is `None` (not `[]`) to avoid the shared-mutable-class-list trap (audit M6).

**Part B — FilterContextButton label.** `FilterContextButton.get_context` now calls the shared `_apply_label` helper, so its label honors `label_template` / `label_template_code` like every other button (default stays `"Filter"`). No permission check added (a filter toggle isn't access-gated — deliberately out of scope).

**Docs:** new "View-level Context Buttons" section in the reference, a `cv_context_buttons` subsection in the in-repo skill + api-reference, and a `## Unreleased` CHANGELOG section.

## Test plan

- 6 new tests (4 view-level resolution: override / fallback / None-default / explicit-render; 2 filter-label: default + templated).
- Full suite: **416 passed, 1 skipped**.
- `ruff format --check` + `ruff check` clean; `mkdocs build --strict` clean.

Purely additive / backwards compatible. Reviewed via subagent-driven development (per-task + final whole-branch review, approved).

Closes #27.

Spec: `superpowers/specs/2026-06-24-view-level-context-buttons-design.md`