### PR TITLE
docs(example): demo view-level context button on BarDetailView (#27)

### DIFF
--- a/examples/bootstrap5/app/tests.py
+++ b/examples/bootstrap5/app/tests.py
@@ -1,1 +1,37 @@
-# Create your tests here.
+"""Smoke test for the view-level context button on BarDetailView (issue #27 example)."""
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+
+from app.models import Foo, Bar, Baz
+from app.views.bar import cv_bar
+from app.views.baz import cv_baz
+
+
+class ViewLevelContextButtonTest(TestCase):
+    def setUp(self):
+        self.foo = Foo.objects.create(name="Foo1")
+        self.bar = Bar.objects.create(foo=self.foo, name="Bar1")
+        self.baz = Baz.objects.create(bar=self.bar, name="Baz1")
+        user = User.objects.create_superuser(username="admin", password="pw")
+        self.client.force_login(user)
+
+    def test_bazzes_button_on_bar_detail(self):
+        url = reverse(cv_bar.get_router_name("detail"), kwargs={"foo_pk": self.foo.pk, "pk": self.bar.pk})
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        # the view-level "Bazzes" button appears on the detail page...
+        self.assertContains(resp, "Bazzes")
+        # ...and links to this bar's baz collection
+        baz_url = reverse(cv_baz.get_router_name("list"), kwargs={"foo_pk": self.foo.pk, "bar_pk": self.bar.pk})
+        self.assertContains(resp, baz_url)
+
+    def test_bazzes_absent_on_bar_list(self):
+        url = reverse(cv_bar.get_router_name("list"), kwargs={"foo_pk": self.foo.pk})
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        # the view-level button does NOT leak onto the list view...
+        self.assertNotContains(resp, "Bazzes")
+        # ...which still shows the ViewSet-level sibling button
+        self.assertContains(resp, "Quxes")

--- a/examples/bootstrap5/app/views/bar.py
+++ b/examples/bootstrap5/app/views/bar.py
@@ -14,7 +14,7 @@ from crud_views.lib.views import (
     ListViewPermissionRequired,
     CreateViewParentMixin,
 )
-from crud_views.lib.view import SiblingContextButton
+from crud_views.lib.view import SiblingContextButton, ChildContextButton
 from crud_views.lib.viewset import ViewSet, ParentViewSet, context_buttons_default
 
 cv_bar = ViewSet(
@@ -57,6 +57,13 @@ class BarListView(ListViewTableMixin, ListViewPermissionRequired):
 class BarDetailView(DetailViewPermissionRequired):
     model = Bar
     cv_viewset = cv_bar
+    # View-level button: declared on this view only, so it renders on the Bar
+    # detail page but not on bar's list/update/etc. Contrast with the ViewSet-level
+    # "Quxes" sibling button (cv_bar.context_buttons), which the list view shows.
+    cv_context_buttons = [
+        ChildContextButton(key="bazzes", child_name="baz", label_template_code="Bazzes"),
+    ]
+    cv_context_actions = ["home", "detail", "update", "delete", "bazzes"]
     cv_property_display = [
         {
             "title": _("Properties"),

--- a/superpowers/plans/2026-06-24-example-view-level-context-button.md
+++ b/superpowers/plans/2026-06-24-example-view-level-context-button.md
@@ -1,0 +1,167 @@
+# Bootstrap5 Example: View-level Context Button Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a view-only context button ("Bazzes") to `BarDetailView` in the bootstrap5 example so the example demonstrates the `cv_context_buttons` feature (#27), with a smoke test proving it renders on the detail page and not on the list page.
+
+**Architecture:** Single example file change (`examples/bootstrap5/app/views/bar.py`): declare `cv_context_buttons` on `BarDetailView` with a `ChildContextButton` to the bar's `baz` collection, and list its key in that view's `cv_context_actions`. A Django `TestCase` in the example app renders the Bar detail and list pages and asserts the button's presence/absence.
+
+**Tech Stack:** Django, crud_views (`ChildContextButton`), Django test client. The example runs on the repo's root venv (no local `.venv`).
+
+**Spec:** `superpowers/specs/2026-06-24-example-view-level-context-button-design.md` (issue #27, example demo).
+
+## Global Constraints
+
+- Example-only change. NO library/source edits under `src/`, NO new model, NO migration.
+- The button is `ChildContextButton(key="bazzes", child_name="baz", label_template_code="Bazzes")`, declared in `BarDetailView.cv_context_buttons`.
+- `BarDetailView.cv_context_actions = ["home", "detail", "update", "delete", "bazzes"]` (the inherited default detail actions `["home", "detail", "update", "delete"]` plus `"bazzes"`).
+- The button must render ONLY on the Bar detail page, never on the Bar list page (which keeps its ViewSet-level `"Quxes"` button).
+- Line length 120, double quotes, ruff-formatted.
+- The example test runs from `examples/bootstrap5/` via `uv run python manage.py test app`. It is NOT part of the nox CI matrix (which only runs `tests/test1`); it is a runnable, repeatable artifact for local verification.
+- Additive / backwards compatible: no change to other example views or existing Bar pages beyond the added detail-view button.
+
+---
+
+### Task 1: View-only "Bazzes" button on BarDetailView + smoke test
+
+**Files:**
+- Modify: `examples/bootstrap5/app/views/bar.py` (import line 17; `BarDetailView` at lines 57-70)
+- Test: `examples/bootstrap5/app/tests.py` (replace the empty placeholder)
+
+**Interfaces:**
+- Consumes: `ChildContextButton` from `crud_views.lib.view`; `cv_bar` (`app.views.bar`), `cv_baz` (`app.views.baz`); models `Foo`, `Bar`, `Baz` (`app.models`); ViewSet router names via `cv_bar.get_router_name("list"|"detail")` and `cv_baz.get_router_name("list")`. URL kwargs: bar list `{"foo_pk": foo.pk}`, bar detail `{"foo_pk": foo.pk, "pk": bar.pk}`, baz list `{"foo_pk": foo.pk, "bar_pk": bar.pk}`.
+- Produces: a rendered `"Bazzes"` button on the Bar detail page linking to that bar's baz list.
+
+- [ ] **Step 1: Write the failing test**
+
+Replace the contents of `examples/bootstrap5/app/tests.py` with:
+
+```python
+"""Smoke test for the view-level context button on BarDetailView (issue #27 example)."""
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+
+from app.models import Foo, Bar, Baz
+from app.views.bar import cv_bar
+from app.views.baz import cv_baz
+
+
+class ViewLevelContextButtonTest(TestCase):
+    def setUp(self):
+        self.foo = Foo.objects.create(name="Foo1")
+        self.bar = Bar.objects.create(foo=self.foo, name="Bar1")
+        self.baz = Baz.objects.create(bar=self.bar, name="Baz1")
+        user = User.objects.create_superuser(username="admin", password="pw")
+        self.client.force_login(user)
+
+    def test_bazzes_button_on_bar_detail(self):
+        url = reverse(cv_bar.get_router_name("detail"), kwargs={"foo_pk": self.foo.pk, "pk": self.bar.pk})
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        # the view-level "Bazzes" button appears on the detail page...
+        self.assertContains(resp, "Bazzes")
+        # ...and links to this bar's baz collection
+        baz_url = reverse(cv_baz.get_router_name("list"), kwargs={"foo_pk": self.foo.pk, "bar_pk": self.bar.pk})
+        self.assertContains(resp, baz_url)
+
+    def test_bazzes_absent_on_bar_list(self):
+        url = reverse(cv_bar.get_router_name("list"), kwargs={"foo_pk": self.foo.pk})
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        # the view-level button does NOT leak onto the list view...
+        self.assertNotContains(resp, "Bazzes")
+        # ...which still shows the ViewSet-level sibling button
+        self.assertContains(resp, "Quxes")
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd examples/bootstrap5 && uv run python manage.py test app -v 2`
+Expected: `test_bazzes_button_on_bar_detail` FAILS on `self.assertContains(resp, "Bazzes")` — the button does not exist yet (the detail page renders 200 but contains no "Bazzes"). `test_bazzes_absent_on_bar_list` already passes (the button was never on the list).
+
+- [ ] **Step 3: Add the import**
+
+In `examples/bootstrap5/app/views/bar.py`, extend the existing button import (line 17):
+
+```python
+from crud_views.lib.view import SiblingContextButton, ChildContextButton
+```
+
+- [ ] **Step 4: Declare the view-level button on BarDetailView**
+
+In `examples/bootstrap5/app/views/bar.py`, update `BarDetailView` (lines 57-70) to add `cv_context_buttons` and `cv_context_actions` (leave `cv_property_display` as-is):
+
+```python
+class BarDetailView(DetailViewPermissionRequired):
+    model = Bar
+    cv_viewset = cv_bar
+    # View-level button: declared on this view only, so it renders on the Bar
+    # detail page but not on bar's list/update/etc. Contrast with the ViewSet-level
+    # "Quxes" sibling button (cv_bar.context_buttons), which the list view shows.
+    cv_context_buttons = [
+        ChildContextButton(key="bazzes", child_name="baz", label_template_code="Bazzes"),
+    ]
+    cv_context_actions = ["home", "detail", "update", "delete", "bazzes"]
+    cv_property_display = [
+        {
+            "title": _("Properties"),
+            "icon": "bone",
+            "description": _("Bar attributes"),
+            "properties": [
+                "id",
+                "name",
+            ],
+        },
+    ]
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd examples/bootstrap5 && uv run python manage.py test app -v 2`
+Expected: PASS (2 tests OK).
+
+- [ ] **Step 6: Format**
+
+Run: `uv run ruff format examples/bootstrap5/app/views/bar.py examples/bootstrap5/app/tests.py`
+Then: `uv run ruff check examples/bootstrap5/app/views/bar.py examples/bootstrap5/app/tests.py`
+Expected: formatted / "All checks passed!"
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add examples/bootstrap5/app/views/bar.py examples/bootstrap5/app/tests.py
+git commit -m "docs(example): demo view-level context button on BarDetailView (#27)"
+```
+
+---
+
+### Task 2: Verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Re-run the example test**
+
+Run: `cd examples/bootstrap5 && uv run python manage.py test app -v 2`
+Expected: 2 tests pass — confirms the Bar detail page renders 200 with the "Bazzes" button linking to the baz list, and the list page renders without it.
+
+- [ ] **Step 2: Confirm the library suite is unaffected**
+
+The change is example-only, but confirm nothing in the package regressed:
+Run: `cd tests && uv run pytest -q`
+Expected: 416 passed, 1 skipped (unchanged from before — the example is not part of this suite, so this is a sanity check that no shared file was touched).
+
+- [ ] **Step 3: Confirm clean tree**
+
+Run: `git status --short`
+Expected: empty (Task 1 committed everything).
+
+---
+
+## Notes for the implementer
+
+- Do NOT touch anything under `src/` — the `cv_context_buttons` feature already shipped; this is purely an example demonstrating it.
+- The `"bazzes"` key is registered by being declared in `cv_context_buttons`, so listing it in `cv_context_actions` is safe (no unregistered-key 500 like issue #56). Every other key in the list (`home`/`detail`/`update`/`delete`) is a standard registered view.
+- `ChildContextButton` needs the current object to build the child URL — that is why it belongs on the detail view (an object view) and is the natural reason to scope it per-view.
+- If `uv run` from `examples/bootstrap5/` fails to find the environment, run from the repo root with the venv active: `python examples/bootstrap5/manage.py test app` (cwd must let `app` and `project` import — prefer running from inside `examples/bootstrap5/`).

--- a/superpowers/specs/2026-06-24-example-view-level-context-button-design.md
+++ b/superpowers/specs/2026-06-24-example-view-level-context-button-design.md
@@ -1,0 +1,95 @@
+# Bootstrap5 example: view-level context button — design
+
+**Date:** 2026-06-24
+**Status:** approved (pending user review of this spec)
+**Relates to:** issue #27 (view-level context buttons, shipped on `main`); example demo only.
+
+## Goal
+
+Demonstrate the view-level context button feature (`cv_context_buttons`, from #27) in the
+`examples/bootstrap5` project. Add a button that appears on a **single view** of a ViewSet —
+contrasting with the example's existing **ViewSet-level** custom buttons.
+
+## Why here (current state)
+
+The `foo → bar/qux → baz` chain in the example is the dedicated context-button demo area, and
+it already shows ViewSet-level custom buttons:
+
+- `cv_bar` (`examples/bootstrap5/app/views/bar.py:20-29`) defines
+  `context_buttons=context_buttons_default() + [SiblingContextButton(key="quxes", sibling_name="qux", ...)]`.
+  `BarListView.cv_context_actions` (`bar.py:54`) lists `"quxes"`, so the **"Quxes"** button shows
+  on the bar **list** page — and, being ViewSet-level, is available to every bar view that lists it.
+- `cv_qux` mirrors this with a `"bars"` sibling button.
+
+All existing example buttons are ViewSet-level. There is no example of a button scoped to one
+view. `Bar` has a child `Baz` (`cv_baz` parent is `bar`, `baz.py:19`), and `BazListView` exists
+(key `"list"`), so a bar→baz child link is available.
+
+`BarDetailView` (`bar.py:57-70`) currently sets no `cv_context_actions`, so it inherits the
+default `["home", "detail", "update", "delete"]`.
+
+## Design
+
+Single-file change: `examples/bootstrap5/app/views/bar.py`.
+
+1. Extend the existing button import:
+   ```python
+   from crud_views.lib.view import SiblingContextButton, ChildContextButton
+   ```
+
+2. On `BarDetailView`, add a view-level button and list its key so it renders:
+   ```python
+   class BarDetailView(DetailViewPermissionRequired):
+       model = Bar
+       cv_viewset = cv_bar
+       # View-level button: appears ONLY on this detail view, not on bar's list/update/etc.
+       cv_context_buttons = [
+           ChildContextButton(key="bazzes", child_name="baz", label_template_code="Bazzes"),
+       ]
+       cv_context_actions = ["home", "detail", "update", "delete", "bazzes"]
+       cv_property_display = [ ... ]  # unchanged
+   ```
+
+`cv_context_actions` mirrors the inherited default detail actions
+(`["home", "detail", "update", "delete"]`) with `"bazzes"` appended, so the Bar detail page
+keeps its existing buttons and gains the new one.
+
+### Behavior demonstrated
+
+- **"Bazzes"** renders only on a Bar's **detail** page, linking to that bar's child `baz`
+  collection (`/foo/<foo_pk>/bar/<bar_pk>/baz/`). The current bar object becomes the parent PK
+  in the child URL — which is why `ChildContextButton` belongs on an object view.
+- It does **not** appear on the Bar **list** page, which shows the ViewSet-level **"Quxes"**
+  button instead. Same ViewSet, two buttons at different scopes — the teaching contrast.
+
+### Why `ChildContextButton`
+
+It requires the current object to build the child URL, so it is only meaningful on an object
+view (detail) — naturally reinforcing why a button would be scoped to one view. The label is
+set via `label_template_code="Bazzes"`. `child_key` defaults to `"list"` (the registered baz
+list view).
+
+## Out of scope (non-goals)
+
+- No library/source changes — the `cv_context_buttons` feature already shipped in #27.
+- No new model or migration — `bar → baz` already exists.
+- No docs or CHANGELOG changes — `docs/reference/context_buttons.md` already documents
+  view-level buttons; this is an example-only addition.
+- No override demo — this example shows the view-only (additive) case, per the brainstorm
+  decision. The override aspect of #27 is intentionally not demonstrated here.
+
+## Testing / verification
+
+- Run the example and navigate foo → bar → a bar's detail page; confirm the **"Bazzes"**
+  button appears and links to that bar's `/.../baz/` list.
+- Confirm the button is **absent** on the bar list page (which still shows **"Quxes"**).
+- The example's existing smoke coverage (`examples/bootstrap5/app/tests.py` and/or the
+  `bs5_test` management command) must still render every page without error — guarding against
+  a repeat of the #56 unregistered-context-key 500. If the smoke test does not already hit the
+  Bar detail page, the implementation should ensure it does (or add a minimal assertion that
+  the Bar detail page renders 200 with the "Bazzes" button present).
+
+## Backwards compatibility
+
+Additive and example-only. No change to the library, other example views, or existing Bar
+pages beyond the added button on the detail view.


### PR DESCRIPTION
Adds an example of the view-level context button feature (#27) to the bootstrap5 example project.

## What changed

`BarDetailView` (`examples/bootstrap5/app/views/bar.py`) now declares a **view-level** `ChildContextButton` ("Bazzes") via `cv_context_buttons`, listed in that view's `cv_context_actions`. The button:
- renders **only** on the Bar **detail** page, linking to that bar's child `baz` collection;
- does **not** appear on the Bar **list** page, which keeps its existing **ViewSet-level** `SiblingContextButton` ("Quxes").

That side-by-side contrast — same ViewSet, one button view-scoped, one ViewSet-scoped — is the teaching point.

## Test

New Django `TestCase` in `examples/bootstrap5/app/tests.py` (the file was an empty placeholder): renders the Bar detail page (200, contains "Bazzes" + the baz-list href) and the Bar list page (200, no "Bazzes", still has "Quxes"). Run with `cd examples/bootstrap5 && uv run python manage.py test app.tests`.

Example-only change — nothing under `src/`, no model, no migration. Library suite unaffected (416 passed, 1 skipped).

Note: `manage.py test app` (full discovery) hits a **pre-existing**, unrelated `ViewSetError: poly_formset already registered` in the polymorphic formset example — not touched by this change; the scoped `app.tests` run is clean.

Built via subagent-driven development (task review approved).