### PR TITLE
fix: lazy workflow imports, warn on CRUD_VIEWS_THEME, document cv_csrf_token removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 ### Fixed
 
 - The list table template `crud_views/table/bootstrap5.html` now works with **both django-tables2 2.x and 3.x**. It uses a new `{% cv_querystring %}` template tag that delegates to django-tables2's `{% querystring_replace %}` (≥ 3.0) or `{% querystring %}` (< 3.0), so list pages no longer raise a `TemplateSyntaxError` depending on the installed version. Custom table templates can use `{% cv_querystring %}` (after `{% load crud_views %}`) to stay version-agnostic too.
+- `WorkflowModelMixin` can now be imported before Django's app registry is ready. `crud_views_workflow/lib/mixins.py` no longer imports `ContentType` and `WorkflowInfo` at module level (they are imported lazily inside `get_workflow_info_queryset`), eliminating an `AppRegistryNotReady` error when a consumer model module imports the mixin while apps are still loading.
+
+### Added
+
+- System-check warning `crud_views.W110`: setting `CRUD_VIEWS_THEME` has no effect (theming is done by overriding templates, not via a setting) and was previously ignored silently. Consumers who set it now get a clear warning with a hint instead of no feedback.
+
+### Docs
+
+- Documented that `{% cv_csrf_token %}` was removed in 0.4.0 (replaced by `{% cv_config %}` / `{% cv_const_js %}`), so consumers upgrading from < 0.4.0 know how to resolve the `TemplateSyntaxError`.
 
 ## 0.9.0
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -75,6 +75,13 @@ The `{% cv_config %}` template tag renders server-side request data as `data-*` 
 
 The `{% cv_const_js %}` tag still works as a backwards-compatible alias but renders the same CSP-safe output as `{% cv_config %}`.
 
+!!! warning "Upgrading from < 0.4.0: `{% cv_csrf_token %}` was removed"
+
+    The `{% cv_csrf_token %}` template tag was removed in the 0.4.0 CSP refactor. If you upgrade from
+    an earlier version you will get `TemplateSyntaxError: Invalid block tag 'cv_csrf_token'`. Remove the
+    tag from your templates — CSRF/config data is now provided by `{% cv_config %}` (or its alias
+    `{% cv_const_js %}`) in your base template, as shown above.
+
 ### JavaScript architecture
 
 All interactive behavior (list action form submissions, cancel button navigation, filter toggling) is handled via event delegation in the external `viewset.js` static file. Dynamic data is passed from Django to JavaScript through `data-*` attributes:

--- a/src/crud_views/lib/settings.py
+++ b/src/crud_views/lib/settings.py
@@ -3,7 +3,7 @@ from typing import Any, ClassVar, List, Tuple
 
 from box import Box
 from django.conf import settings
-from django.core.checks import CheckMessage, Error
+from django.core.checks import CheckMessage, Error, Warning as CheckWarning
 from django.template import TemplateDoesNotExist
 from django.template.loader import get_template
 from pydantic import BaseModel
@@ -25,6 +25,8 @@ class CrudViewsSettings(BaseModel):
     manage_show_users: bool = from_settings("CRUD_VIEWS_MANAGE_SHOW_USERS", default=False)
     manage_view_class: str | None = from_settings("CRUD_VIEWS_MANAGE_VIEW_CLASS", default=None)
     guardian_manage_view_class: str | None = from_settings("CRUD_VIEWS_GUARDIAN_MANAGE_VIEW_CLASS", default=None)
+    # not a supported setting; only read to warn consumers who set it (see check_messages)
+    theme: str | None = from_settings("CRUD_VIEWS_THEME", default=None)
 
     # session
     session_data_key: str = from_settings("CRUD_VIEWS_SESSION_DATA_KEY", "viewset")
@@ -68,6 +70,19 @@ class CrudViewsSettings(BaseModel):
                 get_template(self.extends)
             except TemplateDoesNotExist:
                 messages.append(Error(id="crud_views.E100", msg=f"template {self.extends} not found"))
+
+        if self.theme is not None:
+            messages.append(
+                CheckWarning(
+                    id="crud_views.W110",
+                    msg="setting CRUD_VIEWS_THEME has no effect and is ignored",
+                    hint=(
+                        "Theming is done by overriding templates, not via a setting. Ship templates "
+                        "under the crud_views/ namespace and list your app (e.g. crud_views_plain) "
+                        "before crud_views in INSTALLED_APPS. Remove CRUD_VIEWS_THEME."
+                    ),
+                )
+            )
 
         if self.manage_views_enabled not in self.MANAGE_VIEWS_ENABLED_VALUES:
             messages.append(

--- a/src/crud_views_workflow/lib/mixins.py
+++ b/src/crud_views_workflow/lib/mixins.py
@@ -1,12 +1,10 @@
 from functools import cached_property
 from typing import Dict, Any, List
 
-from django.contrib.contenttypes.models import ContentType
 from django.db.models import Choices
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 
-from ..models import WorkflowInfo
 from .enums import BadgeEnum, WorkflowComment
 
 TState = str
@@ -52,6 +50,12 @@ class WorkflowModelMixin:
         return dict(comment=comment) if comment else dict()
 
     def get_workflow_info_queryset(self):
+        # Imported lazily so WorkflowModelMixin can be imported before the app registry is ready
+        # (a consumer model module importing this mixin loads while Django is still populating apps).
+        from django.contrib.contenttypes.models import ContentType
+
+        from ..models import WorkflowInfo
+
         return WorkflowInfo.objects.filter(
             workflow_object_pk=str(self.pk),
             workflow_object_content_type=ContentType.objects.get_for_model(self),

--- a/tests/test1/test_import_safety.py
+++ b/tests/test1/test_import_safety.py
@@ -32,6 +32,29 @@ def test_templatetags_import_without_app_registry():
     assert "IMPORT-OK" in result.stdout
 
 
+def test_workflow_mixins_import_without_app_registry():
+    """Regression: WorkflowModelMixin must be importable before the app registry is ready.
+
+    A consumer model module that imports WorkflowModelMixin is loaded while Django is still
+    populating apps; importing crud_views_workflow's own models at that point raised
+    AppRegistryNotReady.
+    """
+    code = textwrap.dedent(
+        """
+        from django.conf import settings
+
+        settings.configure()  # no django.setup() -- the app registry is not ready
+
+        import crud_views_workflow.lib.mixins
+
+        print("IMPORT-OK")
+        """
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert "IMPORT-OK" in result.stdout
+
+
 def test_workflow_models_load_with_late_custom_user_app(tmp_path):
     """
     Contract: a custom AUTH_USER_MODEL whose app is listed *after*

--- a/tests/test1/test_settings_checks.py
+++ b/tests/test1/test_settings_checks.py
@@ -40,3 +40,10 @@ def test_valid_settings_produce_no_messages():
     # the test project configures a valid CRUD_VIEWS_EXTENDS template
     settings_obj = CrudViewsSettings()
     assert settings_obj.check_messages == []
+
+
+def test_theme_setting_warns_it_is_ignored():
+    # CRUD_VIEWS_THEME is not a supported setting; theming is done via template-override apps
+    settings_obj = CrudViewsSettings(theme="bootstrap5")
+    messages = settings_obj.check_messages
+    assert any("CRUD_VIEWS_THEME" in m.msg for m in messages)


### PR DESCRIPTION
Batches three findings from the consumer-upgrade audit (the remaining issues after the django-tables2 fix in #64).

## #4 — `AppRegistryNotReady` from `WorkflowModelMixin` (robustness)

`crud_views_workflow/lib/mixins.py` imported `ContentType` and `WorkflowInfo` at module level. A consumer model module importing `WorkflowModelMixin` loads while Django is still populating apps, so those model imports raised `AppRegistryNotReady`. Both are now imported lazily inside `get_workflow_info_queryset`.

## #6 — `CRUD_VIEWS_THEME` silently ignored (minor)

The setting was never read — theming is done by overriding templates (ship templates under `crud_views/` and list your app, e.g. `crud_views_plain`, before `crud_views` in `INSTALLED_APPS`). Consumers who set `CRUD_VIEWS_THEME` got no effect and no feedback. A new system-check **warning `crud_views.W110`** now fires when it is set, with a hint to the real mechanism.

## #3 — `{% cv_csrf_token %}` removal undocumented (docs)

The tag was removed in the 0.4.0 CSP refactor; upgraders from < 0.4.0 hit `TemplateSyntaxError: Invalid block tag 'cv_csrf_token'` with no guidance. Documented in the CSP section of `settings.md` (replaced by `{% cv_config %}` / `{% cv_const_js %}`).

## Tests
- `test_workflow_mixins_import_without_app_registry` — imports the mixin under `settings.configure()` with no `django.setup()`; was RED with `AppRegistryNotReady`, now green.
- `test_theme_setting_warns_it_is_ignored` — asserts the W110 warning fires.
- Full suite: 423 passed, 1 skipped; ruff clean.