### PR TITLE
fix(example): make 'manage.py test app' work (poly_formset double registration)

### DIFF
--- a/examples/bootstrap5/project/settings.py
+++ b/examples/bootstrap5/project/settings.py
@@ -17,6 +17,11 @@ from django.utils.translation import gettext_lazy as _
 # Build paths inside the project like this: BASE_DIR / "subdir".
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+# Pin test discovery's top-level dir to BASE_DIR so `manage.py test app` imports
+# app sub-packages under their canonical names (avoids a duplicate ViewSet
+# registration from unittest double-importing package __init__ modules).
+TEST_RUNNER = "project.test_runner.BaseDirDiscoverRunner"
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 

--- a/examples/bootstrap5/project/test_runner.py
+++ b/examples/bootstrap5/project/test_runner.py
@@ -1,0 +1,27 @@
+from django.conf import settings
+from django.test.runner import DiscoverRunner
+
+
+class BaseDirDiscoverRunner(DiscoverRunner):
+    """Pin test discovery's top-level directory to ``BASE_DIR``.
+
+    ``manage.py test app`` otherwise discovers with the top-level directory set to
+    the ``app/`` package itself, so unittest imports the app's sub-packages under
+    non-canonical names (e.g. ``views.formset`` instead of ``app.views.formset``).
+
+    Several view packages register a ViewSet at import time in their
+    ``__init__.py`` (``app/views/formset``, ``app/views/poly``). The non-canonical
+    import executes that ``__init__`` once, then the canonical import from
+    ``app.urls`` executes it again under a different module name — registering the
+    same ViewSet twice and tripping the duplicate-name guard
+    (``ViewSetError: ViewSet name poly_formset is already registered``).
+
+    Pinning the top-level directory to ``BASE_DIR`` makes both imports resolve to
+    the same canonical module name, so each package ``__init__`` runs once.
+    An explicit ``-t/--top-level-directory`` on the command line still wins.
+    """
+
+    def __init__(self, *args, top_level=None, **kwargs):
+        if top_level is None:
+            top_level = str(settings.BASE_DIR)
+        super().__init__(*args, top_level=top_level, **kwargs)


### PR DESCRIPTION
## Problem

`cd examples/bootstrap5 && python manage.py test app` crashes:

```
crud_views.lib.exceptions.ViewSetError: ViewSet name poly_formset is already registered by ViewSet(poly_formset)
```

(`manage.py check`, `runserver`, and `manage.py test app.tests` are all fine.)

## Root cause

`manage.py test app` runs unittest discovery with `start_dir="app"`, so `top_level_dir` becomes the `app/` directory. unittest imports the app's **package `__init__` modules** while walking the tree, under **non-canonical** names (e.g. `views.formset` instead of `app.views.formset`).

Two view packages register a ViewSet at import time in their `__init__.py` — `app/views/formset` (`poly_formset`) and `app/views/poly` (`poly`). So the module body runs **twice**: once as `views.formset` (discovery) and once as `app.views.formset` (`app.urls` during `run_checks`). The second registration trips the duplicate-name guard. (The phantom "Found 4 tests" was the same double-import counting the 2 real tests twice.)

Confirmed by instrumenting the registry: two stacks, one via `test_loader.discover`, one via `run_checks → app.urls`.

## Fix

A custom `TEST_RUNNER` (`project.test_runner.BaseDirDiscoverRunner`) that pins discovery's top-level directory to `BASE_DIR`, so both imports resolve to the canonical `app.views.*` name and each package `__init__` executes once. No change to the example's package layout; an explicit `-t/--top-level-directory` still wins.

## Verification

- `manage.py test app` → **Ran 2 tests, OK** (was crashing; now also reports the correct count of 2).
- `manage.py test app.tests` → still OK.
- `manage.py check` → still clean.
- Library suite (`tests/`) unaffected: 416 passed, 1 skipped.

Found while shipping the #27 example (PR #60), which flagged this pre-existing crash.