### PR TITLE
fix(workflow): name WorkflowInfo index to stop makemigrations drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - The list table template `crud_views/table/bootstrap5.html` now works with **both django-tables2 2.x and 3.x**. It uses a new `{% cv_querystring %}` template tag that delegates to django-tables2's `{% querystring_replace %}` (≥ 3.0) or `{% querystring %}` (< 3.0), so list pages no longer raise a `TemplateSyntaxError` depending on the installed version. Custom table templates can use `{% cv_querystring %}` (after `{% load crud_views %}`) to stay version-agnostic too.
 - `WorkflowModelMixin` can now be imported before Django's app registry is ready. `crud_views_workflow/lib/mixins.py` no longer imports `ContentType` and `WorkflowInfo` at module level (they are imported lazily inside `get_workflow_info_queryset`), eliminating an `AppRegistryNotReady` error when a consumer model module imports the mixin while apps are still loading.
+- The `WorkflowInfo` model index now carries the explicit name `cvw_workflo_workflo_idx` (matching migration `0002`). Previously the index had no name, so Django auto-generated a hashed name and `makemigrations --check` perpetually proposed a `RenameIndex` migration for consumers. No new migration is required; existing databases are unaffected.
 
 ### Added
 

--- a/src/crud_views_workflow/models.py
+++ b/src/crud_views_workflow/models.py
@@ -18,5 +18,10 @@ class WorkflowInfo(models.Model):
 
     class Meta:
         indexes = [
-            models.Index(fields=["workflow_object_pk", "workflow_object_content_type"]),
+            # Explicit name matches migration 0002 (AddIndex). Without it, Django auto-generates a
+            # hashed name that differs from the shipped migration, causing perpetual RenameIndex drift.
+            models.Index(
+                fields=["workflow_object_pk", "workflow_object_content_type"],
+                name="cvw_workflo_workflo_idx",
+            ),
         ]

--- a/tests/test1/test_migrations.py
+++ b/tests/test1/test_migrations.py
@@ -1,0 +1,19 @@
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+
+
+@pytest.mark.django_db
+def test_workflow_app_has_no_missing_migrations():
+    """`makemigrations --check` must be clean for the cvw app.
+
+    Regression: the WorkflowInfo Meta index had no explicit name, so Django auto-generated a
+    hashed name that differed from the name shipped in migration 0002, making `makemigrations`
+    perpetually propose a RenameIndex for consumers.
+    """
+    out = StringIO()
+    try:
+        call_command("makemigrations", "cvw", check=True, dry_run=True, stdout=out, stderr=out)
+    except SystemExit:
+        pytest.fail(f"cvw has missing migrations:\n{out.getvalue()}")


### PR DESCRIPTION
The last finding from the consumer-upgrade audit (#5).

## Problem

`WorkflowInfo.Meta.indexes` declared an index without an explicit `name`, so Django auto-generated a hashed name (`cvw_workflo_workflo_102a2f_idx`). Migration `0002` had shipped the same index with the explicit name `cvw_workflo_workflo_idx`. Model state and migration state therefore disagreed, and `makemigrations --check` perpetually proposed:

```
~ Rename index cvw_workflo_workflo_idx on workflowinfo to cvw_workflo_workflo_102a2f_idx
```

This gave every consumer a spurious pending migration.

## Fix

Give the model index the explicit name migration `0002` already created (`cvw_workflo_workflo_idx`), so model state matches migration state. This is preferred over shipping the proposed `RenameIndex`:

- **No new migration** — model and migrations agree.
- **Existing databases unaffected** — the index is already named `cvw_workflo_workflo_idx` on disk from migration `0002`.
- **Robust** — an explicit name avoids future drift if Django's auto-name hashing ever changes.

## Tests

- New `test_workflow_app_has_no_missing_migrations` runs `makemigrations --check --dry-run` for `cvw` and fails on any pending migration (RED reproduced the exact RenameIndex; now green).
- Full suite: 424 passed, 1 skipped; ruff clean.