### PR TITLE
fix(formsets): order-independent validity gate (follow-up to #55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   tested rule instead of an always-on placeholder. A grandchild formset with data
   is rejected when its parent row is blank (its foreign key would have nothing to
   point at). Removed the leftover `"Child TODO …"` placeholder message. (#55)
+- **Formsets:** the validity gate is now order-independent — an error added to a parent
+  form by a child formset's `clean()` reliably rejects the submission instead of slipping
+  through to `save()`. (follow-up to #55)
 
 ### Added
 

--- a/src/crud_views/lib/formsets/formsets.py
+++ b/src/crud_views/lib/formsets/formsets.py
@@ -307,6 +307,23 @@ class FormSets(BaseModel, arbitrary_types_allowed=True):
         for x_formset in self.x_formsets:
             yield from x_formset.is_valid()
 
+    def all_valid(self) -> bool:
+        """Return True only if every form and formset in the hierarchy is valid.
+
+        Two-phase and order-independent: a child formset's clean() may add_error() to a
+        parent form, but in a single traversal the parent's validity is collected before
+        the child's clean() runs. Phase 1 triggers every clean(); phase 2 re-derives
+        validity from the now-complete (shared) error state. Django's is_valid() runs
+        full_clean only once, so phase 2 re-runs no clean() and does no DB work, and it
+        delegates to Django's own per-formset validity (which already skips DELETE-marked
+        and empty extra forms).
+        """
+        # Phase 1: trigger every formset's clean() (where cross-form add_error happens).
+        # Discard results — collected in hierarchy order, before later cleans ran.
+        list(self.is_valid())
+        # Phase 2: re-collect; reflects errors added to any form during phase 1.
+        return all(valid for _, valid in self.is_valid())
+
     def save(self, commit: bool = True):
         for x_formset in self.x_formsets:
             x_formset.save(commit=commit)

--- a/src/crud_views/lib/formsets/mixins.py
+++ b/src/crud_views/lib/formsets/mixins.py
@@ -85,7 +85,10 @@ class FormSetMixinBase:
 
         # order-independent: a child formset's clean() may add_error() to a parent form,
         # which a single-pass tally would miss. See FormSets.all_valid().
-        return form_valid and formsets.all_valid()
+        # Evaluate eagerly (do not short-circuit on form_valid) so formset error state is
+        # always populated for the re-rendered page, matching the prior behavior.
+        all_formsets_valid = formsets.all_valid()
+        return form_valid and all_formsets_valid
 
     def cv_form_valid(self, context: dict):
         """

--- a/src/crud_views/lib/formsets/mixins.py
+++ b/src/crud_views/lib/formsets/mixins.py
@@ -83,13 +83,9 @@ class FormSetMixinBase:
             else:
                 return form_valid
 
-        # formsets valid?
-        formsets_valid = list(formsets.is_valid())
-        all_formsets_valid = all([v for fs, v in formsets_valid])
-
-        # form and formsets valid?
-        is_valid = all([form_valid, all_formsets_valid])
-        return is_valid
+        # order-independent: a child formset's clean() may add_error() to a parent form,
+        # which a single-pass tally would miss. See FormSets.all_valid().
+        return form_valid and formsets.all_valid()
 
     def cv_form_valid(self, context: dict):
         """

--- a/superpowers/plans/2026-06-26-formsets-validation-gate-hardening.md
+++ b/superpowers/plans/2026-06-26-formsets-validation-gate-hardening.md
@@ -1,0 +1,221 @@
+# Formsets Validation Gate Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the formset validity gate order-independent so an error added to a parent form by a child formset's `clean()` reliably rejects the submission instead of slipping through to `save()`.
+
+**Architecture:** Add a two-phase `FormSets.all_valid()` that triggers every formset's `clean()` (phase 1, results discarded) then re-collects validity (phase 2) from the now-complete, shared per-form error state. `cv_form_is_valid()` calls it instead of its single-pass tally. The existing `raise` in `InlineFormSet.clean()` is kept as harmless defense-in-depth but is no longer load-bearing.
+
+**Tech Stack:** Django (4.2/5.2/6.0) model formsets, pytest + pytest-django.
+
+## Global Constraints
+
+- Line length 120; double quotes; ruff format/check must pass.
+- Target release: fold into the **unreleased `0.10.2`** CHANGELOG section. No version bump in this work.
+- Run tests from `tests/`: `cd tests && pytest`.
+- Scope is the gate only (no first-class cross-form-validation API).
+- Do NOT modify `FormSets.is_valid()` / `XFormSet.is_valid()` traversal — both phases reuse it as-is.
+- Do NOT remove or weaken the `raise ValidationError` in `InlineFormSet.clean()`.
+- Do NOT add a re-validation guard inside `cv_form_valid()` (save) — the gate is the single source of truth and `cv_form_valid()` runs only after `cv_form_is_valid()` returns True (`src/crud_views/lib/views/mixins.py:35-41`).
+- Test app nesting under test: Publisher → books (Book) → notes (BookNote), in `tests/test1/app/views_formset.py`; `BookNoteInlineFormSet` is the nested (`level > 0`) formset.
+
+---
+
+### Task 1: Order-independent gate via two-phase `all_valid()`
+
+**Files:**
+- Modify: `src/crud_views/lib/formsets/formsets.py` (add `all_valid()` to class `FormSets`, immediately after `is_valid()` at lines 306-308)
+- Modify: `src/crud_views/lib/formsets/mixins.py` (method `cv_form_is_valid`, lines 69-92)
+- Test: `tests/test1/test_formsets_validation_gate.py` (create)
+
+**Interfaces:**
+- Consumes: existing `FormSets.is_valid(self) -> Iterable[Tuple[Any, bool]]` (`formsets.py:306`); `InlineFormSet._parent_is_present()`, `InlineFormSet.has_any_form_with_data`, `InlineFormSet.parent_form` (all existing on the nested formset).
+- Produces: `FormSets.all_valid(self) -> bool` — True only if every form and formset in the hierarchy is valid, independent of traversal order. Called by `cv_form_is_valid`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test1/test_formsets_validation_gate.py`:
+
+```python
+"""
+Tests for the order-independent formset validity gate.
+
+A child formset's clean() may add_error() to a PARENT form. The gate must reject the
+submission even when the parent form's validity was already collected earlier in the
+traversal. This is verified WITHOUT a raise (the live InlineFormSet.clean() also raises,
+which would otherwise mask the gate behavior).
+"""
+
+import pytest
+from django.forms.models import BaseInlineFormSet
+from django.test.client import Client
+
+from tests.lib.helper.forms import field_key, form_payload
+from tests.test1.app.models import BookNote, Publisher
+from tests.test1.app.views_formset import BookNoteInlineFormSet
+
+
+@pytest.mark.django_db
+def test_cross_form_add_error_without_raise_rejects_submission(
+    monkeypatch, client_user_publisher_formset: Client, cv_publisher_formset
+):
+    """A child clean() that add_error()s its parent WITHOUT raising must still reject."""
+
+    def add_error_only(self):
+        # Django's base formset clean populates cleaned_data; then annotate the parent
+        # WITHOUT raising — exactly the cross-form pattern the hardened gate must catch.
+        BaseInlineFormSet.clean(self)
+        if self.parent_form and self.has_any_form_with_data and not self._parent_is_present():
+            self.parent_form.add_error(None, "boom: parent missing")
+
+    monkeypatch.setattr(BookNoteInlineFormSet, "clean", add_error_only)
+
+    response = client_user_publisher_formset.get("/publisher-formset/create/")
+    payload = form_payload(response)
+    payload["name"] = "Ace Books"
+    # fill the nested note, leave the parent book row blank -> orphan
+    payload[field_key(payload, "-note")] = "orphan"
+
+    response = client_user_publisher_formset.post("/publisher-formset/create/", payload)
+
+    assert response.status_code == 200  # rejected, re-rendered (not 302, not a crash)
+    assert b"boom: parent missing" in response.content
+    assert not Publisher.objects.filter(name="Ace Books").exists()
+    assert not BookNote.objects.exists()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tests && pytest test1/test_formsets_validation_gate.py -v`
+Expected: FAIL on the current single-pass gate. The orphan slips through the gate and reaches `save()`, which raises `ValueError: save() prohibited ... unsaved related object 'book'` (the Django test client re-raises it). Either way the test does NOT pass — confirming the gate leaks cross-form errors.
+
+- [ ] **Step 3: Add `all_valid()` to `FormSets`**
+
+In `src/crud_views/lib/formsets/formsets.py`, immediately after the `is_valid()` method (currently lines 306-308) in class `FormSets`, add:
+
+```python
+    def all_valid(self) -> bool:
+        """Return True only if every form and formset in the hierarchy is valid.
+
+        Two-phase and order-independent: a child formset's clean() may add_error() to a
+        parent form, but in a single traversal the parent's validity is collected before
+        the child's clean() runs. Phase 1 triggers every clean(); phase 2 re-derives
+        validity from the now-complete (shared) error state. Django's is_valid() runs
+        full_clean only once, so phase 2 re-runs no clean() and does no DB work, and it
+        delegates to Django's own per-formset validity (which already skips DELETE-marked
+        and empty extra forms).
+        """
+        # Phase 1: trigger every formset's clean() (where cross-form add_error happens).
+        # Discard results — collected in hierarchy order, before later cleans ran.
+        list(self.is_valid())
+        # Phase 2: re-collect; reflects errors added to any form during phase 1.
+        return all(valid for _, valid in self.is_valid())
+```
+
+- [ ] **Step 4: Wire `cv_form_is_valid` to use it**
+
+In `src/crud_views/lib/formsets/mixins.py`, replace the body of `cv_form_is_valid` (lines 69-92) so the formset tally goes through `all_valid()`. The method becomes:
+
+```python
+    def cv_form_is_valid(self, context: dict) -> bool:
+        """
+        Check if the form is valid.
+        Crud Views modules may extend this method with further checks.
+        """
+
+        # the main form
+        form_valid = super().cv_form_is_valid(context)
+
+        # get the formsets
+        formsets = context.get("formsets", None)
+        if formsets is None:
+            if self.cv_formsets_required:
+                raise ValueError("Formsets are required but not defined, cv_formsets_required=True")
+            else:
+                return form_valid
+
+        # order-independent: a child formset's clean() may add_error() to a parent form,
+        # which a single-pass tally would miss. See FormSets.all_valid().
+        return form_valid and formsets.all_valid()
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd tests && pytest test1/test_formsets_validation_gate.py -v`
+Expected: PASS — the gate now catches the parent-form error, returns False, the view re-renders (200) with "boom: parent missing", and nothing is saved.
+
+- [ ] **Step 6: Run the formset regression suites**
+
+Run: `cd tests && pytest test1/test_formsets.py test1/test_formsets_bugs.py test1/test_formsets_ergonomics.py test1/test_formsets_parent_required.py -v`
+Expected: PASS — confirms no false positives (valid nested create/update, add-via-extra-row, delete a book row + its notes, invalid-row re-render all still behave), and the parent-required feature still works.
+
+- [ ] **Step 7: Lint**
+
+Run: `task check && task format`
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/crud_views/lib/formsets/formsets.py src/crud_views/lib/formsets/mixins.py tests/test1/test_formsets_validation_gate.py
+git commit -m "fix(formsets): order-independent validity gate via two-phase all_valid()"
+```
+
+---
+
+### Task 2: Changelog entry
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a "Fixed" bullet in the existing unreleased `0.10.2` section.
+
+- [ ] **Step 1: Add the changelog bullet**
+
+Open `CHANGELOG.md`, find the existing `## 0.10.2` section (added by the parent-required work; it already has `### Fixed` and `### Added` subsections). Add this bullet to the END of the existing `### Fixed` list, matching the surrounding style:
+
+```markdown
+- **Formsets:** the validity gate is now order-independent — an error added to a parent
+  form by a child formset's `clean()` reliably rejects the submission instead of slipping
+  through to `save()`. (follow-up to #55)
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `git diff CHANGELOG.md`
+Expected: a single new bullet under the existing `0.10.2` → `### Fixed` list; no new version heading, no other changes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): note order-independent formset validity gate"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Core fix — two-phase `FormSets.all_valid()` → Task 1, Step 3. ✓
+- `cv_form_is_valid()` uses `all_valid()` → Task 1, Step 4. ✓
+- Keep the `raise` (untouched); no save-side guard; no traversal change → enforced by Global Constraints; Task 1 modifies only `all_valid()` + the gate. ✓
+- Decisive test: cross-form `add_error` WITHOUT raise rejects + saves nothing, fails on old gate → Task 1, Steps 1-2 (RED) and 5 (GREEN). ✓
+- No false positives / DELETE + empty handling → Task 1, Step 6 (existing suites). ✓
+- Parent-required unchanged → Task 1, Step 6 (`test_formsets_parent_required.py`). ✓
+- CHANGELOG 0.10.2 updated → Task 2. ✓
+
+**Risk/contingency (from spec):** if a Django version in the CI matrix does not reflect the
+mutation on the second pass (Task 1, Step 6 across 4.2/5.2/6.0 would reveal this), the
+documented fallback is to replace the `all_valid()` body with an explicit hierarchy
+error-walk (check each non-DELETE form's `errors` plus each formset's `non_form_errors()`)
+behind the same method signature and call site. Only pursue if a matrix run fails.
+
+**Placeholder scan:** No TBD/TODO/"implement later"; all code shown in full. (The string
+`"boom: parent missing"` is an intentional test sentinel, not a placeholder.)
+
+**Type consistency:** `all_valid()` defined in Task 1 Step 3 is the exact name consumed in
+Step 4. `is_valid()` reused matches the existing signature. The monkeypatched `clean`
+references real members (`_parent_is_present`, `has_any_form_with_data`, `parent_form`).

--- a/superpowers/specs/2026-06-26-formsets-validation-gate-hardening-design.md
+++ b/superpowers/specs/2026-06-26-formsets-validation-gate-hardening-design.md
@@ -1,0 +1,156 @@
+# Formsets: order-independent validation gate (hardening)
+
+**Date:** 2026-06-26
+**Follow-up to:** #55 (parent-required validation). Deferred observation from that PR's final review.
+**Target release:** v0.10.2 (fold into the existing unreleased CHANGELOG section)
+
+## Problem
+
+The formset validity gate is sensitive to the order in which formsets are validated. A
+child formset's `clean()` may add an error to a **parent** form (the parent-required rule
+in `InlineFormSet.clean()` does exactly this via `self.parent_form.add_error(...)`). But by
+the time the child's `clean()` runs, the parent formset's validity has already been
+collected, so the late error is not counted by the gate.
+
+Trace:
+
+- `cv_form_is_valid()` (`src/crud_views/lib/formsets/mixins.py:69`) calls
+  `list(formsets.is_valid())` and tallies the booleans.
+- `FormSets.is_valid()` → `XFormSet.is_valid()` (`render_tree.py:193`) yields
+  `(parent_formset, parent.is_valid())` **first**, then descends into each form's child
+  formsets. The child's `clean()` — where `parent_form.add_error(...)` happens — runs
+  *after* the parent's `True` was already collected.
+- Net effect: an error added to a parent form by a child's `clean()` does not fail the gate.
+  Since `cv_form_valid()` (save) is reached only when the gate returns `True`
+  (`src/crud_views/lib/views/mixins.py:35-41`), the submission proceeds to `save()` and can
+  crash (e.g. `ValueError: save() prohibited ... unsaved related object`) or mis-save.
+
+Today this is masked because `InlineFormSet.clean()` also raises `ValidationError`, which
+fails the **child's own** `is_valid()` (evaluated fresh) and so is caught by the gate. The
+`raise` is therefore load-bearing, and the architecture stays fragile for any future
+cross-form validation that annotates another form without also raising on itself.
+
+## Decision
+
+Harden the gate so it is **order-independent**: validity is derived from the *complete*
+error state of the hierarchy after every `clean()` has run, not from booleans collected mid
+traversal. This makes the existing `raise` belt-and-suspenders rather than load-bearing, and
+makes cross-form `add_error()` reliably reject a submission.
+
+Scope is the gate only (Option 1 from the brainstorm). We are **not** adding a documented,
+first-class cross-form-validation API (Option 2) — there is no use case beyond the
+parent-required rule, which the gate hardening covers.
+
+## Core fix: two-phase validity
+
+Django's `BaseFormSet._errors` stores *references* to each form's `ErrorDict`, and
+`formset.is_valid()` re-derives its result from the current per-form / non-form error state
+on every call (it runs `full_clean` only once, then reads the shared, mutable error state).
+So collecting validity a **second** time — after all `clean()`s have run — reflects every
+cross-form `add_error()`, without re-running any `clean()` and without DB work.
+
+New method on `FormSets` (`src/crud_views/lib/formsets/formsets.py`), encapsulating the
+two-phase rationale in one documented place:
+
+```python
+def all_valid(self) -> bool:
+    """Return True only if every form and formset in the hierarchy is valid.
+
+    Two-phase, order-independent: a child formset's clean() may add_error() to a
+    parent form, and in a single traversal the parent's validity is collected before
+    the child's clean() runs. Phase 1 triggers every clean(); phase 2 re-derives
+    validity from the now-complete (shared) error state. is_valid() runs full_clean
+    only once, so phase 2 re-runs no clean() and does no DB work.
+    """
+    # Phase 1: trigger every formset's clean() (where cross-form add_error happens).
+    # Discard these results — collected in hierarchy order, before later cleans ran.
+    list(self.is_valid())
+    # Phase 2: re-collect. Reflects errors added to any form during phase 1.
+    return all(valid for _, valid in self.is_valid())
+```
+
+`cv_form_is_valid()` then replaces its inline single-pass tally with `formsets.all_valid()`:
+
+```python
+def cv_form_is_valid(self, context: dict) -> bool:
+    form_valid = super().cv_form_is_valid(context)
+    formsets = context.get("formsets", None)
+    if formsets is None:
+        if self.cv_formsets_required:
+            raise ValueError("Formsets are required but not defined, cv_formsets_required=True")
+        return form_valid
+    return form_valid and formsets.all_valid()
+```
+
+### Why this is robust, not clever-fragile
+
+Phase 2 delegates to Django's own `formset.is_valid()`, which already skips DELETE-marked
+forms and tolerates empty `extra` rows. We inherit correct handling of those cases instead
+of hand-rolling an error walk that could over-reject (false positives on legitimately blank
+or deleted rows).
+
+## Decisions
+
+- **Keep the `raise` in `InlineFormSet.clean()`.** It becomes redundant (the hardened gate
+  now also catches the parent-form error), but it is harmless defense-in-depth and provides
+  a clear non-field error path. Not load-bearing anymore.
+- **No extra guard in `cv_form_valid()` (save).** The gate is the single source of truth and
+  `cv_form_valid()` runs only after `cv_form_is_valid()` returns `True`
+  (`views/mixins.py:35-41`). A redundant re-validation before save would double-traverse for
+  no gain. Hardening the gate fixes the save path.
+- **No change to `FormSets.is_valid()` / `XFormSet.is_valid()` traversal.** Reused as-is by
+  both phases; the ordering fix lives entirely in the new `all_valid()`.
+
+## Testing
+
+The decisive test must exercise a cross-form `add_error()` **without** an accompanying
+`raise`, since the live `InlineFormSet.clean()` still raises and would otherwise mask the
+gate behavior.
+
+1. **Gate catches order-late cross-form error (regression — the core test).**
+   Drive the real Publisher → books → notes create flow. Monkeypatch the notes
+   `InlineFormSet.clean()` so that, when the child has data under a blank parent, it calls
+   `self.parent_form.add_error(None, "<msg>")` **without raising**. POST an orphan payload
+   (note filled, parent book blank). Assert: `status_code == 200` (rejected, re-rendered),
+   the error message is present, and no `Publisher`/`Book`/`BookNote` rows were created.
+   This test **fails on the current single-pass gate** (302/crash) and **passes** with
+   `all_valid()`.
+
+2. **No false positives — valid submissions still save.** The existing
+   `tests/test1/test_formsets.py` suite (nested create, update, add-via-extra-row, delete a
+   book row + its notes, invalid-row re-render) must stay green — confirms the two-phase gate
+   does not over-reject, and that DELETE-marked and empty `extra` rows are handled correctly.
+
+3. **Parent-required behavior unchanged.** The `tests/test1/test_formsets_parent_required.py`
+   suite must stay green — the feature still works (now via both the `raise` and the gate).
+
+4. **Unit test for `all_valid()` (if feasible without heavy tree construction).** Otherwise
+   the integration tests above are sufficient coverage.
+
+## Risk / contingency
+
+The two-phase approach relies on Django's shared-`ErrorDict`-reference behavior and on
+`is_valid()` re-deriving from cached error state. This is verified empirically by test (1)
+across the CI matrix (Django 4.2 / 5.2 / 6.0, Python 3.12 / 3.13 / 3.14). If any version does
+not reflect the mutation on the second pass, the documented fallback is an explicit
+hierarchy error-walk in `all_valid()` that checks each non-DELETE form's `errors` plus each
+formset's `non_form_errors()` directly — same public method, same call site, more verbose
+body.
+
+## Release & docs
+
+- Fold into the **unreleased `0.10.2`** CHANGELOG section (the parent-required entry is
+  already there; 0.10.2 is not yet tagged). Add a "Fixed" bullet: the formset validity gate
+  is now order-independent, so an error added to a parent form by a child formset's `clean()`
+  reliably rejects the submission instead of slipping through to `save()`.
+- No public API beyond the new `FormSets.all_valid()` method (documented via its docstring).
+- No version bump in this work — release is a separate step.
+
+## Acceptance
+
+- `cv_form_is_valid()` uses `FormSets.all_valid()`; validity no longer depends on traversal
+  order.
+- A test proves a cross-form `add_error()` without `raise` rejects the submission and saves
+  nothing (fails on the old gate, passes on the new one).
+- All existing formset and parent-required tests stay green.
+- CHANGELOG `0.10.2` updated.

--- a/tests/test1/test_formsets_validation_gate.py
+++ b/tests/test1/test_formsets_validation_gate.py
@@ -1,0 +1,45 @@
+"""
+Tests for the order-independent formset validity gate.
+
+A child formset's clean() may add_error() to a PARENT form. The gate must reject the
+submission even when the parent form's validity was already collected earlier in the
+traversal. This is verified WITHOUT a raise (the live InlineFormSet.clean() also raises,
+which would otherwise mask the gate behavior).
+"""
+
+import pytest
+from django.forms.models import BaseInlineFormSet
+from django.test.client import Client
+
+from tests.lib.helper.forms import field_key, form_payload
+from tests.test1.app.models import BookNote, Publisher
+from tests.test1.app.views_formset import BookNoteInlineFormSet
+
+
+@pytest.mark.django_db
+def test_cross_form_add_error_without_raise_rejects_submission(
+    monkeypatch, client_user_publisher_formset: Client, cv_publisher_formset
+):
+    """A child clean() that add_error()s its parent WITHOUT raising must still reject."""
+
+    def add_error_only(self):
+        # Django's base formset clean populates cleaned_data; then annotate the parent
+        # WITHOUT raising — exactly the cross-form pattern the hardened gate must catch.
+        BaseInlineFormSet.clean(self)
+        if self.parent_form and self.has_any_form_with_data and not self._parent_is_present():
+            self.parent_form.add_error(None, "boom: parent missing")
+
+    monkeypatch.setattr(BookNoteInlineFormSet, "clean", add_error_only)
+
+    response = client_user_publisher_formset.get("/publisher-formset/create/")
+    payload = form_payload(response)
+    payload["name"] = "Ace Books"
+    # fill the nested note, leave the parent book row blank -> orphan
+    payload[field_key(payload, "-note")] = "orphan"
+
+    response = client_user_publisher_formset.post("/publisher-formset/create/", payload)
+
+    assert response.status_code == 200  # rejected, re-rendered (not 302, not a crash)
+    assert b"boom: parent missing" in response.content
+    assert not Publisher.objects.filter(name="Ace Books").exists()
+    assert not BookNote.objects.exists()


### PR DESCRIPTION
Follow-up to #55. Hardens the formset validity gate so it no longer depends on traversal order.

## Problem

`cv_form_is_valid` collected formset validity in a single hierarchy-ordered pass: `FormSets.is_valid()` yields each parent formset's validity **before** descending into its child formsets. The parent-required rule lives in a *child* formset's `clean()` but annotates the *parent* form (`parent_form.add_error(...)`). By then the parent's `True` was already collected — the late error never reached the gate, so an orphaned submission slipped through to `save()` and crashed (`ValueError: save() prohibited ... unsaved related object`) or mis-saved.

Today this is masked only because `InlineFormSet.clean()` also `raise`s; that `raise` was load-bearing, leaving the architecture fragile for any future cross-form validation.

## Fix

Two-phase, order-independent validity:

- **`FormSets.all_valid()`** — phase 1 runs every formset's `clean()` (results discarded), phase 2 re-derives validity from the now-settled, shared per-form error state. Django caches `full_clean` (so phase 2 re-runs no `clean()` and does no DB work) and `BaseFormSet.is_valid()` re-reads each form's errors on every call, so a cross-form `add_error` from phase 1 is reflected. Phase 2 delegates to Django's own `is_valid()`, inheriting correct handling of DELETE-marked and empty `extra` rows — so no false positives.
- **`cv_form_is_valid`** routes through `all_valid()`, evaluated **eagerly** (no short-circuit on the main form), preserving the prior behavior of always populating formset error state for the re-render.

The `raise` in `InlineFormSet.clean()` is kept as harmless defense-in-depth; it is no longer load-bearing.

## Tests

New `tests/test1/test_formsets_validation_gate.py`: monkeypatches the nested formset's `clean()` to `add_error` a parent form **without** raising (the live `clean()` raises, which would otherwise mask the gate), then POSTs an orphan. Asserts the submission is rejected (200), the error shows, and nothing is saved. Verified to fail on the old single-pass gate (the original `ValueError` crash) and pass on the new one. All existing formset + parent-required suites stay green (438 passed, 1 skipped).

## Notes

- Scope is the gate only — no first-class cross-form-validation API, no traversal change, no save-side guard.
- CHANGELOG `0.10.2` (unreleased) updated; no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)