### PR TITLE
feat(modal): opt-in Bootstrap 5 modal views (cv_modal)

### DIFF
--- a/docs/reference/modals.md
+++ b/docs/reference/modals.md
@@ -1,0 +1,46 @@
+# Modals
+
+Views can opt in to Bootstrap 5 modal rendering: action buttons then open the view in a modal
+dialog instead of navigating to a full page.
+
+```python
+class AuthorDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionRequired):
+    form_class = CrispyDeleteForm
+    cv_viewset = cv_author
+    cv_modal = True                 # opt in
+    cv_modal_size = "modal-lg"      # optional: "", "modal-sm", "modal-lg", "modal-xl"
+```
+
+## Supported views
+
+`DeleteView`, `DetailView`, `CustomFormView` and `CustomFormNoObjectView` (and their
+permission-required and extension-package variants). Setting `cv_modal = True` on other view
+types raises system check error `viewset.E251`. Create/update support is planned.
+
+## Behavior
+
+- Buttons linking to a modal-enabled view fetch the view with the `X-CV-Modal: true` header and
+  show the returned partial in a shared modal shell (rendered by `{% cv_config %}` — no template
+  changes needed in your project).
+- On successful POST the server answers `204` with an `X-CV-Redirect` header and the browser
+  navigates to the view's success URL — messages and `cv_success_key` work exactly as without
+  modals.
+- Validation errors (and delete protection) re-render inside the open modal (status 422).
+- Progressive enhancement: direct links, middle-click, disabled JavaScript and non-Bootstrap
+  themes (e.g. `crud_views_plain`) all render the normal full page.
+
+## Requirements
+
+Your base template must load Bootstrap 5's JavaScript bundle and jQuery (both are already
+required for the Bootstrap 5 theme), plus the standard `{% cv_config %}` / `{% cv_js %}` tags.
+
+## Extending
+
+After every content injection the shell dispatches a `cv:modal:loaded` CustomEvent on
+`#cv-modal` — use it to initialize custom scripts inside modal content:
+
+```javascript
+document.getElementById("cv-modal").addEventListener("cv:modal:loaded", function () {
+    // initialize widgets inside the injected modal content
+});
+```

--- a/examples/bootstrap5/app/views/author.py
+++ b/examples/bootstrap5/app/views/author.py
@@ -110,10 +110,13 @@ class AuthorDeleteView(CrispyModelViewMixin, MessageMixin, GuardianDeleteViewPer
     cv_message = _("Deleted author »{object}«")
     cv_show_related_objects = True
     cv_link_related_objects = True
+    cv_modal = True
+    cv_modal_size = "modal-lg"
 
 
 class AuthorDetailView(GuardianDetailViewPermissionRequired):
     cv_viewset = cv_author
+    cv_modal = True
 
     cv_property_display = [
         {
@@ -185,6 +188,7 @@ class AuthorContactView(MessageMixin, CrispyModelViewMixin, CustomFormViewPermis
     cv_path = "contact"
     cv_icon_action = "fa-solid fa-envelope"
     cv_viewset = cv_author
+    cv_modal = True
     form_class = AuthorContactForm
 
     cv_message_template_code = _("Successfully contacted author <strong>{{ object }}</strong>")

--- a/skills/django-crud-views/SKILL.md
+++ b/skills/django-crud-views/SKILL.md
@@ -222,6 +222,41 @@ Execution order: GET checks `cv_check_delete_protection()` (hides form if errors
 
 ---
 
+## Modal Views
+
+Opt a view into Bootstrap 5 modal rendering: its action buttons then open the view in a modal dialog
+(fetched in place, submitted without a full page reload) instead of navigating to a full page.
+
+```python
+class AuthorDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionRequired):
+    form_class = CrispyDeleteForm
+    cv_viewset = cv_author
+    cv_modal = True                 # opt in
+    cv_modal_size = "modal-lg"      # optional: "" | "modal-sm" | "modal-lg" | "modal-xl"
+```
+
+**Supported view types:** `DeleteView`, `DetailView`, `CustomFormView`, `CustomFormNoObjectView` (and
+their `*PermissionRequired` and Guardian/extension variants). Setting `cv_modal = True` on any other view
+type (create, update, list, …) raises system check `viewset.E251`. An invalid `cv_modal_size` — anything
+other than the exact strings `""`, `"modal-sm"`, `"modal-lg"`, `"modal-xl"` — raises `viewset.E250`.
+
+**No template, JS, URL, or settings changes needed.** The shared modal shell is rendered by
+`{% cv_config %}` and the transport JS by `{% cv_js %}` — both already present in the Bootstrap 5 base
+template. It is the same URL: the view detects the modal request via an `X-CV-Modal: true` request header
+and returns just the modal partial (reusing the view's normal content). On POST, success answers `204` +
+an `X-CV-Redirect` header (the browser navigates — Django messages and `cv_success_key` work unchanged);
+invalid forms and delete protection re-render inside the open modal (status `422`).
+
+**Progressive enhancement:** direct links, middle-click, disabled JavaScript, and non-Bootstrap themes
+(`crud_views_plain`) all render the normal full page. `cv_modal = False` (the default) changes nothing.
+
+**Re-init hook:** after each content injection a `cv:modal:loaded` CustomEvent fires on `#cv-modal` — use
+it to initialize custom widgets inside modal content.
+
+Full reference: [docs/reference/modals.md](../../docs/reference/modals.md).
+
+---
+
 ## Nested Resources (Child ViewSet)
 
 Add `parent=ParentViewSet(name="author")` to the child ViewSet. Use `CreateViewParentMixin` on the child's create
@@ -771,3 +806,5 @@ To customise the manage view class for a specific viewset, pass `manage_view_cla
 | Guardian child create: button always visible | `GuardianCreateViewPermissionRequired` is used but `cv_guardian_parent_create_permission` is not set on the viewset |
 | Cascading deletes not showing | Set `cv_show_related_objects = True` on the delete view (opt-in, off by default) |
 | Related object links not rendering | Set `cv_link_related_objects = True` and ensure the related model has a ViewSet with a `detail` view |
+| `cv_modal` raises `viewset.E251` | Modal is phase-1 only: `DeleteView`, `DetailView`, `CustomFormView`, `CustomFormNoObjectView` (create/update/list not supported) |
+| `cv_modal_size` raises `viewset.E250` | Use an exact value: `""`, `"modal-sm"`, `"modal-lg"`, or `"modal-xl"` (not `"lg"`, `"large"`, etc.) |

--- a/skills/django-crud-views/references/api-reference.md
+++ b/skills/django-crud-views/references/api-reference.md
@@ -303,6 +303,33 @@ Add `"redirect_child"` (or the specific cv_key) to `cv_list_actions`.
 
 ---
 
+### Modal rendering (cv_modal)
+
+Opt-in Bootstrap 5 modal rendering for a single view. Buttons that link to the view open it in a modal
+dialog (same URL, fetched via an `X-CV-Modal: true` header) instead of navigating to a full page.
+
+| Attribute | Type | Default | Notes |
+|---|---|---|---|
+| `cv_modal` | bool | `False` | Opt in. Only allowed on `DeleteView`, `DetailView`, `CustomFormView`, `CustomFormNoObjectView` (and variants) — otherwise `viewset.E251`. |
+| `cv_modal_size` | str | `""` | One of `""`, `"modal-sm"`, `"modal-lg"`, `"modal-xl"` — otherwise `viewset.E250`. |
+
+```python
+class AuthorDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionRequired):
+    form_class = CrispyDeleteForm
+    cv_viewset = cv_author
+    cv_modal = True
+    cv_modal_size = "modal-lg"
+```
+
+Protocol: modal GET returns the modal partial (`200`, `Vary: X-CV-Modal`); POST success returns `204` +
+`X-CV-Redirect` (browser navigates; messages/`cv_success_key` unaffected); invalid form / delete
+protection re-renders the partial with `422`. No project template, JS, URL, or settings changes are
+needed — the shell comes from `{% cv_config %}` and the transport JS from `{% cv_js %}`. Degrades to the
+full page for direct links, no-JS, and the `crud_views_plain` theme. See the `Modal Views` section in
+SKILL.md and `docs/reference/modals.md` for the full guide.
+
+---
+
 ## Context Buttons
 
 Context buttons appear in the `cv_context_actions` area (typically top-right of a view). The ViewSet's `context_buttons` list controls which custom buttons are available. Default buttons: `home` (link to list), `parent` (link to parent viewset), `filter` (toggle filter form; hidden when `cv_filter_pinned` is set).

--- a/src/crud_views/lib/settings.py
+++ b/src/crud_views/lib/settings.py
@@ -120,6 +120,7 @@ class CrudViewsSettings(BaseModel):
                 "viewset": self.get_js("viewset.js"),
                 "formset": self.get_js("formset.js"),
                 "list_filter": self.get_js("list.filter.js"),
+                "modal": self.get_js("modal.js"),
             }
         )
 

--- a/src/crud_views/lib/view/base.py
+++ b/src/crud_views/lib/view/base.py
@@ -8,7 +8,14 @@ if TYPE_CHECKING:
     from django.contrib.auth.models import AbstractUser as User
 
 from crud_views.lib import check
-from crud_views.lib.check import Check, CheckAttributeReg, CheckAttribute, CheckTemplateOrCode, CheckTemplate
+from crud_views.lib.check import (
+    Check,
+    CheckAttributeReg,
+    CheckAttribute,
+    CheckTemplateOrCode,
+    CheckTemplate,
+    CheckExpression,
+)
 from crud_views.lib.exceptions import cv_raise, ParentViewSetError, CrudViewError, ViewSetKeyFoundError
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.db.models import Model
@@ -100,6 +107,19 @@ class CrudView(metaclass=CrudViewMetaClass):
                 "cv_action_short_label_template",
             ]:
                 yield CheckTemplateOrCode(context=cls, attribute=attribute)
+
+        yield CheckExpression(
+            context=cls,
+            id="E250",
+            expression=cls.cv_modal_size in ("", "modal-sm", "modal-lg", "modal-xl"),
+            msg=f"cv_modal_size must be one of '', 'modal-sm', 'modal-lg', 'modal-xl', got {cls.cv_modal_size!r}",
+        )
+        yield CheckExpression(
+            context=cls,
+            id="E251",
+            expression=not cls.cv_modal or cls.cv_modal_supported,
+            msg="cv_modal is not supported for this view type (phase 1: delete, detail and custom form views)",
+        )
 
     def get_success_url(self) -> str:
         url = self.cv_get_url(key=self.cv_success_key, obj=getattr(self, "object", None))

--- a/src/crud_views/lib/view/base.py
+++ b/src/crud_views/lib/view/base.py
@@ -16,6 +16,7 @@ from django.shortcuts import get_object_or_404
 from django.template import Context as TemplateContext, Template
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils.cache import patch_vary_headers
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from typing_extensions import Self
@@ -24,6 +25,11 @@ from .buttons import ContextButton
 from .context import ViewContext
 from .meta import CrudViewMetaClass
 from ..settings import crud_views_settings
+
+
+def cv_is_modal_request(request) -> bool:
+    """True when the client asked for the modal partial (X-CV-Modal header)."""
+    return request.headers.get("X-CV-Modal") == "true"
 
 
 class CrudView(metaclass=CrudViewMetaClass):
@@ -48,6 +54,12 @@ class CrudView(metaclass=CrudViewMetaClass):
     cv_parent_key: str | None = "list"  # parent key, defaults to list todo: does this make sense at all?
 
     cv_extends_template: str | None = None  # template to extend
+
+    # modal rendering (Bootstrap 5 theme; see superpowers/specs/2026-07-14-bootstrap-modals-design.md)
+    cv_modal: bool = False  # opt-in: action buttons open this view in a modal
+    cv_modal_size: str = ""  # "" | "modal-sm" | "modal-lg" | "modal-xl"
+    cv_modal_supported: bool = False  # phase gate: which view types may set cv_modal
+    cv_content_template: str | None = None  # the view's body partial, shared by full page and modal
 
     # texts and labels
     cv_header_template: str | None = None  # template snippet to render header label
@@ -100,6 +112,17 @@ class CrudView(metaclass=CrudViewMetaClass):
         context = super().get_context_data(**kwargs)
         context["cv_extends"] = self.cv_get_extends_template()
         return context
+
+    def get_template_names(self):
+        if self.cv_modal and cv_is_modal_request(self.request):
+            return ["crud_views/modal/content.html"]
+        return super().get_template_names()
+
+    def dispatch(self, request, *args, **kwargs):
+        response = super().dispatch(request, *args, **kwargs)
+        if self.cv_modal:
+            patch_vary_headers(response, ["X-CV-Modal"])
+        return response
 
     def cv_get_extends_template(self) -> str:
         if self.cv_extends_template:
@@ -221,6 +244,8 @@ class CrudView(metaclass=CrudViewMetaClass):
             cv_cancel_key=cls.cv_cancel_key,
             cv_icon_action=cls.cv_icon_action,
             cv_icon_header=cls.cv_icon_header,
+            cv_modal=cls.cv_modal,
+            cv_modal_size=cls.cv_modal_size,
         )
         data["cv_is_active"] = cls.cv_viewset.get_router_name(cls.cv_key) == context.router_name
         data.update(extra)

--- a/src/crud_views/lib/views/card.py
+++ b/src/crud_views/lib/views/card.py
@@ -8,6 +8,7 @@ from crud_views.lib.settings import crud_views_settings
 
 class CardListView(CardOrderMixin, CrudView, generic.ListView):
     template_name = "crud_views/view_card.html"
+    cv_content_template = "crud_views/view_card.content.html"
 
     cv_pk: bool = False
     cv_key = "card"

--- a/src/crud_views/lib/views/create.py
+++ b/src/crud_views/lib/views/create.py
@@ -7,6 +7,7 @@ from .mixins import CrudViewProcessFormMixin
 
 class CreateView(CrudViewProcessFormMixin, CrudView, generic.CreateView):
     template_name = "crud_views/view_create.html"
+    cv_content_template = "crud_views/view_create.content.html"
 
     cv_key = "create"
     cv_object = False

--- a/src/crud_views/lib/views/delete.py
+++ b/src/crud_views/lib/views/delete.py
@@ -9,6 +9,7 @@ from django.views import generic
 
 from crud_views.lib.settings import crud_views_settings
 from crud_views.lib.view import CrudView, CrudViewPermissionRequiredMixin
+from crud_views.lib.view.base import cv_is_modal_request
 from crud_views.lib.views.mixins import CrudViewProcessFormMixin
 
 logger = logging.getLogger(__name__)
@@ -173,7 +174,10 @@ class DeleteView(CrudViewProcessFormMixin, CrudView, generic.DeleteView):
                 form = context["form"]
                 for error in errors:
                     form.add_error(None, error)
-                return self.render_to_response(context)
+                response = self.render_to_response(context)
+                if self.cv_modal and cv_is_modal_request(self.request):
+                    response.status_code = 422
+                return response
             self.cv_form_valid(context)
             self.cv_form_valid_hook(context)
             return self.cv_form_valid_redirect(context)

--- a/src/crud_views/lib/views/delete.py
+++ b/src/crud_views/lib/views/delete.py
@@ -22,6 +22,8 @@ class RelatedObjects(NamedTuple):
 
 class DeleteView(CrudViewProcessFormMixin, CrudView, generic.DeleteView):
     template_name = "crud_views/view_delete.html"
+    cv_content_template = "crud_views/view_delete.content.html"
+    cv_modal_supported = True
 
     cv_key = "delete"
     cv_path = "delete"

--- a/src/crud_views/lib/views/detail.py
+++ b/src/crud_views/lib/views/detail.py
@@ -11,6 +11,8 @@ from crud_views.lib.views.detail_custom import DetailCustomView
 
 class DetailView(ObjectDetailMixin, DetailCustomView):
     template_name = "crud_views/view_detail.html"
+    cv_content_template = "crud_views/view_detail.content.html"
+    cv_modal_supported = True
 
     cv_property_display: list | None = None
 

--- a/src/crud_views/lib/views/form.py
+++ b/src/crud_views/lib/views/form.py
@@ -17,6 +17,8 @@ class CustomFormView(CrudViewProcessFormMixin, CrudView, FormMixin, DetailView):
     """
 
     template_name = "crud_views/view_custom_form.html"
+    cv_content_template = "crud_views/view_custom_form.content.html"
+    cv_modal_supported = True
     cv_context_actions = crud_views_settings.detail_context_actions
 
     def cv_form_valid(self, context: dict):
@@ -47,6 +49,8 @@ class CustomFormNoObjectView(CrudViewProcessFormMixin, CrudView, FormMixin, Temp
     cv_object = False
 
     template_name = "crud_views/view_custom_form.html"
+    cv_content_template = "crud_views/view_custom_form.content.html"
+    cv_modal_supported = True
     cv_context_actions = crud_views_settings.detail_context_actions
 
     def get(self, request, *args, **kwargs):

--- a/src/crud_views/lib/views/list.py
+++ b/src/crud_views/lib/views/list.py
@@ -15,6 +15,7 @@ except ImportError:
 
 class ListView(CrudView, generic.ListView):
     template_name = "crud_views/view_list.html"
+    cv_content_template = "crud_views/view_list.content.html"
 
     cv_pk: bool = False  # does not need primary key
     cv_key = "list"

--- a/src/crud_views/lib/views/mixins.py
+++ b/src/crud_views/lib/views/mixins.py
@@ -4,14 +4,14 @@ from urllib.parse import parse_qs, urlencode
 
 from django.contrib import messages
 from django.core.exceptions import BadRequest
-from django.http import HttpResponseRedirect
-from django.http import JsonResponse
+from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django_filters.views import FilterView
 from django_tables2 import SingleTableMixin
 
 from crud_views.lib.check import Check, CheckTemplateOrCode
 from crud_views.lib.session import SessionData
 from crud_views.lib.settings import crud_views_settings
+from crud_views.lib.view.base import cv_is_modal_request
 
 
 class CrudViewProcessFormMixin:
@@ -68,9 +68,13 @@ class CrudViewProcessFormMixin:
 
     def cv_form_invalid(self, context: dict):
         """
-        Handle invalid form
+        Handle invalid form; modal requests are answered with 422 so the client
+        can distinguish the re-rendered partial from a confirmation page.
         """
-        return self.render_to_response(context)
+        response = self.render_to_response(context)
+        if self.cv_modal and cv_is_modal_request(self.request):
+            response.status_code = 422
+        return response
 
     def cv_form_invalid_hook(self, context: dict):
         """
@@ -78,11 +82,18 @@ class CrudViewProcessFormMixin:
         """
         pass
 
-    def cv_form_valid_redirect(self, context: dict) -> HttpResponseRedirect:
+    def cv_form_valid_redirect(self, context: dict) -> HttpResponse:
         """
-        Redirect to the success url
+        Redirect to the success url.
+        Modal requests get 204 + X-CV-Redirect instead of a 302: fetch() follows
+        redirects transparently, so the client needs the target as data.
         """
-        return HttpResponseRedirect(self.get_success_url())
+        url = self.get_success_url()
+        if self.cv_modal and cv_is_modal_request(self.request):
+            response = HttpResponse(status=204)
+            response["X-CV-Redirect"] = url
+            return response
+        return HttpResponseRedirect(url)
 
     def cv_form_invalid_redirect(self, context: dict) -> HttpResponseRedirect:
         """

--- a/src/crud_views/lib/views/mixins.py
+++ b/src/crud_views/lib/views/mixins.py
@@ -197,6 +197,7 @@ class ListViewTableMixin(SingleTableMixin):
     """
 
     template_name = "crud_views/view_list_table.html"
+    cv_content_template = "crud_views/view_list_table.content.html"
 
     table: SingleTableMixin = None
     table_class: str = None

--- a/src/crud_views/lib/views/update.py
+++ b/src/crud_views/lib/views/update.py
@@ -7,6 +7,7 @@ from .mixins import CrudViewProcessFormMixin
 
 class UpdateView(CrudViewProcessFormMixin, CrudView, generic.UpdateView):
     template_name = "crud_views/view_update.html"
+    cv_content_template = "crud_views/view_update.content.html"
 
     cv_key = "update"
     cv_path = "update"

--- a/src/crud_views/static/crud_views/js/modal.js
+++ b/src/crud_views/static/crud_views/js/modal.js
@@ -1,0 +1,109 @@
+/**
+ * CrudViews modal: fetch-based Bootstrap 5 modal rendering for views with cv_modal = True.
+ *
+ * Protocol (superpowers/specs/2026-07-14-bootstrap-modals-design.md):
+ *   GET  url  + X-CV-Modal: true  -> 200 modal partial (modal-header + modal-body)
+ *   POST form + X-CV-Modal: true  -> 204 + X-CV-Redirect header (success: navigate)
+ *                                 -> 422 + re-rendered partial   (validation errors: swap)
+ * Anything else falls back to a full-page navigation — never strand the user in a broken modal.
+ *
+ * After every injection a "cv:modal:loaded" CustomEvent is dispatched on #cv-modal
+ * (hook for re-initializing scripts inside modal content).
+ */
+
+const CVModalConst = Object.freeze({
+    modal: "cv-modal",
+    dialog: "cv-modal-dialog",
+    content: "cv-modal-content",
+    urlAttr: "data-cv-url",
+    loadedEvent: "cv:modal:loaded",
+});
+
+function cvModalElements() {
+    const modal = document.getElementById(CVModalConst.modal);
+    if (!modal) {
+        throw new Error("cvModal: #cv-modal not found. Make sure {% cv_config %} is in your base template.");
+    }
+    if (typeof bootstrap === "undefined" || !bootstrap.Modal) {
+        throw new Error("cvModal: Bootstrap 5 JavaScript not loaded.");
+    }
+    return {
+        modal: modal,
+        dialog: document.getElementById(CVModalConst.dialog),
+        content: document.getElementById(CVModalConst.content),
+    };
+}
+
+function cvModalInject(html) {
+    const els = cvModalElements();
+    els.content.innerHTML = html;
+    els.modal.dispatchEvent(new CustomEvent(CVModalConst.loadedEvent, {bubbles: true}));
+}
+
+function cvModalOpen(url, size) {
+    const els = cvModalElements();
+    fetch(url, {headers: {"X-CV-Modal": "true"}})
+        .then(function (response) {
+            if (!response.ok) {
+                window.location.assign(url);
+                return null;
+            }
+            return response.text();
+        })
+        .then(function (html) {
+            if (html === null) {
+                return;
+            }
+            els.dialog.className = "modal-dialog" + (size ? " " + size : "");
+            els.modal.setAttribute(CVModalConst.urlAttr, url);
+            cvModalInject(html);
+            bootstrap.Modal.getOrCreateInstance(els.modal).show();
+        })
+        .catch(function () {
+            window.location.assign(url);
+        });
+}
+
+function cvModalSubmit(form) {
+    const els = cvModalElements(),
+        url = form.getAttribute("action"),
+        fallback = els.modal.getAttribute(CVModalConst.urlAttr) || url;
+    fetch(url, {
+        method: "POST",
+        body: new FormData(form),
+        headers: {"X-CV-Modal": "true"},
+    })
+        .then(function (response) {
+            const redirect = response.headers.get("X-CV-Redirect");
+            if (redirect) {
+                window.location.assign(redirect);
+                return null;
+            }
+            if (response.status === 422) {
+                return response.text();
+            }
+            window.location.assign(fallback);
+            return null;
+        })
+        .then(function (html) {
+            if (html === null || html === undefined) {
+                return;
+            }
+            cvModalInject(html);
+        })
+        .catch(function () {
+            window.location.assign(fallback);
+        });
+}
+
+$(document).ready(function () {
+    $(document).on("click", "[data-cv-modal='true']", function (e) {
+        e.preventDefault();
+        cvModalOpen($(this).attr("href"), $(this).attr("data-cv-modal-size"));
+    });
+
+    $(document).on("submit", "#cv-modal-content form", function (e) {
+        e.preventDefault();
+        cvModalSubmit(this);
+    });
+});

--- a/src/crud_views/templates/crud_views/modal/content.html
+++ b/src/crud_views/templates/crud_views/modal/content.html
@@ -1,0 +1,8 @@
+{% load crud_views i18n %}
+<div class="modal-header">
+    <h5 class="modal-title">{% cv_header_icon %} {% cv_header %}</h5>
+    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{% translate 'Close' %}"></button>
+</div>
+<div class="modal-body">
+    {% include view.cv_content_template %}
+</div>

--- a/src/crud_views/templates/crud_views/tags/context_action.html
+++ b/src/crud_views/templates/crud_views/tags/context_action.html
@@ -2,6 +2,7 @@
     <a href="{{ cv_url }}" class="btn btn-outline-primary {% if cv_is_active %}active{% endif %} btn-lg"
        role="button"
        title="{{ cv_action_label }}"
+       {% if cv_modal %}data-cv-modal="true" data-cv-modal-size="{{ cv_modal_size }}"{% endif %}
        cv-key="{{ cv_key }}">
         <i class="{{ cv_icon_action }}"></i>
     </a>

--- a/src/crud_views/templates/crud_views/tags/cv_config.html
+++ b/src/crud_views/templates/crud_views/tags/cv_config.html
@@ -3,3 +3,8 @@
      data-query-string="{{ request_query_string }}"
      data-csrf-token="{{ csrf_token }}"
      hidden></div>
+<div class="modal fade" id="cv-modal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog" id="cv-modal-dialog">
+        <div class="modal-content" id="cv-modal-content"></div>
+    </div>
+</div>

--- a/src/crud_views/templates/crud_views/tags/list_action.html
+++ b/src/crud_views/templates/crud_views/tags/list_action.html
@@ -1,5 +1,9 @@
 {% if cv_action_enabled is not False and cv_access is True %}
-<a {% if cv_list_action_method == "get" %}
+<a {% if cv_modal %}
+    href="{{ cv_url }}"
+    data-cv-modal="true"
+    data-cv-modal-size="{{ cv_modal_size }}"
+{% elif cv_list_action_method == "get" %}
     href="{{ cv_url }}"
 {% elif cv_list_action_method == "post" %}
     href="#"

--- a/src/crud_views/templates/crud_views/view_card.html
+++ b/src/crud_views/templates/crud_views/view_card.html
@@ -7,5 +7,5 @@
 {% endblock cv_filter %}
 
 {% block cv_content %}
-    {% include "crud_views/view_card.content.html" %}
+    {% include view.cv_content_template %}
 {% endblock cv_content %}

--- a/src/crud_views/templates/crud_views/view_create.content.html
+++ b/src/crud_views/templates/crud_views/view_create.content.html
@@ -1,6 +1,6 @@
 {% load crud_views %}
 
-<form class="cv-form" method="post" novalidate>
+<form class="cv-form" method="post" action="{{ request.path }}" novalidate>
     {% csrf_token %}
 
     {{ form.non_form_errors }}

--- a/src/crud_views/templates/crud_views/view_create.html
+++ b/src/crud_views/templates/crud_views/view_create.html
@@ -3,5 +3,5 @@
 {% load crud_views %}
 
 {% block cv_content %}
-    {% include "crud_views/view_create.content.html" %}
+    {% include view.cv_content_template %}
 {% endblock cv_content %}

--- a/src/crud_views/templates/crud_views/view_custom_form.content.html
+++ b/src/crud_views/templates/crud_views/view_custom_form.content.html
@@ -1,6 +1,6 @@
 {% load crud_views %}
 
-<form class="cv-form" method="post" novalidate>
+<form class="cv-form" method="post" action="{{ request.path }}" novalidate>
     {% csrf_token %}
 
     {{ form.non_form_errors }}

--- a/src/crud_views/templates/crud_views/view_custom_form.html
+++ b/src/crud_views/templates/crud_views/view_custom_form.html
@@ -1,5 +1,5 @@
 {% extends cv_extends %}
 
 {% block cv_content %}
-    {% include "crud_views/view_custom_form.content.html" %}
+    {% include view.cv_content_template %}
 {% endblock cv_content %}

--- a/src/crud_views/templates/crud_views/view_delete.content.html
+++ b/src/crud_views/templates/crud_views/view_delete.content.html
@@ -14,7 +14,7 @@
         {% include "crud_views/snippets/delete/related_objects.html" %}
     {% endif %}
 
-    <form class="cv-form" method="post" novalidate>
+    <form class="cv-form" method="post" action="{{ request.path }}" novalidate>
         {% csrf_token %}
 
         {{ form.non_form_errors }}

--- a/src/crud_views/templates/crud_views/view_delete.html
+++ b/src/crud_views/templates/crud_views/view_delete.html
@@ -2,6 +2,6 @@
 
 {% block cv_content %}
 
-    {% include "crud_views/view_delete.content.html" %}
+    {% include view.cv_content_template %}
 
 {% endblock cv_content %}

--- a/src/crud_views/templates/crud_views/view_detail.html
+++ b/src/crud_views/templates/crud_views/view_detail.html
@@ -2,6 +2,6 @@
 
 {% block cv_content %}
 
-    {% include "crud_views/view_detail.content.html" %}
+    {% include view.cv_content_template %}
 
 {% endblock cv_content %}

--- a/src/crud_views/templates/crud_views/view_list.html
+++ b/src/crud_views/templates/crud_views/view_list.html
@@ -4,5 +4,5 @@
 {% load django_tables2 %}
 
 {% block cv_content %}
-    {% include "crud_views/view_list.content.html" %}
+    {% include view.cv_content_template %}
 {% endblock cv_content %}

--- a/src/crud_views/templates/crud_views/view_list_table.html
+++ b/src/crud_views/templates/crud_views/view_list_table.html
@@ -5,5 +5,5 @@
 {% endblock cv_filter %}
 
 {% block cv_content %}
-    {% include "crud_views/view_list_table.content.html" %}
+    {% include view.cv_content_template %}
 {% endblock cv_content %}

--- a/src/crud_views/templates/crud_views/view_update.content.html
+++ b/src/crud_views/templates/crud_views/view_update.content.html
@@ -1,6 +1,6 @@
 {% load crud_views %}
 
-<form class="cv-form" method="post" enctype="multipart/form-data" novalidate>
+<form class="cv-form" method="post" action="{{ request.path }}" enctype="multipart/form-data" novalidate>
     {% csrf_token %}
 
     {{ form.non_form_errors }}

--- a/src/crud_views/templates/crud_views/view_update.html
+++ b/src/crud_views/templates/crud_views/view_update.html
@@ -1,5 +1,5 @@
 {% extends cv_extends %}
 
 {% block cv_content %}
-    {% include "crud_views/view_update.content.html" %}
+    {% include view.cv_content_template %}
 {% endblock cv_content %}

--- a/src/crud_views_plain/templates/crud_views/view_create.html
+++ b/src/crud_views_plain/templates/crud_views/view_create.html
@@ -3,7 +3,7 @@
 {% load crud_views %}
 
 {% block cv_content %}
-    {% include "crud_views/view_create.content.html" %}
+    {% include view.cv_content_template %}
 {% endblock cv_content %}
 
 

--- a/src/crud_views_plain/templates/crud_views/view_custom_form.html
+++ b/src/crud_views_plain/templates/crud_views/view_custom_form.html
@@ -3,5 +3,5 @@
 {% load crud_views %}
 
 {% block cv_content %}
-    {% include "crud_views/view_custom_form.content.html" %}
+    {% include view.cv_content_template %}
 {% endblock cv_content %}

--- a/src/crud_views_plain/templates/crud_views/view_delete.html
+++ b/src/crud_views_plain/templates/crud_views/view_delete.html
@@ -2,6 +2,6 @@
 
 {% block cv_content %}
 
-    {% include "crud_views/view_delete.content.html" %}
+    {% include view.cv_content_template %}
 
 {% endblock cv_content %}

--- a/src/crud_views_plain/templates/crud_views/view_list_table.html
+++ b/src/crud_views_plain/templates/crud_views/view_list_table.html
@@ -5,5 +5,5 @@
 {% endblock cv_filter %}
 
 {% block cv_content %}
-    {% include "crud_views/view_list_table.content.html" %}
+    {% include view.cv_content_template %}
 {% endblock cv_content %}

--- a/src/crud_views_plain/templates/crud_views/view_update.html
+++ b/src/crud_views_plain/templates/crud_views/view_update.html
@@ -3,5 +3,5 @@
 {% load crud_views %}
 
 {% block cv_content %}
-    {% include "crud_views/view_update.content.html" %}
+    {% include view.cv_content_template %}
 {% endblock cv_content %}

--- a/src/crud_views_polymorphic/lib/create_select.py
+++ b/src/crud_views_polymorphic/lib/create_select.py
@@ -21,6 +21,7 @@ class PolymorphicContentTypeForm(forms.Form):
 
 class PolymorphicCreateSelectView(CrudView, generic.FormView):
     template_name = "crud_views/view_create.html"
+    cv_content_template = "crud_views/view_create.content.html"
     form_class = PolymorphicContentTypeForm
 
     cv_key = "create_select"

--- a/superpowers/prompts/2026-07-14-bootstrap-modals.md
+++ b/superpowers/prompts/2026-07-14-bootstrap-modals.md
@@ -1,0 +1,37 @@
+# New Feature: Modals
+
+I want to plan a new feature for django-crud-views: Modal windows.
+For now this will be implemented only with Bootstrap.
+
+# Skill
+/django-crud-views use it
+
+# Discussion
+
+Currently, we have confirmation pages for delete.
+These do a check if the object can be deleted.
+If it can, a delete button is shown, which posts to the delete view, which does the action.
+After that the user is redirected to the list view, or something else depending on the view's configuration.
+
+My idea for this:
+- introduce a cv_modal:bool option for views
+- currently I see there:
+  - delete
+  - custom form view
+  - detail view
+- I am not sure about, needs discussion:
+  - create
+  - update
+
+For now only for bootstrap5.
+
+Elaborate multiple solutions for this new feature in the brainstorming session.
+The result should not be an implementation, but rather one Markdown document
+which describes the different solutions in details with pros/cons and code examples.
+
+This document will be the input for the final brainstorming session for the implementation.
+
+# Constraints
+- don't guess
+- be precise
+- ground everything in existing code

--- a/tests/test1/app/templates/app/base.html
+++ b/tests/test1/app/templates/app/base.html
@@ -28,6 +28,7 @@
 
     <!-- ViewSet -->
     {% cv_config %}
+    {% cv_js %}
     <link rel="stylesheet" href="{% static "viewset/css/property.css" %}">
 </head>
 

--- a/tests/test1/app/urls.py
+++ b/tests/test1/app/urls.py
@@ -16,6 +16,8 @@ from tests.test1.app.views import (
     cv_publisher_protected,
     cv_publisher_form_protected,
     cv_publisher_linked,
+    cv_author_modal,
+    cv_publisher_modal_protected,
 )
 from tests.test1.app.views_formset import cv_publisher_formset
 
@@ -38,3 +40,5 @@ urlpatterns += cv_publisher_protected.urlpatterns
 urlpatterns += cv_publisher_form_protected.urlpatterns
 urlpatterns += cv_publisher_linked.urlpatterns
 urlpatterns += cv_publisher_formset.urlpatterns
+urlpatterns += cv_author_modal.urlpatterns
+urlpatterns += cv_publisher_modal_protected.urlpatterns

--- a/tests/test1/app/views.py
+++ b/tests/test1/app/views.py
@@ -3,6 +3,7 @@ import django_tables2 as tables
 import django_filters
 
 from django.forms import modelform_factory
+from django.forms.fields import CharField
 
 from django.core.exceptions import ValidationError
 
@@ -51,7 +52,7 @@ from crud_views_guardian.lib.views import (
 )
 from crud_views_workflow.lib.forms import WorkflowForm
 from crud_views_workflow.lib.views import WorkflowViewPermissionRequired
-from crud_views.lib.crispy import Column4, Column6
+from crud_views.lib.crispy import Column4, Column6, Column12
 from crispy_forms.layout import Row, Layout
 
 cv_author = ViewSet(model=Author, name="author", icon_header="fa-regular fa-user")
@@ -797,3 +798,80 @@ class CustomGuardianManageViewForTest(ManageView):
     """Importable subclass used by test_guardian.py to verify manage_view_class on GuardianViewSet."""
 
     pass
+
+
+# --- Author Modal (UUID PK, cv_modal=True on delete/detail/custom form) ---
+
+cv_author_modal = ViewSet(
+    model=Author,
+    name="author_modal",
+)
+
+
+class AuthorModalListView(ListViewTableMixin, ListViewPermissionRequired):
+    table_class = AuthorTable
+    cv_viewset = cv_author_modal
+
+
+class AuthorModalDetailView(DetailViewPermissionRequired):
+    cv_viewset = cv_author_modal
+    cv_modal = True
+    cv_property_display = [
+        {"title": "Attributes", "properties": ["first_name", "last_name"]},
+    ]
+
+
+class AuthorModalDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionRequired):
+    form_class = CrispyDeleteForm
+    cv_viewset = cv_author_modal
+    cv_modal = True
+    cv_modal_size = "modal-lg"
+
+
+class AuthorModalContactForm(CrispyModelForm):
+    submit_label = "Send"
+    subject = CharField(label="Subject", required=True)
+    body = CharField(label="Body", required=True)
+
+    class Meta:
+        model = Author
+        fields = ["subject", "body"]
+
+    def get_layout_fields(self):
+        return Column12("subject"), Column12("body")
+
+
+class AuthorModalContactView(MessageMixin, CrispyModelViewMixin, CustomFormViewPermissionRequired):
+    cv_key = "contact"
+    cv_path = "contact"
+    cv_viewset = cv_author_modal
+    cv_modal = True
+    form_class = AuthorModalContactForm
+    cv_icon_action = "fa-solid fa-envelope"
+    cv_message_template_code = "Contacted author"
+    cv_header_template_code = "Contact"
+    cv_paragraph_template_code = "Contact the author"
+    cv_action_label_template_code = "Contact"
+    cv_action_short_label_template_code = "Contact"
+
+
+# --- Publisher Modal Protected (INT PK, cv_modal + delete protection) ---
+
+cv_publisher_modal_protected = ViewSet(
+    model=Publisher,
+    name="publisher_modal_protected",
+)
+
+
+class PublisherModalProtectedListView(ListViewTableMixin, ListViewPermissionRequired):
+    table_class = PublisherTable
+    cv_viewset = cv_publisher_modal_protected
+
+
+class PublisherModalProtectedDeleteView(CrispyModelViewMixin, DeleteViewPermissionRequired):
+    form_class = CrispyDeleteForm
+    cv_viewset = cv_publisher_modal_protected
+    cv_modal = True
+
+    def cv_check_delete_protection(self) -> list[str]:
+        return ["Cannot delete this publisher."]

--- a/tests/test1/conftest.py
+++ b/tests/test1/conftest.py
@@ -688,3 +688,51 @@ def user_publisher_formset(cv_publisher_formset):
 def client_user_publisher_formset(client, user_publisher_formset) -> Client:
     client.force_login(user_publisher_formset)
     return client
+
+
+# --- Author Modal fixtures ---
+
+
+@pytest.fixture
+def cv_author_modal():
+    from tests.test1.app.views import cv_author_modal as ret
+
+    return ret
+
+
+@pytest.fixture
+def user_author_modal(cv_author_modal):
+    from django.contrib.auth.models import User
+
+    user = User.objects.create_user(username="user_author_modal", password="password")
+    user_viewset_permission(user, cv_author_modal, "view")
+    user_viewset_permission(user, cv_author_modal, "delete")
+    return user
+
+
+@pytest.fixture
+def client_user_author_modal(client, user_author_modal) -> Client:
+    client.force_login(user_author_modal)
+    return client
+
+
+@pytest.fixture
+def cv_publisher_modal_protected():
+    from tests.test1.app.views import cv_publisher_modal_protected as ret
+
+    return ret
+
+
+@pytest.fixture
+def user_publisher_modal_protected_delete(cv_publisher_modal_protected):
+    from django.contrib.auth.models import User
+
+    user = User.objects.create_user(username="user_publisher_modal_protected_delete", password="password")
+    user_viewset_permission(user, cv_publisher_modal_protected, "delete")
+    return user
+
+
+@pytest.fixture
+def client_user_publisher_modal_protected_delete(client, user_publisher_modal_protected_delete) -> Client:
+    client.force_login(user_publisher_modal_protected_delete)
+    return client

--- a/tests/test1/test_modal.py
+++ b/tests/test1/test_modal.py
@@ -76,3 +76,68 @@ def test_custom_form_modal_partial(client_user_author_modal: Client, author_doug
     assert response.status_code == 200
     assert "crud_views/modal/content.html" in template_names(response)
     assert "<form" in response.content.decode()
+
+
+# ---------------------------------------------------------------------------
+# POST protocol (Task 3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_modal_delete_success_returns_204_with_redirect(client_user_author_modal: Client, author_douglas_adams):
+    from django.contrib.messages import get_messages
+
+    from tests.test1.app.models import Author
+
+    pk = author_douglas_adams.pk
+    response = client_user_author_modal.post(f"/author_modal/{pk}/delete/", {"confirm": True}, headers=MODAL_HEADERS)
+    assert response.status_code == 204
+    assert response.headers["X-CV-Redirect"] == "/author_modal/"
+    assert not Author.objects.filter(pk=pk).exists()
+    assert len(list(get_messages(response.wsgi_request))) == 1  # MessageMixin still queues the message
+
+
+@pytest.mark.django_db
+def test_modal_delete_protection_returns_422_partial(
+    client_user_publisher_modal_protected_delete: Client, publisher_penguin
+):
+    from tests.test1.app.models import Publisher
+
+    pk = publisher_penguin.pk
+    response = client_user_publisher_modal_protected_delete.post(
+        f"/publisher_modal_protected/{pk}/delete/", {"confirm": True}, headers=MODAL_HEADERS
+    )
+    assert response.status_code == 422
+    assert "crud_views/modal/content.html" in template_names(response)
+    assert "Cannot delete this publisher." in response.content.decode()
+    assert Publisher.objects.filter(pk=pk).exists()
+
+
+@pytest.mark.django_db
+def test_modal_custom_form_invalid_returns_422(client_user_author_modal: Client, author_douglas_adams):
+    response = client_user_author_modal.post(
+        f"/author_modal/{author_douglas_adams.pk}/contact/",
+        {"subject": "", "body": ""},
+        headers=MODAL_HEADERS,
+    )
+    assert response.status_code == 422
+    assert "crud_views/modal/content.html" in template_names(response)
+
+
+@pytest.mark.django_db
+def test_modal_custom_form_valid_returns_204(client_user_author_modal: Client, author_douglas_adams):
+    response = client_user_author_modal.post(
+        f"/author_modal/{author_douglas_adams.pk}/contact/",
+        {"subject": "Hello", "body": "Nice to meet you."},
+        headers=MODAL_HEADERS,
+    )
+    assert response.status_code == 204
+    assert response.headers["X-CV-Redirect"] == "/author_modal/"
+
+
+@pytest.mark.django_db
+def test_non_modal_post_flows_unchanged(client_user_author_modal: Client, author_douglas_adams):
+    """Without the header, a cv_modal view still redirects with 302 (regression guard)."""
+    response = client_user_author_modal.post(f"/author_modal/{author_douglas_adams.pk}/delete/", {"confirm": True})
+    assert response.status_code == 302
+    assert response.url == "/author_modal/"

--- a/tests/test1/test_modal.py
+++ b/tests/test1/test_modal.py
@@ -190,3 +190,38 @@ def test_check_modal_supported_on_delete():
         cv_modal = True
 
     assert "viewset.E251" not in check_ids(GoodModalDeleteView)
+
+
+# ---------------------------------------------------------------------------
+# Button attributes, form action, shell (Task 5)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_list_buttons_carry_modal_attributes(client_user_author_modal: Client, author_douglas_adams):
+    response = client_user_author_modal.get("/author_modal/")
+    content = response.content.decode()
+    assert 'data-cv-modal="true"' in content
+    assert 'data-cv-modal-size="modal-lg"' in content  # AuthorModalDeleteView
+
+
+@pytest.mark.django_db
+def test_list_buttons_without_modal_have_no_attributes(client_user_author_delete: Client, author_douglas_adams):
+    response = client_user_author_delete.get("/author/")
+    assert "data-cv-modal" not in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_modal_partial_form_has_explicit_action(client_user_author_modal: Client, author_douglas_adams):
+    pk = author_douglas_adams.pk
+    response = client_user_author_modal.get(f"/author_modal/{pk}/delete/", headers=MODAL_HEADERS)
+    assert f'action="/author_modal/{pk}/delete/"' in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_cv_config_renders_modal_shell(client_user_author_modal: Client):
+    response = client_user_author_modal.get("/author_modal/")
+    content = response.content.decode()
+    assert 'id="cv-modal"' in content
+    assert 'id="cv-modal-dialog"' in content
+    assert 'id="cv-modal-content"' in content

--- a/tests/test1/test_modal.py
+++ b/tests/test1/test_modal.py
@@ -1,0 +1,78 @@
+"""
+Tests for cv_modal: Bootstrap 5 modal rendering via X-CV-Modal content negotiation.
+Spec: superpowers/specs/2026-07-14-bootstrap-modals-design.md
+"""
+
+import pytest
+from django.test.client import Client
+
+MODAL_HEADERS = {"X-CV-Modal": "true"}
+
+
+def template_names(response) -> list:
+    return [t.name for t in response.templates if t.name]
+
+
+# ---------------------------------------------------------------------------
+# GET rendering (Task 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_get_without_header_renders_full_page(client_user_author_modal: Client, author_douglas_adams):
+    """No X-CV-Modal header -> unchanged full page (deep links, no-JS)."""
+    response = client_user_author_modal.get(f"/author_modal/{author_douglas_adams.pk}/delete/")
+    assert response.status_code == 200
+    assert "crud_views/view_delete.html" in template_names(response)
+    assert "crud_views/modal/content.html" not in template_names(response)
+
+
+@pytest.mark.django_db
+def test_get_with_header_renders_modal_partial(client_user_author_modal: Client, author_douglas_adams):
+    """X-CV-Modal: true on a cv_modal view -> modal partial, no page chrome."""
+    response = client_user_author_modal.get(f"/author_modal/{author_douglas_adams.pk}/delete/", headers=MODAL_HEADERS)
+    assert response.status_code == 200
+    names = template_names(response)
+    assert "crud_views/modal/content.html" in names
+    assert "crud_views/view_delete.html" not in names
+    content = response.content.decode()
+    assert "modal-header" in content
+    assert "modal-body" in content
+    assert "<html" not in content
+
+
+@pytest.mark.django_db
+def test_get_with_header_on_non_modal_view_renders_full_page(
+    client_user_author_delete: Client, cv_author, author_douglas_adams
+):
+    """Header on a cv_modal=False view is ignored."""
+    response = client_user_author_delete.get(f"/author/{author_douglas_adams.pk}/delete/", headers=MODAL_HEADERS)
+    assert response.status_code == 200
+    assert "crud_views/view_delete.html" in template_names(response)
+
+
+@pytest.mark.django_db
+def test_modal_view_sets_vary_header(client_user_author_modal: Client, author_douglas_adams):
+    """Responses of modal-enabled views carry Vary: X-CV-Modal (with and without the header)."""
+    url = f"/author_modal/{author_douglas_adams.pk}/delete/"
+    for headers in ({}, MODAL_HEADERS):
+        response = client_user_author_modal.get(url, headers=headers)
+        assert "X-CV-Modal" in response.headers.get("Vary", "")
+
+
+@pytest.mark.django_db
+def test_detail_modal_partial(client_user_author_modal: Client, author_douglas_adams):
+    """DetailView renders its object-detail groups inside the modal partial."""
+    response = client_user_author_modal.get(f"/author_modal/{author_douglas_adams.pk}/detail/", headers=MODAL_HEADERS)
+    assert response.status_code == 200
+    assert "crud_views/modal/content.html" in template_names(response)
+    assert "Douglas" in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_custom_form_modal_partial(client_user_author_modal: Client, author_douglas_adams):
+    """CustomFormView renders its form inside the modal partial."""
+    response = client_user_author_modal.get(f"/author_modal/{author_douglas_adams.pk}/contact/", headers=MODAL_HEADERS)
+    assert response.status_code == 200
+    assert "crud_views/modal/content.html" in template_names(response)
+    assert "<form" in response.content.decode()

--- a/tests/test1/test_modal.py
+++ b/tests/test1/test_modal.py
@@ -225,3 +225,24 @@ def test_cv_config_renders_modal_shell(client_user_author_modal: Client):
     assert 'id="cv-modal"' in content
     assert 'id="cv-modal-dialog"' in content
     assert 'id="cv-modal-content"' in content
+
+
+# ---------------------------------------------------------------------------
+# modal.js registration (Task 6) — JS behavior itself is verified manually
+# in examples/bootstrap5 (see design spec, testing decision)
+# ---------------------------------------------------------------------------
+
+
+def test_modal_js_registered_and_shipped():
+    from django.contrib.staticfiles import finders
+
+    from crud_views.lib.settings import crud_views_settings
+
+    assert crud_views_settings.javascript()["modal"] == "crud_views/js/modal.js"
+    assert finders.find("crud_views/js/modal.js")
+
+
+@pytest.mark.django_db
+def test_cv_js_tag_includes_modal_js(client_user_author_modal: Client):
+    response = client_user_author_modal.get("/author_modal/")
+    assert "crud_views/js/modal.js" in response.content.decode()

--- a/tests/test1/test_modal.py
+++ b/tests/test1/test_modal.py
@@ -141,3 +141,52 @@ def test_non_modal_post_flows_unchanged(client_user_author_modal: Client, author
     response = client_user_author_modal.post(f"/author_modal/{author_douglas_adams.pk}/delete/", {"confirm": True})
     assert response.status_code == 302
     assert response.url == "/author_modal/"
+
+
+# ---------------------------------------------------------------------------
+# System checks (Task 4)
+# ---------------------------------------------------------------------------
+
+
+def check_ids(view_cls) -> list:
+    return [m.id for c in view_cls.checks() for m in c.messages()]
+
+
+def test_check_modal_size_invalid():
+    from crud_views.lib.views import DeleteView
+
+    class BadSizeDeleteView(DeleteView):
+        cv_modal = True
+        cv_modal_size = "modal-huge"
+
+    assert "viewset.E250" in check_ids(BadSizeDeleteView)
+
+
+def test_check_modal_size_valid_values():
+    from crud_views.lib.views import DeleteView
+
+    for size in ("", "modal-sm", "modal-lg", "modal-xl"):
+
+        class GoodSizeDeleteView(DeleteView):
+            cv_modal = True
+            cv_modal_size = size
+
+        assert "viewset.E250" not in check_ids(GoodSizeDeleteView)
+
+
+def test_check_modal_not_supported_on_create():
+    from crud_views.lib.views import CreateView
+
+    class BadModalCreateView(CreateView):
+        cv_modal = True
+
+    assert "viewset.E251" in check_ids(BadModalCreateView)
+
+
+def test_check_modal_supported_on_delete():
+    from crud_views.lib.views import DeleteView
+
+    class GoodModalDeleteView(DeleteView):
+        cv_modal = True
+
+    assert "viewset.E251" not in check_ids(GoodModalDeleteView)


### PR DESCRIPTION
## Summary

Opt-in **Bootstrap 5 modal rendering** for views. Setting `cv_modal = True` on a supported view makes its action buttons open the view in a modal dialog (fetched in place, in-modal validation, full-page redirect on success) instead of navigating to a full page. Zero behavior change when not opted in.

```python
class AuthorDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionRequired):
    form_class = CrispyDeleteForm
    cv_viewset = cv_author
    cv_modal = True
    cv_modal_size = "modal-lg"   # "" | "modal-sm" | "modal-lg" | "modal-xl"
```

## How it works

Same-URL content negotiation via an `X-CV-Modal: true` request header — no new URLs:

| Request | Response |
|---|---|
| GET + `X-CV-Modal: true` | `200` modal partial (`Vary: X-CV-Modal`) |
| POST success | `204` + `X-CV-Redirect: <url>` (browser navigates; messages / `cv_success_key` unchanged) |
| POST invalid / delete protection | `422`, partial re-rendered inside the modal |
| No header (direct link, middle-click, no-JS, `crud_views_plain`) | unchanged full page |

A new vanilla `modal.js` (fetch + jQuery delegation) drives a shared modal shell rendered by `{% cv_config %}`. No new runtime dependencies.

## Scope

- **Phase-1 view types:** `DeleteView`, `DetailView`, `CustomFormView`, `CustomFormNoObjectView` (and their permission-required / Guardian / extension variants). Other types are hard-gated by system check **E251**.
- System check **E250** validates `cv_modal_size`.
- Progressive enhancement throughout; `crud_views_plain` degrades to full pages with zero changes.

## Changes

- `cv_modal` / `cv_modal_size` / `cv_modal_supported` / `cv_content_template` attributes, `X-CV-Modal` detection, modal partial rendering
- Single-source content-partial names (`view.cv_content_template`) across full-page templates in both themes
- POST protocol: `204` + `X-CV-Redirect` on success, `422` on invalid / protection
- System checks E250 / E251
- Button data attributes, modal shell via `{% cv_config %}`, explicit form actions
- `modal.js` transport + settings registration
- Example app (`examples/bootstrap5`) opt-in + reference docs (`docs/reference/modals.md`) + skill docs

## Testing

- `tests/test1/test_modal.py` — full protocol coverage (GET partial, `Vary`, 204/redirect, 422, checks, buttons, shell, JS registration)
- Full suite: **459 passed, 1 skipped**
- `task check` / `task format` clean
- Full nox matrix (Python 3.12/3.13/3.14 × Django 4.2/5.2/6.0): **8/9 green**, 1 expected skip (Django 4.2 has no Python 3.14 support)
- Live browser smoke test in the bootstrap5 example: delete modal opens as a real Bootstrap `modal-lg` rendering the correct partial

## Known limitations (phase 2)

- `Vary: X-CV-Modal` is not applied to permission-denied responses (`PermissionRequiredMixin.dispatch` short-circuits before `CrudView.dispatch`). Reviewed as harmless: those responses are invariant to the header, so no cache mismatch.
- A modal GET that hits an auth/session-expiry redirect injects the login page into the modal; it self-recovers via `modal.js`'s fallback navigation on submit.

Create/update modal support is intentionally deferred to a later phase.
