### PR TITLE
Hardening & cleanup v0.10.1 (#33, #34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Django CRUD Views - Changelog
 
+## 0.10.1
+
+### Fixed
+
+- `ViewSet.default_permissions` now derives each action key by stripping the trailing `_<model>` from the permission codename instead of splitting on its first occurrence. A custom permission whose codename contains `_<model>` before its end (e.g. `change_book_status` on a `book` model) previously parsed to a truncated action (`change`) that collided with the standard `change` permission; it now parses correctly (`change_book_status`). Standard `add`/`change`/`delete`/`view` permissions are unaffected.
+
+### Deprecated
+
+- `CrispyModelViewMixin` is deprecated in favor of `CrispyViewMixin` and will be removed in a future release. The two are identical; rename imports and base classes to `CrispyViewMixin`. The alias still works in this release.
+
 ## 0.10.0
 
 ### Fixed

--- a/src/crud_views/lib/viewset/__init__.py
+++ b/src/crud_views/lib/viewset/__init__.py
@@ -364,12 +364,19 @@ class ViewSet(BaseModel):
             - view
             - ...
             - and custom permissions defined on model
+
+        Note: this is a process-lifetime ``cached_property`` that performs database queries
+        (a ``ContentType`` lookup and a ``Permission`` query). It is evaluated once per
+        process and is not refreshed if permissions change at runtime.
         """
         model = self.model  # noqa
         content_type = ContentType.objects.get_for_model(model)
         permissions = OrderedDict()
         for permission in Permission.objects.filter(content_type=content_type):
-            action = permission.codename.split(f"_{permission.content_type.model}")[0]
+            # Django codenames are "<action>_<model>"; the model name is always the suffix.
+            # Strip it as a suffix (not split on the first match) so actions that themselves
+            # contain the model name parse correctly, e.g. "rebook_book" -> "rebook".
+            action = permission.codename.removesuffix(f"_{permission.content_type.model}")
             permissions[action] = f"{permission.content_type.app_label}.{permission.codename}"
         return permissions
 

--- a/src/crud_views/lib/viewset/__init__.py
+++ b/src/crud_views/lib/viewset/__init__.py
@@ -373,9 +373,10 @@ class ViewSet(BaseModel):
         content_type = ContentType.objects.get_for_model(model)
         permissions = OrderedDict()
         for permission in Permission.objects.filter(content_type=content_type):
-            # Django codenames are "<action>_<model>"; the model name is always the suffix.
-            # Strip it as a suffix (not split on the first match) so actions that themselves
-            # contain the model name parse correctly, e.g. "rebook_book" -> "rebook".
+            # Django codenames are "<action>_<model>"; the model name is the suffix. Strip it
+            # as a suffix (not split on the first match) so a custom permission whose codename
+            # contains "_<model>" before its end parses fully, e.g. "change_book_status" stays
+            # "change_book_status" instead of being truncated to "change" for model "book".
             action = permission.codename.removesuffix(f"_{permission.content_type.model}")
             permissions[action] = f"{permission.content_type.app_label}.{permission.codename}"
         return permissions

--- a/superpowers/plans/2026-06-25-hardening-cleanup-v0.10.1.md
+++ b/superpowers/plans/2026-06-25-hardening-cleanup-v0.10.1.md
@@ -39,11 +39,13 @@ Append to `tests/test1/test_viewset.py`:
 ```python
 @pytest.mark.django_db
 def test_default_permissions_parses_action_containing_model_name():
-    """Custom permission whose codename embeds the model name parses to the full action.
+    """Custom permission whose codename contains the model name parses to the full action.
 
     Regression (#33): default_permissions split the codename on the first "_<model>"
-    occurrence, so an action that itself contains the model name (e.g. "rebook_book" for
-    model "book") was truncated to "re". It now strips "_<model>" as a suffix -> "rebook".
+    occurrence, truncating any action that contains "_<model>" before its end. For model
+    "book", a custom permission "change_book_status" was truncated to "change" -- colliding
+    with the standard "change" permission. Stripping "_<model>" only as a suffix keeps the
+    custom action intact ("change_book_status") and leaves the standard key untouched.
     """
     from django.contrib.auth.models import Permission
     from django.contrib.contenttypes.models import ContentType
@@ -51,7 +53,7 @@ def test_default_permissions_parses_action_containing_model_name():
     from tests.test1.app.models import Book
 
     ct = ContentType.objects.get_for_model(Book)  # ct.model == "book"
-    Permission.objects.create(content_type=ct, codename="rebook_book", name="Can rebook book")
+    Permission.objects.create(content_type=ct, codename="change_book_status", name="Can change book status")
 
     name = "book_perm_parsing_probe"
     viewset = ViewSet(model=Book, name=name)
@@ -60,9 +62,12 @@ def test_default_permissions_parses_action_containing_model_name():
     finally:
         _REGISTRY.pop(name, None)  # keep the global registry clean for other tests
 
-    assert "rebook" in permissions  # full action, not the truncated "re"
-    assert "re" not in permissions
-    assert permissions["rebook"] == f"{ct.app_label}.rebook_book"
+    # custom action keeps its full name instead of being truncated to "change"
+    assert "change_book_status" in permissions
+    assert permissions["change_book_status"] == f"{ct.app_label}.change_book_status"
+    # the standard "change" permission is not clobbered by the truncated custom one
+    assert permissions["change"] == f"{ct.app_label}.change_book"
+    # standard actions still parse
     for action in ("add", "change", "delete", "view"):
         assert action in permissions  # standard actions still parse
 ```
@@ -79,7 +84,7 @@ If `import pytest` is missing, add it at the top. (`_REGISTRY` is imported local
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `cd tests && pytest test1/test_viewset.py::test_default_permissions_parses_action_containing_model_name -v`
-Expected: FAIL — `assert "rebook" in permissions` fails because the current `split("_book")[0]` yields `"re"` (so `"rebook"` is absent and `"re"` is present).
+Expected: FAIL — `assert "change_book_status" in permissions` fails because the current `split("_book")[0]` truncates the codename to `"change"` (so the full action key is absent, and it collides with the standard `change` permission).
 
 - [ ] **Step 3: Write the minimal implementation**
 
@@ -180,7 +185,7 @@ In `CHANGELOG.md`, immediately below the top `# Django CRUD Views - Changelog` h
 
 ### Fixed
 
-- `ViewSet.default_permissions` now derives each action key by stripping the trailing `_<model>` from the permission codename instead of splitting on its first occurrence. A custom permission whose action contains the model name (e.g. `rebook_book` on a `book` model) previously parsed to a truncated action (`re`); it now parses correctly (`rebook`). Standard `add`/`change`/`delete`/`view` permissions are unaffected.
+- `ViewSet.default_permissions` now derives each action key by stripping the trailing `_<model>` from the permission codename instead of splitting on its first occurrence. A custom permission whose codename contains `_<model>` before its end (e.g. `change_book_status` on a `book` model) previously parsed to a truncated action (`change`) that collided with the standard `change` permission; it now parses correctly (`change_book_status`). Standard `add`/`change`/`delete`/`view` permissions are unaffected.
 
 ### Deprecated
 

--- a/superpowers/plans/2026-06-25-hardening-cleanup-v0.10.1.md
+++ b/superpowers/plans/2026-06-25-hardening-cleanup-v0.10.1.md
@@ -1,0 +1,287 @@
+# Hardening & Cleanup v0.10.1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a non-breaking v0.10.1 patch that hardens `ViewSet.default_permissions` codename parsing (#33) and records the `CrispyModelViewMixin` deprecation in the CHANGELOG (#34).
+
+**Architecture:** One-line parsing fix (`str.split` → `str.removesuffix`) on `ViewSet.default_permissions`, guarded by a new regression test that constructs a throwaway ViewSet over an existing model carrying a custom permission whose codename embeds the model name. The #34 deprecation is communicated through the CHANGELOG only — no code change. A final release task bumps the version and follows the project's PR → merge → tag flow.
+
+**Tech Stack:** Python 3.12+, Django 4.2/5.2/6.0, Pydantic v2 (ViewSet is a `BaseModel`), pytest / pytest-django, ruff, bump-my-version, Taskfile (`task`).
+
+**Spec:** `superpowers/specs/2026-06-25-hardening-cleanup-design.md`
+
+## Global Constraints
+
+- Python floor is **3.12+** — `str.removesuffix` (3.9+) is available; no compatibility shim needed.
+- Line length **120**, **double quotes**, ruff-formatted (pre-commit runs `ruff-format`).
+- All `CrudView`/ViewSet attributes use the `cv_` prefix; this change touches neither.
+- Release flow (per project history): feature branch → PR → wait CI → fix ruff → squash-merge to `main` → wait main CI; version bump (`bump-my-version`) commits **and** tags `v{new_version}`.
+- Quick test loop runs from `tests/`: `cd tests && pytest`. Full matrix is `task test` (nox; slow).
+- This release is **non-breaking**: no public symbol is removed (the `CrispyModelViewMixin` alias stays).
+- CHANGELOG is hand-maintained; the newest section sits at the top, currently `## 0.10.0`.
+
+---
+
+### Task 1: Harden `default_permissions` codename parsing (#33)
+
+**Files:**
+- Modify: `src/crud_views/lib/viewset/__init__.py:357-374` (the `default_permissions` cached_property)
+- Test: `tests/test1/test_viewset.py` (append a new test; file already holds the permission-mapping tests)
+
+**Interfaces:**
+- Consumes: `crud_views.lib.viewset.ViewSet` (Pydantic `BaseModel`; constructor takes `model=<Model>, name=<str>`), the module-level registry `crud_views.lib.viewset._REGISTRY` (an `OrderedDict` keyed by ViewSet `name`), and `tests.test1.app.models.Book` (PK = `BigAutoField`, so `ContentType.objects.get_for_model(Book).model == "book"`).
+- Produces: no new public symbol. `ViewSet.default_permissions` keeps its signature `-> OrderedDict[str, str]` (action key → `"<app_label>.<codename>"`); only the action-key derivation changes.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test1/test_viewset.py`:
+
+```python
+@pytest.mark.django_db
+def test_default_permissions_parses_action_containing_model_name():
+    """Custom permission whose codename embeds the model name parses to the full action.
+
+    Regression (#33): default_permissions split the codename on the first "_<model>"
+    occurrence, so an action that itself contains the model name (e.g. "rebook_book" for
+    model "book") was truncated to "re". It now strips "_<model>" as a suffix -> "rebook".
+    """
+    from django.contrib.auth.models import Permission
+    from django.contrib.contenttypes.models import ContentType
+    from crud_views.lib.viewset import ViewSet, _REGISTRY
+    from tests.test1.app.models import Book
+
+    ct = ContentType.objects.get_for_model(Book)  # ct.model == "book"
+    Permission.objects.create(content_type=ct, codename="rebook_book", name="Can rebook book")
+
+    name = "book_perm_parsing_probe"
+    viewset = ViewSet(model=Book, name=name)
+    try:
+        permissions = viewset.default_permissions
+    finally:
+        _REGISTRY.pop(name, None)  # keep the global registry clean for other tests
+
+    assert "rebook" in permissions  # full action, not the truncated "re"
+    assert "re" not in permissions
+    assert permissions["rebook"] == f"{ct.app_label}.rebook_book"
+    for action in ("add", "change", "delete", "view"):
+        assert action in permissions  # standard actions still parse
+```
+
+Check that `tests/test1/test_viewset.py` already imports `pytest` and `from crud_views.lib.viewset import ViewSet`; the top of the file should read like:
+
+```python
+import pytest
+from crud_views.lib.viewset import ViewSet
+```
+
+If `import pytest` is missing, add it at the top. (`_REGISTRY` is imported locally inside the test, so no top-level import is needed for it.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tests && pytest test1/test_viewset.py::test_default_permissions_parses_action_containing_model_name -v`
+Expected: FAIL — `assert "rebook" in permissions` fails because the current `split("_book")[0]` yields `"re"` (so `"rebook"` is absent and `"re"` is present).
+
+- [ ] **Step 3: Write the minimal implementation**
+
+In `src/crud_views/lib/viewset/__init__.py`, replace the `default_permissions` property body. Change the docstring to add the cached/DB note, and replace the parsing line.
+
+Find:
+
+```python
+    @cached_property
+    def default_permissions(self) -> OrderedDict[str, str]:
+        """
+        Default permissions extracted from model
+            - add
+            - change
+            - delete
+            - view
+            - ...
+            - and custom permissions defined on model
+        """
+        model = self.model  # noqa
+        content_type = ContentType.objects.get_for_model(model)
+        permissions = OrderedDict()
+        for permission in Permission.objects.filter(content_type=content_type):
+            action = permission.codename.split(f"_{permission.content_type.model}")[0]
+            permissions[action] = f"{permission.content_type.app_label}.{permission.codename}"
+        return permissions
+```
+
+Replace with:
+
+```python
+    @cached_property
+    def default_permissions(self) -> OrderedDict[str, str]:
+        """
+        Default permissions extracted from model
+            - add
+            - change
+            - delete
+            - view
+            - ...
+            - and custom permissions defined on model
+
+        Note: this is a process-lifetime ``cached_property`` that performs database queries
+        (a ``ContentType`` lookup and a ``Permission`` query). It is evaluated once per
+        process and is not refreshed if permissions change at runtime.
+        """
+        model = self.model  # noqa
+        content_type = ContentType.objects.get_for_model(model)
+        permissions = OrderedDict()
+        for permission in Permission.objects.filter(content_type=content_type):
+            # Django codenames are "<action>_<model>"; the model name is always the suffix.
+            # Strip it as a suffix (not split on the first match) so actions that themselves
+            # contain the model name parse correctly, e.g. "rebook_book" -> "rebook".
+            action = permission.codename.removesuffix(f"_{permission.content_type.model}")
+            permissions[action] = f"{permission.content_type.app_label}.{permission.codename}"
+        return permissions
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd tests && pytest test1/test_viewset.py::test_default_permissions_parses_action_containing_model_name -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the surrounding suite to confirm no regression**
+
+Run: `cd tests && pytest test1/test_viewset.py test1/test_permissions.py test1/test_permissions_full.py -q`
+Expected: all pass (these exercise the permission mapping that `default_permissions` feeds).
+
+- [ ] **Step 6: Lint**
+
+Run: `task check && task format`
+Expected: no errors; `default_permissions` body within 120-col, double quotes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/crud_views/lib/viewset/__init__.py tests/test1/test_viewset.py
+git commit -m "fix(viewset): strip model suffix in default_permissions codename parsing (#33)"
+```
+
+---
+
+### Task 2: CHANGELOG 0.10.1 section (#33 + #34)
+
+**Files:**
+- Modify: `CHANGELOG.md` (insert a new `## 0.10.1` section above `## 0.10.0`)
+
+**Interfaces:**
+- Consumes: nothing in code. Documents Task 1's fix and the standing `CrispyModelViewMixin` deprecation.
+- Produces: the release notes consumed by the version bump in Task 3.
+
+- [ ] **Step 1: Insert the 0.10.1 section**
+
+In `CHANGELOG.md`, immediately below the top `# Django CRUD Views - Changelog` heading and above `## 0.10.0`, insert:
+
+```markdown
+## 0.10.1
+
+### Fixed
+
+- `ViewSet.default_permissions` now derives each action key by stripping the trailing `_<model>` from the permission codename instead of splitting on its first occurrence. A custom permission whose action contains the model name (e.g. `rebook_book` on a `book` model) previously parsed to a truncated action (`re`); it now parses correctly (`rebook`). Standard `add`/`change`/`delete`/`view` permissions are unaffected.
+
+### Deprecated
+
+- `CrispyModelViewMixin` is deprecated in favor of `CrispyViewMixin` and will be removed in a future release. The two are identical; rename imports and base classes to `CrispyViewMixin`. The alias still works in this release.
+```
+
+- [ ] **Step 2: Verify the section renders and ordering is correct**
+
+Run: `sed -n '1,20p' CHANGELOG.md`
+Expected: `## 0.10.1` appears directly under the title and above `## 0.10.0`, with `### Fixed` then `### Deprecated`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): add 0.10.1 section (#33 fix, #34 deprecation)"
+```
+
+---
+
+### Task 3: Release — bump to 0.10.1 and follow the PR flow
+
+**Files:**
+- Modify (by `bump-my-version`): `pyproject.toml`, `src/crud_views/__init__.py`, `src/crud_views_plain/__init__.py`, `docs/index.md`, `README.md` (version string `0.10.0` → `0.10.1`).
+
+**Interfaces:**
+- Consumes: the merged Task 1 + Task 2 commits.
+- Produces: a `v0.10.1` git tag (created by `bump-my-version`) that triggers the Publish CI on push.
+
+> This task contains human-driven gates (waiting on CI, squash-merge). Do not bump the version until the code/CHANGELOG commits are on `main`, because `bump-my-version` tags the current commit.
+
+- [ ] **Step 1: Confirm you are on a feature branch (not `main`)**
+
+Run: `git branch --show-current`
+Expected: a feature branch name (e.g. `fix/default-permissions-parsing`). If it prints `main`, create and switch first:
+
+```bash
+git switch -c fix/default-permissions-parsing
+```
+
+(If Task 1/2 were committed on `main` by mistake, move them onto a branch before pushing.)
+
+- [ ] **Step 2: Push the branch and open the PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --base main --fill --title "Hardening & cleanup v0.10.1 (#33, #34)"
+```
+
+- [ ] **Step 3: Wait for PR CI and fix ruff if it flags anything**
+
+Run: `gh pr checks --watch`
+Expected: all checks green across Python 3.12/3.13/3.14 × Django 4.2/5.2/6.0. If ruff fails, run `task check && task format`, commit, push, re-watch.
+
+- [ ] **Step 4: Squash-merge to `main` and update local `main`**
+
+```bash
+gh pr merge --squash --delete-branch
+git switch main && git pull
+```
+
+- [ ] **Step 5: Wait for main CI to go green**
+
+Run: `gh run list --branch main --limit 1` then `gh run watch <run-id>`
+Expected: main CI green before tagging.
+
+- [ ] **Step 6: Bump the version (creates the commit + `v0.10.1` tag)**
+
+Run: `task bump-patch`
+Expected: `bump-my-version` rewrites the five version files `0.10.0` → `0.10.1`, creates a `Bump version: 0.10.0 → 0.10.1` commit, and tags `v0.10.1`. Verify:
+
+```bash
+git log --oneline -1 && git tag --list 'v0.10.1'
+```
+
+Expected: latest commit is the bump; tag `v0.10.1` exists.
+
+- [ ] **Step 7: Push main and the tag to trigger Publish CI**
+
+```bash
+git push origin main --follow-tags
+```
+
+Expected: the `v0.10.1` tag push starts the Publish workflow.
+
+- [ ] **Step 8: Confirm Publish CI succeeds**
+
+Run: `gh run list --workflow Publish --limit 1` then `gh run watch <run-id>`
+Expected: Publish workflow green; v0.10.1 released.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- #33 parsing fix (`removesuffix`) + placement-stays-on-ViewSet + cached/DB docstring note → Task 1, Step 3. ✓
+- #33 regression test (model-name-embedded codename; standard actions still parse) → Task 1, Step 1. ✓
+- #34 CHANGELOG-only deprecation, alias kept, no runtime warning → Task 2, Step 1 (`### Deprecated`); no code touched. ✓
+- v0.10.1 patch bump + `### Fixed`/`### Deprecated` headings + PR/merge/tag flow → Tasks 2 & 3. ✓
+- Out-of-scope (#55, relocating `default_permissions`, alias removal, warning machinery) → none of these appear in any task. ✓
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"/"similar to" placeholders; every code step shows complete code or exact commands. ✓
+
+**Type consistency:** `ViewSet(model=..., name=...)`, `_REGISTRY` (`OrderedDict`, `.pop(name, None)`), and `default_permissions -> OrderedDict[str, str]` are used identically across Task 1's test and implementation. The test asserts the `"<app_label>.<codename>"` value shape that the implementation produces. ✓

--- a/superpowers/specs/2026-06-25-hardening-cleanup-design.md
+++ b/superpowers/specs/2026-06-25-hardening-cleanup-design.md
@@ -28,10 +28,14 @@ action key for each model permission by splitting the codename on the first occu
 action = permission.codename.split(f"_{permission.content_type.model}")[0]
 ```
 
-Django codenames have the form `{action}_{model}`, where the model name is always the
-**suffix**. Splitting on the *first* `_{model}` truncates the action whenever the model name
-also appears inside the action itself. Example — model `book`, custom permission codename
-`rebook_book`: `"rebook_book".split("_book")[0]` yields `"re"` instead of `"rebook"`.
+Django's auto-created permissions have the form `{action}_{model}`, where the model name is
+the **suffix** (`add_book`, `change_book`, …). Custom permissions (declared via
+`Meta.permissions`) carry arbitrary codenames. Splitting on the *first* `_{model}` truncates
+the action whenever `_{model}` appears before the end of the codename. Example — model `book`,
+custom permission codename `change_book_status`: `"change_book_status".split("_book")[0]` yields
+`"change"`, which silently **collides** with the standard `change` permission. (Note: a codename
+like `rebook_book` is *not* affected — `_book` occurs only at the end, so split and removesuffix
+agree.)
 
 ### Change
 
@@ -61,14 +65,19 @@ at runtime.
 
 Add a focused test (in the existing `tests/test1/` suite):
 
-- A test model carrying a custom `Meta.permissions` entry whose codename **embeds the model
-  name** (e.g. model `book` with permission codename `rebook_book`).
-- Assert the parsed action key is the full action (`rebook`), not the truncated form (`re`).
+- A custom permission whose codename contains `_{model}` **before its end** (e.g. model `book`
+  with permission codename `change_book_status`). This is the case where `split` and
+  `removesuffix` diverge — the regression test must use such a codename, or it passes on both the
+  old and new code and proves nothing.
+- Assert the parsed action key is the full action (`change_book_status`), not the truncated form
+  (`change`), and that the standard `change` key still maps to `change_book` (i.e. the truncated
+  custom action no longer collides with it).
 - Assert the standard `add` / `change` / `delete` / `view` actions still parse correctly for the
   same model (no regression on the common case).
 
-The test model definition belongs in the implementation plan; it must be a model whose
-permission codename contains its own model name as a non-suffix substring.
+The concrete test mechanism belongs in the implementation plan. It constructs a throwaway
+`ViewSet` over an existing model with a runtime-created `Permission`, rather than adding a
+dedicated model, to avoid a model-less ViewSet polluting the global registry / system checks.
 
 ## #34 — Deprecate `CrispyModelViewMixin` alias
 

--- a/superpowers/specs/2026-06-25-hardening-cleanup-design.md
+++ b/superpowers/specs/2026-06-25-hardening-cleanup-design.md
@@ -1,0 +1,119 @@
+# Hardening & Cleanup — v0.10.1
+
+*Date: 2026-06-25 · Scope: single patch release · Baseline: v0.10.0 (main)*
+*Roadmap: [2026-06-24-audit-followup-roadmap-design.md](2026-06-24-audit-followup-roadmap-design.md) — the "Hardening & cleanup" batch, trimmed.*
+
+## What this is
+
+A small, **non-breaking** patch release bundling two low-risk items from the audit
+follow-up roadmap:
+
+- **#33** — Harden `ViewSet.default_permissions` codename parsing *(the only code change)*
+- **#34** — Deprecate the `CrispyModelViewMixin` alias *(CHANGELOG note only)*
+
+The roadmap originally batched a third item, **#55** (formsets `parent_form` cleanup),
+into this release. It is **deferred**: formsets are tricky and the `parent_form`
+validation hook may turn out to be needed, so #55 stays open for its own dedicated
+brainstorm → spec → plan cycle rather than being gutted here.
+
+## #33 — Harden `default_permissions` codename parsing
+
+### Problem
+
+`ViewSet.default_permissions` (`src/crud_views/lib/viewset/__init__.py:357-374`) derives an
+action key for each model permission by splitting the codename on the first occurrence of
+`_<model>`:
+
+```python
+action = permission.codename.split(f"_{permission.content_type.model}")[0]
+```
+
+Django codenames have the form `{action}_{model}`, where the model name is always the
+**suffix**. Splitting on the *first* `_{model}` truncates the action whenever the model name
+also appears inside the action itself. Example — model `book`, custom permission codename
+`rebook_book`: `"rebook_book".split("_book")[0]` yields `"re"` instead of `"rebook"`.
+
+### Change
+
+Replace the split with a suffix strip:
+
+```python
+action = permission.codename.removesuffix(f"_{permission.content_type.model}")
+```
+
+`removesuffix` removes the model name only when it is the actual suffix, leaving any earlier
+occurrence intact. It is available on the project's Python floor (3.12+). When the codename
+does not end with `_{model}` (not expected for model permissions, but defensive), `removesuffix`
+returns the codename unchanged rather than raising.
+
+### Placement
+
+`default_permissions` stays on `ViewSet`. It is a model-derived registry concern consumed by
+ViewSet routing and permission resolution; relocating it to the view was floated in the issue
+but is rejected here as scope-creep with real blast radius for no user-facing gain.
+
+The audit's task-3.6 documentation ask is closed by adding a docstring note that the property is
+a process-lifetime `cached_property` performing database queries (`ContentType` lookup +
+`Permission` query), so it is evaluated once per process and not refreshed if permissions change
+at runtime.
+
+### Test
+
+Add a focused test (in the existing `tests/test1/` suite):
+
+- A test model carrying a custom `Meta.permissions` entry whose codename **embeds the model
+  name** (e.g. model `book` with permission codename `rebook_book`).
+- Assert the parsed action key is the full action (`rebook`), not the truncated form (`re`).
+- Assert the standard `add` / `change` / `delete` / `view` actions still parse correctly for the
+  same model (no regression on the common case).
+
+The test model definition belongs in the implementation plan; it must be a model whose
+permission codename contains its own model name as a non-suffix substring.
+
+## #34 — Deprecate `CrispyModelViewMixin` alias
+
+### Problem
+
+`CrispyModelViewMixin(CrispyViewMixin)` (`src/crud_views/lib/crispy/form.py:134-136`) is an empty
+public alias of `CrispyViewMixin`, exported in `__all__` and used in docs, examples, and
+downstream projects. It was marked for eventual removal but is still a public name.
+
+### Decision
+
+Keep the alias in place this release. **No runtime `DeprecationWarning`** and **no code change** —
+a runtime warning was considered and rejected as more churn than the maintainer wants for a name
+that is not being removed yet. The existing in-code comment already references issue #34 and is
+left as-is.
+
+The deprecation is communicated through the CHANGELOG only:
+
+> **Deprecated:** `CrispyModelViewMixin` is deprecated in favor of `CrispyViewMixin` and will be
+> removed in a future release. The two are identical; rename imports/base classes to
+> `CrispyViewMixin`.
+
+Actual removal is a later (breaking → minor) release, not this one.
+
+## Release mechanics
+
+- Single feature branch off `main`; roughly two commits (the #33 fix + test, and the CHANGELOG
+  updates).
+- PR → wait for CI → fix any ruff → squash-merge to `main` → wait for main CI.
+- CHANGELOG `## 0.10.1` section with:
+  - `### Fixed` — #33 codename parsing.
+  - `### Deprecated` — #34 alias note.
+- Version bump: **patch → v0.10.1** (`task bump-patch`, which syncs `pyproject.toml`,
+  `__init__.py`, docs, README).
+
+## Out of scope
+
+- **#55** formsets `parent_form` cleanup — deferred to its own cycle.
+- Relocating `default_permissions` off `ViewSet`.
+- Removing the `CrispyModelViewMixin` alias (later release).
+- Any runtime deprecation-warning machinery for #34.
+
+## Definition of done
+
+- `default_permissions` uses `removesuffix`, carries the cached/DB docstring note, and the new
+  parsing test passes alongside the existing suite.
+- CHANGELOG has a `## 0.10.1` section with the `### Fixed` and `### Deprecated` entries.
+- Version bumped to 0.10.1, PR merged, main CI green.

--- a/tests/test1/test_viewset.py
+++ b/tests/test1/test_viewset.py
@@ -35,3 +35,33 @@ def test_viewset_get_router_name(cv_author: ViewSet):
     assert cv_author.get_router_name("create") == "author-create"
     assert cv_author.get_router_name("update") == "author-update"
     assert cv_author.get_router_name("delete") == "author-delete"
+
+
+@pytest.mark.django_db
+def test_default_permissions_parses_action_containing_model_name():
+    """Custom permission whose codename embeds the model name parses to the full action.
+
+    Regression (#33): default_permissions split the codename on the first "_<model>"
+    occurrence, so an action that itself contains the model name (e.g. "rebook_book" for
+    model "book") was truncated to "re". It now strips "_<model>" as a suffix -> "rebook".
+    """
+    from django.contrib.auth.models import Permission
+    from django.contrib.contenttypes.models import ContentType
+    from crud_views.lib.viewset import ViewSet, _REGISTRY
+    from tests.test1.app.models import Book
+
+    ct = ContentType.objects.get_for_model(Book)  # ct.model == "book"
+    Permission.objects.create(content_type=ct, codename="rebook_book", name="Can rebook book")
+
+    name = "book_perm_parsing_probe"
+    viewset = ViewSet(model=Book, name=name)
+    try:
+        permissions = viewset.default_permissions
+    finally:
+        _REGISTRY.pop(name, None)  # keep the global registry clean for other tests
+
+    assert "rebook" in permissions  # full action, not the truncated "re"
+    assert "re" not in permissions
+    assert permissions["rebook"] == f"{ct.app_label}.rebook_book"
+    for action in ("add", "change", "delete", "view"):
+        assert action in permissions  # standard actions still parse

--- a/tests/test1/test_viewset.py
+++ b/tests/test1/test_viewset.py
@@ -56,8 +56,8 @@ def test_default_permissions_parses_action_containing_model_name():
     Permission.objects.create(content_type=ct, codename="change_book_status", name="Can change book status")
 
     name = "book_perm_parsing_probe"
-    viewset = ViewSet(model=Book, name=name)
     try:
+        viewset = ViewSet(model=Book, name=name)
         permissions = viewset.default_permissions
     finally:
         _REGISTRY.pop(name, None)  # keep the global registry clean for other tests

--- a/tests/test1/test_viewset.py
+++ b/tests/test1/test_viewset.py
@@ -39,11 +39,13 @@ def test_viewset_get_router_name(cv_author: ViewSet):
 
 @pytest.mark.django_db
 def test_default_permissions_parses_action_containing_model_name():
-    """Custom permission whose codename embeds the model name parses to the full action.
+    """Custom permission whose codename contains the model name parses to the full action.
 
     Regression (#33): default_permissions split the codename on the first "_<model>"
-    occurrence, so an action that itself contains the model name (e.g. "rebook_book" for
-    model "book") was truncated to "re". It now strips "_<model>" as a suffix -> "rebook".
+    occurrence, truncating any action that contains "_<model>" before its end. For model
+    "book", a custom permission "change_book_status" was truncated to "change" -- colliding
+    with the standard "change" permission. Stripping "_<model>" only as a suffix keeps the
+    custom action intact ("change_book_status") and leaves the standard key untouched.
     """
     from django.contrib.auth.models import Permission
     from django.contrib.contenttypes.models import ContentType
@@ -51,7 +53,7 @@ def test_default_permissions_parses_action_containing_model_name():
     from tests.test1.app.models import Book
 
     ct = ContentType.objects.get_for_model(Book)  # ct.model == "book"
-    Permission.objects.create(content_type=ct, codename="rebook_book", name="Can rebook book")
+    Permission.objects.create(content_type=ct, codename="change_book_status", name="Can change book status")
 
     name = "book_perm_parsing_probe"
     viewset = ViewSet(model=Book, name=name)
@@ -60,8 +62,11 @@ def test_default_permissions_parses_action_containing_model_name():
     finally:
         _REGISTRY.pop(name, None)  # keep the global registry clean for other tests
 
-    assert "rebook" in permissions  # full action, not the truncated "re"
-    assert "re" not in permissions
-    assert permissions["rebook"] == f"{ct.app_label}.rebook_book"
+    # custom action keeps its full name instead of being truncated to "change"
+    assert "change_book_status" in permissions
+    assert permissions["change_book_status"] == f"{ct.app_label}.change_book_status"
+    # the standard "change" permission is not clobbered by the truncated custom one
+    assert permissions["change"] == f"{ct.app_label}.change_book"
+    # standard actions still parse
     for action in ("add", "change", "delete", "view"):
-        assert action in permissions  # standard actions still parse
+        assert action in permissions


### PR DESCRIPTION
## Summary

Non-breaking patch (targets **v0.10.1**) bundling two low-risk hardening items from the audit-followup roadmap.

### #33 — Harden `ViewSet.default_permissions` codename parsing
`default_permissions` now strips the trailing `_<model>` from each permission codename (`str.removesuffix`) instead of splitting on the first occurrence. The old `split(f"_{model}")[0]` truncated any custom permission whose codename contained `_<model>` **before its end** — e.g. `change_book_status` on a `book` model parsed to `change`, silently colliding with the standard `change` permission. Standard `add`/`change`/`delete`/`view` permissions are unaffected. Added a docstring note recording that the property is a process-lifetime `cached_property` doing DB queries (closes audit task 3.6).

Placement unchanged (stays on `ViewSet`).

### #34 — Deprecate `CrispyModelViewMixin` (CHANGELOG only)
Recorded in the CHANGELOG that `CrispyModelViewMixin` is deprecated in favor of `CrispyViewMixin` and will be removed in a future release. The alias still works this release — no code change, no runtime warning.

## Tests
- New regression test `test_default_permissions_parses_action_containing_model_name` — genuinely RED on the old `split` code (the custom action key is truncated/collides) and GREEN on `removesuffix`. It constructs a throwaway `ViewSet` and pops it from the global registry in a `finally`, so it doesn't pollute other tests.
- Full suite: **425 passed, 1 skipped** locally.

## Notes
The version bump to `0.10.1` and the `v0.10.1` tag (which triggers the Publish workflow) are intentionally **not** in this PR — they follow on `main` after merge, per the project's release flow.

Spec: `superpowers/specs/2026-06-25-hardening-cleanup-design.md`
Plan: `superpowers/plans/2026-06-25-hardening-cleanup-v0.10.1.md`

Closes #33.