### PR TITLE
feat: public asset registry + vendor helper + plain-theme form.media fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Django CRUD Views - Changelog
 
+## Unreleased
+
+### Added
+- Asset registry: apps can contribute JS/CSS to `{% cv_js %}`/`{% cv_css %}` via
+  `crud_views.lib.assets.register_assets()` in `AppConfig.ready()`. Supports static
+  paths and external URLs, `emit=False` suppression for bundler setups, and a
+  reusable vendor helper (`crud_views.lib.vendor`) with drift checks W330/W331.
+  See `docs/reference/assets.md`.
+
+### Fixed
+- Plain theme: create and update views now render `{{ form.media }}`, so form widgets
+  that declare a `Media` class no longer lose their CSS/JS on the plain theme. The
+  bootstrap5 theme already emits widget media via crispy-forms and is unaffected.
+
 ## 0.10.2
 
 ### Fixed

--- a/docs/reference/assets.md
+++ b/docs/reference/assets.md
@@ -1,0 +1,51 @@
+# Asset registry
+
+Any Django app can contribute JavaScript and CSS to the output of `{% cv_js %}` and
+`{% cv_css %}` by registering an asset bundle in its `AppConfig.ready()`:
+
+    # myextension/apps.py
+    from django.apps import AppConfig
+
+    class MyExtensionConfig(AppConfig):
+        name = "myextension"
+
+        def ready(self):
+            from crud_views.lib.assets import register_assets
+            register_assets(
+                key="myextension",
+                js=["myextension/plugin.js", "myextension/init.js"],
+                css=["myextension/plugin.css"],
+            )
+
+Rules:
+
+- Entries are static paths resolved through `{% static %}` — unless they start with
+  `http://`, `https://` or `//`, in which case they are rendered verbatim (CDN mode).
+- Core assets always render first; registered bundles follow in registration order,
+  which equals `INSTALLED_APPS` order.
+- `key` must be unique; registering the same key twice raises `ImproperlyConfigured`.
+- `register_assets(..., emit=False)` keeps the bundle registered (its system checks
+  still run) but excludes it from tag output — use this when a bundler such as
+  django-pipeline delivers the files instead.
+- jQuery is **not** managed by the registry. As with core's own scripts, the project
+  loads jQuery in its base template before `{% cv_js %}`.
+
+## Vendoring third-party files
+
+`crud_views.lib.vendor` provides shared infrastructure for extension apps that offer a
+"download the pinned version locally" management command:
+
+    from crud_views.lib.vendor import VendorSpec, vendor, check_vendored
+
+    spec = VendorSpec(
+        key="myextension",
+        version="1.2.3",
+        base_url="https://cdn.jsdelivr.net/npm/some-pkg@{version}/dist/",
+        files=("plugin.js", "plugin.css"),
+        target=vendor_dir / "myextension" / "1.2.3",
+    )
+    vendor(spec)            # downloads files + writes a version stamp
+    check_vendored(spec)    # system-check messages on drift (W330 missing, W331 mismatch)
+
+The target must be a project directory that is on `STATICFILES_DIRS` — never a
+directory inside an installed package.

--- a/docs/reference/assets.md
+++ b/docs/reference/assets.md
@@ -3,19 +3,21 @@
 Any Django app can contribute JavaScript and CSS to the output of `{% cv_js %}` and
 `{% cv_css %}` by registering an asset bundle in its `AppConfig.ready()`:
 
-    # myextension/apps.py
-    from django.apps import AppConfig
+```python
+# myextension/apps.py
+from django.apps import AppConfig
 
-    class MyExtensionConfig(AppConfig):
-        name = "myextension"
+class MyExtensionConfig(AppConfig):
+    name = "myextension"
 
-        def ready(self):
-            from crud_views.lib.assets import register_assets
-            register_assets(
-                key="myextension",
-                js=["myextension/plugin.js", "myextension/init.js"],
-                css=["myextension/plugin.css"],
-            )
+    def ready(self):
+        from crud_views.lib.assets import register_assets
+        register_assets(
+            key="myextension",
+            js=["myextension/plugin.js", "myextension/init.js"],
+            css=["myextension/plugin.css"],
+        )
+```
 
 Rules:
 
@@ -24,9 +26,10 @@ Rules:
 - Core assets always render first; registered bundles follow in registration order,
   which equals `INSTALLED_APPS` order.
 - `key` must be unique; registering the same key twice raises `ImproperlyConfigured`.
-- `register_assets(..., emit=False)` keeps the bundle registered (its system checks
-  still run) but excludes it from tag output — use this when a bundler such as
-  django-pipeline delivers the files instead.
+- `register_assets(..., emit=False)` keeps the bundle registered but excludes it from
+  tag output — use this when a bundler such as django-pipeline delivers the files
+  instead. Vendored bundles are validated separately via `check_vendored()`, which an
+  extension app wires into its own system checks; it is not run automatically.
 - jQuery is **not** managed by the registry. As with core's own scripts, the project
   loads jQuery in its base template before `{% cv_js %}`.
 
@@ -35,17 +38,19 @@ Rules:
 `crud_views.lib.vendor` provides shared infrastructure for extension apps that offer a
 "download the pinned version locally" management command:
 
-    from crud_views.lib.vendor import VendorSpec, vendor, check_vendored
+```python
+from crud_views.lib.vendor import VendorSpec, vendor, check_vendored
 
-    spec = VendorSpec(
-        key="myextension",
-        version="1.2.3",
-        base_url="https://cdn.jsdelivr.net/npm/some-pkg@{version}/dist/",
-        files=("plugin.js", "plugin.css"),
-        target=vendor_dir / "myextension" / "1.2.3",
-    )
-    vendor(spec)            # downloads files + writes a version stamp
-    check_vendored(spec)    # system-check messages on drift (W330 missing, W331 mismatch)
+spec = VendorSpec(
+    key="myextension",
+    version="1.2.3",
+    base_url="https://cdn.jsdelivr.net/npm/some-pkg@{version}/dist/",
+    files=("plugin.js", "plugin.css"),
+    target=vendor_dir / "myextension" / "1.2.3",
+)
+vendor(spec)            # downloads files + writes a version stamp
+check_vendored(spec)    # system-check messages on drift (W330 missing, W331 mismatch)
+```
 
 The target must be a project directory that is on `STATICFILES_DIRS` — never a
 directory inside an installed package.

--- a/src/crud_views/lib/assets.py
+++ b/src/crud_views/lib/assets.py
@@ -1,0 +1,51 @@
+"""Public asset registry: apps contribute JS/CSS to cv_js/cv_css via AppConfig.ready()."""
+
+from dataclasses import dataclass
+from threading import Lock
+from typing import Iterable, List
+
+from django.core.exceptions import ImproperlyConfigured
+from django.templatetags.static import static
+
+_EXTERNAL_PREFIXES = ("http://", "https://", "//")
+
+
+@dataclass(frozen=True)
+class AssetBundle:
+    key: str
+    js: tuple = ()
+    css: tuple = ()
+    emit: bool = True
+
+
+_REGISTRY: dict = {}
+_LOCK = Lock()
+
+
+def register_assets(key: str, js: Iterable[str] = (), css: Iterable[str] = (), emit: bool = True) -> None:
+    """Register an asset bundle. Call from AppConfig.ready().
+
+    Entries are static paths, or external URLs (http://, https://, //) rendered verbatim.
+    Bundles render after core assets, in registration order (= INSTALLED_APPS order).
+    """
+    with _LOCK:
+        if key in _REGISTRY:
+            raise ImproperlyConfigured(f"crud_views asset bundle {key!r} is already registered")
+        _REGISTRY[key] = AssetBundle(key=key, js=tuple(js), css=tuple(css), emit=emit)
+
+
+def get_registered(only_emitting: bool = False) -> List[AssetBundle]:
+    with _LOCK:
+        bundles = list(_REGISTRY.values())
+    if only_emitting:
+        bundles = [b for b in bundles if b.emit]
+    return bundles
+
+
+def is_external(entry: str) -> bool:
+    return entry.startswith(_EXTERNAL_PREFIXES)
+
+
+def resolve_url(entry: str) -> str:
+    """External URLs pass through; static paths resolve via the configured staticfiles storage."""
+    return entry if is_external(entry) else static(entry)

--- a/src/crud_views/lib/vendor.py
+++ b/src/crud_views/lib/vendor.py
@@ -20,11 +20,11 @@ STAMP_NAME = ".vendored"
 
 @dataclass(frozen=True)
 class VendorSpec:
-    key: str            # registry/bundle key, e.g. "datetimepicker"
-    version: str        # pinned upstream version
-    base_url: str       # URL template containing {version}
-    files: tuple        # filenames to download
-    target: Path        # destination directory (should embed the version in its path)
+    key: str  # registry/bundle key, e.g. "datetimepicker"
+    version: str  # pinned upstream version
+    base_url: str  # URL template containing {version}
+    files: tuple  # filenames to download
+    target: Path  # destination directory (should embed the version in its path)
 
     @property
     def resolved_base_url(self) -> str:

--- a/src/crud_views/lib/vendor.py
+++ b/src/crud_views/lib/vendor.py
@@ -1,0 +1,70 @@
+"""Reusable download-and-stamp infrastructure for extension apps that vendor third-party JS/CSS.
+
+Extension apps build a VendorSpec from their settings and get a ~10-line management
+command (call vendor()) plus a drift system check (call check_vendored()) for free.
+The target directory must be a project directory on STATICFILES_DIRS — never an
+installed package's static/ directory.
+"""
+
+import json
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+from django.core.checks import CheckMessage
+from django.core.checks import Warning as CheckWarning
+
+STAMP_NAME = ".vendored"
+
+
+@dataclass(frozen=True)
+class VendorSpec:
+    key: str            # registry/bundle key, e.g. "datetimepicker"
+    version: str        # pinned upstream version
+    base_url: str       # URL template containing {version}
+    files: tuple        # filenames to download
+    target: Path        # destination directory (should embed the version in its path)
+
+    @property
+    def resolved_base_url(self) -> str:
+        return self.base_url.format(version=self.version)
+
+
+def vendor(spec: VendorSpec) -> List[Path]:
+    """Download spec.files into spec.target and write a version stamp."""
+    spec.target.mkdir(parents=True, exist_ok=True)
+    written = []
+    base = spec.resolved_base_url.rstrip("/")
+    for name in spec.files:
+        path = spec.target / name
+        with urllib.request.urlopen(f"{base}/{name}") as response:  # noqa: S310
+            path.write_bytes(response.read())
+        written.append(path)
+    (spec.target / STAMP_NAME).write_text(json.dumps({"key": spec.key, "version": spec.version}))
+    return written
+
+
+def check_vendored(spec: VendorSpec) -> List[CheckMessage]:
+    """System-check helper: warn when configured pin and vendored files drift."""
+    stamp = spec.target / STAMP_NAME
+    if not stamp.exists():
+        return [
+            CheckWarning(
+                f"crud_views asset bundle {spec.key!r} is configured as vendored, "
+                f"but no vendored files were found at {spec.target}.",
+                hint=f"Run the vendor management command for {spec.key!r}.",
+                id="crud_views.W330",
+            )
+        ]
+    data = json.loads(stamp.read_text())
+    if data.get("version") != spec.version:
+        return [
+            CheckWarning(
+                f"crud_views asset bundle {spec.key!r}: vendored version "
+                f"{data.get('version')!r} does not match configured version {spec.version!r}.",
+                hint=f"Re-run the vendor management command for {spec.key!r}.",
+                id="crud_views.W331",
+            )
+        ]
+    return []

--- a/src/crud_views/templates/crud_views/shared/css.html
+++ b/src/crud_views/templates/crud_views/shared/css.html
@@ -1,4 +1,3 @@
-{% load static %}
-{% for link in css.values %}
-    <link rel="stylesheet" href="{% static link %}">
+{% for item in css %}
+    <link rel="stylesheet" href="{{ item.url }}">
 {% endfor %}

--- a/src/crud_views/templates/crud_views/shared/js.html
+++ b/src/crud_views/templates/crud_views/shared/js.html
@@ -1,4 +1,3 @@
-{% load static %}
-{% for link in js.values %}
-    <script type="application/javascript" src="{% static link %}"></script>
+{% for item in js %}
+    <script type="application/javascript" src="{{ item.url }}"></script>
 {% endfor %}

--- a/src/crud_views/templatetags/crud_views.py
+++ b/src/crud_views/templatetags/crud_views.py
@@ -3,6 +3,7 @@ from django.template.loader import get_template, render_to_string
 from django.utils.safestring import mark_safe
 from django_tables2.templatetags import django_tables2 as _dt2
 
+from crud_views.lib import assets
 from crud_views.lib.settings import crud_views_settings
 from crud_views.lib.exceptions import ViewSetKeyFoundError, ignore_exception
 from crud_views.lib.view import CrudView
@@ -17,12 +18,18 @@ _querystring_impl = getattr(_dt2, "querystring_replace", None) or _dt2.querystri
 
 @register.inclusion_tag(f"{crud_views_settings.theme_path}/shared/css.html", takes_context=True)
 def cv_css(context):
-    return {"css": crud_views_settings.css}
+    entries = list(crud_views_settings.css.values())
+    for bundle in assets.get_registered(only_emitting=True):
+        entries.extend(bundle.css)
+    return {"css": [{"url": assets.resolve_url(entry)} for entry in entries]}
 
 
 @register.inclusion_tag(f"{crud_views_settings.theme_path}/shared/js.html", takes_context=True)
 def cv_js(context):
-    return {"js": crud_views_settings.javascript}
+    entries = list(crud_views_settings.javascript().values())
+    for bundle in assets.get_registered(only_emitting=True):
+        entries.extend(bundle.js)
+    return {"js": [{"url": assets.resolve_url(entry)} for entry in entries]}
 
 
 def cv_get_view(context) -> CrudView:

--- a/src/crud_views_plain/templates/crud_views/view_create.content.html
+++ b/src/crud_views_plain/templates/crud_views/view_create.content.html
@@ -7,3 +7,5 @@
 
     {% cv_render_form %}
 </form>
+
+{{ form.media }}

--- a/src/crud_views_plain/templates/crud_views/view_custom_form.content.html
+++ b/src/crud_views_plain/templates/crud_views/view_custom_form.content.html
@@ -7,3 +7,5 @@
 
     {% cv_render_form %}
 </form>
+
+{{ form.media }}

--- a/src/crud_views_plain/templates/crud_views/view_delete.content.html
+++ b/src/crud_views_plain/templates/crud_views/view_delete.content.html
@@ -9,3 +9,5 @@
 
     {% cv_render_form %}
 </form>
+
+{{ form.media }}

--- a/src/crud_views_plain/templates/crud_views/view_update.content.html
+++ b/src/crud_views_plain/templates/crud_views/view_update.content.html
@@ -7,3 +7,5 @@
 
     {% cv_render_form %}
 </form>
+
+{{ form.media }}

--- a/tests/test1/test_assets.py
+++ b/tests/test1/test_assets.py
@@ -1,6 +1,10 @@
+from pathlib import Path
+
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 from django.template import Context, Template
+
+import crud_views_plain
 
 
 @pytest.fixture
@@ -96,3 +100,22 @@ def test_empty_registry_output_unchanged(asset_registry):
     assert "/static/crud_views/js/list.filter.js" in html
     assert "/static/crud_views/js/modal.js" in html
     assert html.count("<script") == 4
+
+
+def test_plain_theme_content_templates_render_form_media():
+    """Regression guard for the plain theme's widget-media bug.
+
+    Unlike the bootstrap5 theme (whose crispy `{% crispy %}` tag auto-includes
+    `{{ form.media }}`), the plain theme's `tags/form.html` renders `{{ form.as_table }}`
+    with no crispy and no media anywhere. Its create/update content templates must therefore
+    render `{{ form.media }}` explicitly, or widget CSS/JS is silently lost.
+
+    This asserts the directive's presence directly in the plain templates: a behavioral
+    render test cannot isolate this line in the test suite, because the active theme is
+    bootstrap5 (crispy auto-includes media, contaminating any rendered output) and
+    `crud_views_plain` is intentionally not in the test project's INSTALLED_APPS.
+    """
+    base = Path(crud_views_plain.__file__).parent / "templates" / "crud_views"
+    for name in ("view_create.content.html", "view_update.content.html"):
+        source = (base / name).read_text()
+        assert "{{ form.media }}" in source, f"plain theme {name} must render {{{{ form.media }}}}"

--- a/tests/test1/test_assets.py
+++ b/tests/test1/test_assets.py
@@ -114,8 +114,16 @@ def test_plain_theme_content_templates_render_form_media():
     render test cannot isolate this line in the test suite, because the active theme is
     bootstrap5 (crispy auto-includes media, contaminating any rendered output) and
     `crud_views_plain` is intentionally not in the test project's INSTALLED_APPS.
+
+    Covers all four plain content templates that render a form via `{% cv_render_form %}`:
+    create, update, custom-form, and delete.
     """
     base = Path(crud_views_plain.__file__).parent / "templates" / "crud_views"
-    for name in ("view_create.content.html", "view_update.content.html"):
+    for name in (
+        "view_create.content.html",
+        "view_update.content.html",
+        "view_custom_form.content.html",
+        "view_delete.content.html",
+    ):
         source = (base / name).read_text()
         assert "{{ form.media }}" in source, f"plain theme {name} must render {{{{ form.media }}}}"

--- a/tests/test1/test_assets.py
+++ b/tests/test1/test_assets.py
@@ -1,5 +1,6 @@
 import pytest
 from django.core.exceptions import ImproperlyConfigured
+from django.template import Context, Template
 
 
 @pytest.fixture
@@ -51,3 +52,47 @@ def test_resolve_url(asset_registry):
     assert asset_registry.resolve_url("//cdn.example.com/x.js") == "//cdn.example.com/x.js"
     # STATIC_URL in tests/test1/conftest.py is "static/" (normalized to "/static/" by static())
     assert asset_registry.resolve_url("crud_views/js/viewset.js") == "/static/crud_views/js/viewset.js"
+
+
+def _render(tag: str) -> str:
+    return Template("{% load crud_views %}{% " + tag + " %}").render(Context({}))
+
+
+def test_cv_js_renders_core_then_registered(asset_registry):
+    asset_registry.register_assets(
+        key="picker",
+        js=["picker/plugin.js", "https://cdn.example.com/extra.js"],
+        css=["picker/plugin.css"],
+    )
+    html = _render("cv_js")
+    # core asset still present and resolved via static()
+    assert "/static/crud_views/js/viewset.js" in html
+    # registered static path resolved, external URL verbatim
+    assert "/static/picker/plugin.js" in html
+    assert 'src="https://cdn.example.com/extra.js"' in html
+    # order: core before registered
+    assert html.index("crud_views/js/viewset.js") < html.index("picker/plugin.js")
+
+
+def test_cv_css_renders_registered(asset_registry):
+    asset_registry.register_assets(key="picker", css=["picker/plugin.css"])
+    html = _render("cv_css")
+    assert "/static/crud_views/css/property.css" in html
+    assert "/static/picker/plugin.css" in html
+    assert html.index("property.css") < html.index("picker/plugin.css")
+
+
+def test_emit_false_not_rendered(asset_registry):
+    asset_registry.register_assets(key="picker", js=["picker/plugin.js"], emit=False)
+    html = _render("cv_js")
+    assert "picker/plugin.js" not in html
+
+
+def test_empty_registry_output_unchanged(asset_registry):
+    # regression guard: with nothing registered, all core assets and nothing else
+    html = _render("cv_js")
+    assert "/static/crud_views/js/viewset.js" in html
+    assert "/static/crud_views/js/formset.js" in html
+    assert "/static/crud_views/js/list.filter.js" in html
+    assert "/static/crud_views/js/modal.js" in html
+    assert html.count("<script") == 4

--- a/tests/test1/test_assets.py
+++ b/tests/test1/test_assets.py
@@ -1,0 +1,53 @@
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+
+
+@pytest.fixture
+def asset_registry():
+    """Snapshot/restore the module-global registry around each test."""
+    from crud_views.lib import assets
+
+    snapshot = dict(assets._REGISTRY)
+    assets._REGISTRY.clear()
+    yield assets
+    assets._REGISTRY.clear()
+    assets._REGISTRY.update(snapshot)
+
+
+def test_register_and_get(asset_registry):
+    asset_registry.register_assets(key="a", js=["a/one.js"], css=["a/one.css"])
+    asset_registry.register_assets(key="b", js=["b/two.js"])
+
+    bundles = asset_registry.get_registered()
+    assert [b.key for b in bundles] == ["a", "b"]  # registration order
+    assert bundles[0].js == ("a/one.js",)
+    assert bundles[0].css == ("a/one.css",)
+    assert bundles[1].css == ()
+    assert bundles[0].emit is True
+
+
+def test_duplicate_key_raises(asset_registry):
+    asset_registry.register_assets(key="a", js=["a/one.js"])
+    with pytest.raises(ImproperlyConfigured, match="already registered"):
+        asset_registry.register_assets(key="a", js=["other.js"])
+
+
+def test_only_emitting_filters(asset_registry):
+    asset_registry.register_assets(key="a", js=["a/one.js"], emit=False)
+    asset_registry.register_assets(key="b", js=["b/two.js"])
+
+    assert [b.key for b in asset_registry.get_registered()] == ["a", "b"]
+    assert [b.key for b in asset_registry.get_registered(only_emitting=True)] == ["b"]
+
+
+def test_is_external(asset_registry):
+    assert asset_registry.is_external("https://cdn.example.com/x.js")
+    assert asset_registry.is_external("http://cdn.example.com/x.js")
+    assert asset_registry.is_external("//cdn.example.com/x.js")
+    assert not asset_registry.is_external("crud_views/js/viewset.js")
+
+
+def test_resolve_url(asset_registry):
+    assert asset_registry.resolve_url("//cdn.example.com/x.js") == "//cdn.example.com/x.js"
+    # STATIC_URL in tests/test1/conftest.py is "static/" (normalized to "/static/" by static())
+    assert asset_registry.resolve_url("crud_views/js/viewset.js") == "/static/crud_views/js/viewset.js"

--- a/tests/test1/test_vendor.py
+++ b/tests/test1/test_vendor.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 import pytest
 

--- a/tests/test1/test_vendor.py
+++ b/tests/test1/test_vendor.py
@@ -1,0 +1,54 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from crud_views.lib.vendor import STAMP_NAME, VendorSpec, check_vendored, vendor
+
+
+@pytest.fixture
+def spec(tmp_path) -> VendorSpec:
+    return VendorSpec(
+        key="picker",
+        version="1.2.3",
+        base_url="https://cdn.example.com/pkg@{version}/build/",
+        files=("plugin.js", "plugin.css"),
+        target=tmp_path / "picker" / "1.2.3",
+    )
+
+
+def test_resolved_base_url(spec):
+    assert spec.resolved_base_url == "https://cdn.example.com/pkg@1.2.3/build/"
+
+
+def test_vendor_downloads_and_stamps(spec, mocker):
+    fake = mocker.patch("crud_views.lib.vendor.urllib.request.urlopen")
+    fake.return_value.__enter__.return_value.read.return_value = b"content"
+
+    written = vendor(spec)
+
+    assert [p.name for p in written] == ["plugin.js", "plugin.css"]
+    assert (spec.target / "plugin.js").read_bytes() == b"content"
+    fake.assert_any_call("https://cdn.example.com/pkg@1.2.3/build/plugin.js")
+    stamp = json.loads((spec.target / STAMP_NAME).read_text())
+    assert stamp == {"key": "picker", "version": "1.2.3"}
+
+
+def test_check_missing_stamp_warns_W330(spec):
+    messages = check_vendored(spec)
+    assert len(messages) == 1
+    assert messages[0].id == "crud_views.W330"
+
+
+def test_check_version_mismatch_warns_W331(spec):
+    spec.target.mkdir(parents=True)
+    (spec.target / STAMP_NAME).write_text(json.dumps({"key": "picker", "version": "9.9.9"}))
+    messages = check_vendored(spec)
+    assert len(messages) == 1
+    assert messages[0].id == "crud_views.W331"
+
+
+def test_check_ok_is_silent(spec):
+    spec.target.mkdir(parents=True)
+    (spec.target / STAMP_NAME).write_text(json.dumps({"key": "picker", "version": "1.2.3"}))
+    assert check_vendored(spec) == []


### PR DESCRIPTION
## Summary

Adds a **public asset registry** to django-crud-views so any Django app can contribute JS/CSS to `{% cv_js %}` / `{% cv_css %}` output by registering in its `AppConfig.ready()`, plus a reusable vendor-download helper and a `{{ form.media }}` template fix for the plain theme.

Implements Workstream 1 of the asset-registry design (`superpowers/specs/2026-07-14-asset-registry-and-extensions-design.md`). Version intentionally **not** bumped — this becomes 0.11.0 at release time.

## What's included

- **Asset registry** (`crud_views/lib/assets.py`): `register_assets(key, js=, css=, emit=)`, `get_registered()`, `AssetBundle`. Static paths resolve via `static()`; entries starting `http://`/`https://`/`//` render verbatim (CDN mode). Core assets render first, then registered bundles in registration order; duplicate key → `ImproperlyConfigured`; `emit=False` suppresses tag output for bundler setups.
- **`cv_js` / `cv_css` rendering** (`templatetags/crud_views.py` + shared `js.html`/`css.html`): merge core assets with registered bundles, resolving URLs in Python so the templates stay dumb. Empty-registry output is functionally unchanged (same URLs, count, order).
- **Vendor helper** (`crud_views/lib/vendor.py`): `VendorSpec` + `vendor()` (download + version stamp) + `check_vendored()` drift checks (**W330** missing files, **W331** version mismatch). Stdlib `urllib.request` only — no new runtime dependencies.
- **Plain-theme `{{ form.media }}` fix**: the plain theme renders forms via `{{ form.as_table }}` (no crispy), so widget media was silently dropped. All four plain form-rendering content templates (create / update / custom_form / delete) now emit `{{ form.media }}`. The bootstrap5 theme already emits media via crispy-forms and is unchanged.
- **Docs + changelog**: `docs/reference/assets.md` and a `## Unreleased` CHANGELOG section.

## Note on scope vs. the original plan

The plan's `form.media` task assumed the **bootstrap5 update view** silently lost widget media. On investigation that premise was false — bootstrap5 renders via `{% crispy %}`, which auto-emits `{{ form.media }}` (`include_media=True`) on every form view. The genuine bug was the **plain theme**, so the fix was re-scoped accordingly (bootstrap5 templates left untouched).

## Testing

- `pytest tests/test1/`: **474 passed, 1 skipped**
- Full nox matrix (`task test`): **8 sessions passed, 1 skipped** (Python 3.12/3.13/3.14 × Django 4.2/5.2/6.0; py3.14×Django4.2 unsupported)
- `ruff check` + `ruff format --check`: clean

## Follow-ups (non-blocking, not in this PR)

- `vendor.py`: add `urlopen(timeout=…)`; guard `json.loads(stamp)` in `check_vendored` so a corrupt stamp warns instead of raising inside a system check.
- Optional: `__all__` exports; a CSS-side `emit=False` test; remove the redundant explicit `{{ form.media }}` at bootstrap5 `view_create.content.html` (crispy already emits it → currently double-rendered).
