### PR TITLE
M2: API stability & backlog triage (0.14.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
   `super()` call to `cv_form_valid`. Part of #31; the configurable-transaction half of that
   issue is deferred to 1.x.
 
+### Added
+- API stability statement: `docs/development/stability.md` defines the public API surface
+  covered by semver from 1.0.0 on, the internal/public split (including the formsets
+  declaration surface), and the post-1.0 deprecation policy.
+
 ## 0.13.0
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
   `CrispyModelForm` and `CrispyForm` views. Migration: replace `CrispyModelViewMixin` with
   `CrispyViewMixin` in imports and view base-class lists.
 
+### Changed
+- **Breaking (workflow):** `WorkflowView` now executes its transition logic in `cv_form_valid`
+  instead of `cv_form_valid_hook`, matching the framework convention (framework work in
+  `cv_form_valid`, `cv_form_valid_hook` reserved for user subclasses). If a subclass overrides
+  `cv_form_valid_hook` and relied on `super()` running the transition there, move that
+  `super()` call to `cv_form_valid`. Part of #31; the configurable-transaction half of that
+  issue is deferred to 1.x.
+
 ## 0.13.0
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Django CRUD Views - Changelog
 
+## 0.14.0
+
+### Removed
+- **Breaking:** the deprecated `CrispyModelViewMixin` alias has been removed (#34). Use
+  `CrispyViewMixin` instead — it was always the implementing class, and it works for both
+  `CrispyModelForm` and `CrispyForm` views. Migration: replace `CrispyModelViewMixin` with
+  `CrispyViewMixin` in imports and view base-class lists.
+
 ## 0.13.0
 
 ### Removed

--- a/docs/development/stability.md
+++ b/docs/development/stability.md
@@ -1,0 +1,80 @@
+# API stability
+
+From release **1.0.0** on, django-crud-views follows [semantic versioning](https://semver.org/):
+breaking changes to the **public API** defined on this page only happen in major releases.
+This policy is effective as of 0.14.0 so that 1.0.0 can ship against a settled surface.
+
+## The rule
+
+The public API is the set of names listed below — the same names shown in the
+[reference documentation](../reference/index.md). Everything else is internal:
+
+- any module or name not listed here,
+- all names prefixed with an underscore (`_`),
+- template internals (block structure and context variables not documented in the reference),
+- anything imported *by* django-crud-views from its dependencies.
+
+Internal APIs may change in any release without notice.
+
+## Public API
+
+### `crud_views` (core)
+
+**ViewSets** — `crud_views.lib.viewset`:
+`ViewSet`, `ParentViewSet`
+
+**View base** — `crud_views.lib.view`:
+`CrudView`, `CrudViewPermissionRequiredMixin`
+
+**Views** — `crud_views.lib.views`:
+`ListView`, `DetailView`, `DetailCustomView`, `CreateView`, `UpdateView`, `DeleteView`,
+`ActionView`, `OrderedUpView`, `OrderedDownView`, `CustomFormView`, `CustomFormNoObjectView`,
+`CardListView`, `ManageView` — each with its `*PermissionRequired` variant — plus the mixins
+`CreateViewParentMixin`, `ListViewTableMixin`, `ListViewTableFilterMixin`, `MessageMixin`
+
+**Crispy forms integration** — `crud_views.lib.crispy`:
+`CrispyViewMixin`, `CrispyModelForm`, `CrispyForm`, `CrispyDeleteForm`,
+`Column1` … `Column12`
+
+**Formsets (declaration surface)** — `crud_views.lib.formsets`:
+`FormSetMixin`, `FormSets`, `FormSet`, `InlineFormSet`, `Formsets`, `FormControl` — i.e.
+exactly the names exported by the package. The formsets machinery behind them (rendering
+tree, per-formset plumbing) is internal, and stays internal in 1.0.
+
+**Resources** — `crud_views.lib.resource`:
+`Resource`, `ResourceViewMixin`
+
+**Settings**: all `CRUD_VIEWS_*` settings documented in the
+[settings reference](../reference/settings.md).
+
+**Template tags**: the tags documented in the reference for the `crud_views` and
+`crud_views_formsets` tag libraries.
+
+**Declared attributes and hooks**: the documented `cv_*` class attributes of the classes
+above, and the documented overridable hooks — e.g. `cv_form_valid` (framework work step),
+`cv_form_valid_hook` (user extension point), `cv_post_hook`, `cv_form_invalid_hook`,
+`cv_form_valid_redirect`.
+
+### `crud_views_workflow`
+
+`WorkflowView`, `WorkflowViewPermissionRequired`, `WorkflowModelMixin`, the `WorkflowInfo`
+model, and the `on_transition` hook.
+
+### `crud_views_polymorphic`
+
+`PolymorphicCreateSelectView`, `PolymorphicCreateView`, `PolymorphicUpdateView`,
+`PolymorphicDeleteView`, `PolymorphicDetailView` — each with its `*PermissionRequired`
+variant.
+
+### `crud_views_guardian`
+
+`GuardianViewSet`, `GuardianManageView`, and the `Guardian*PermissionRequired` view variants
+(list, card list, detail, detail custom, create, update, delete, action).
+
+## Deprecation policy (post-1.0)
+
+- Public-API breaking changes happen only in **major** releases.
+- A name slated for removal is deprecated first: it keeps working and emits a
+  `DeprecationWarning` for the remainder of the current major cycle, and is removed no
+  earlier than the next major release.
+- Every deprecation and removal is recorded in the CHANGELOG with a migration hint.

--- a/docs/getting_started/tutorial2.md
+++ b/docs/getting_started/tutorial2.md
@@ -8,7 +8,7 @@ Now let's add some other views.
 ```python
 from crispy_forms.layout import Row
 from crud_views.lib.views import CreateViewPermissionRequired, MessageMixin
-from crud_views.lib.crispy import Column4, CrispyModelForm, CrispyModelViewMixin, CrispyDeleteForm
+from crud_views.lib.crispy import Column4, CrispyModelForm, CrispyViewMixin, CrispyDeleteForm
 
 class AuthorCreateForm(CrispyModelForm):
 
@@ -20,7 +20,7 @@ class AuthorCreateForm(CrispyModelForm):
         return Row(Column4("first_name"), Column4("last_name"), Column4("pseudonym"))
 
     
-class AuthorCreateView(CrispyModelViewMixin, MessageMixin, CreateViewPermissionRequired):
+class AuthorCreateView(CrispyViewMixin, MessageMixin, CreateViewPermissionRequired):
     form_class = AuthorCreateForm
     vs = vs_author
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,12 @@ you're building a small project or a large application, Django CRUD Views can he
   [bring your own theme](reference/theme.md) to customize the look and feel
 - Django system checks for configurations to fail early on startup
 
+## API stability
+
+From 1.0.0 on, django-crud-views follows [semantic versioning](https://semver.org) with a
+[documented public API surface](development/stability.md): breaking changes to the public
+API only happen in major releases, and deprecations are announced ahead of removal.
+
 ## What it is not
 
 - a replacement for Django's admin interface

--- a/docs/reference/action_enabled.md
+++ b/docs/reference/action_enabled.md
@@ -55,7 +55,7 @@ views and `self.cv_get_parent_object()` for child-create views.
 ## Example: Locked Group Disables Member Add/Remove
 
 ```python
-class PersonDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionRequired):
+class PersonDeleteView(CrispyViewMixin, MessageMixin, DeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_person
     cv_message = "Deleted person »{object}«"
@@ -66,7 +66,7 @@ class PersonDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionR
         return not (obj and obj.group.filter(locked=True).exists())
 
 
-class PersonCreateView(CrispyModelViewMixin, MessageMixin, CreateViewParentMixin, CreateViewPermissionRequired):
+class PersonCreateView(CrispyViewMixin, MessageMixin, CreateViewParentMixin, CreateViewPermissionRequired):
     cv_viewset = cv_person
 
     @classmethod

--- a/docs/reference/create_view.md
+++ b/docs/reference/create_view.md
@@ -9,7 +9,7 @@ for form layout.
 ```python
 from crispy_forms.layout import Row
 from django.utils.translation import gettext as _
-from crud_views.lib.crispy import Column4, CrispyModelForm, CrispyModelViewMixin
+from crud_views.lib.crispy import Column4, CrispyModelForm, CrispyViewMixin
 from crud_views.lib.views import CreateViewPermissionRequired, MessageMixin
 from crud_views.lib.viewset import ViewSet
 from .models import Author
@@ -32,7 +32,7 @@ class AuthorCreateForm(CrispyModelForm):
         return Row(Column4("first_name"), Column4("last_name"), Column4("pseudonym"))
 
 
-class AuthorCreateView(CrispyModelViewMixin, MessageMixin, CreateViewPermissionRequired):
+class AuthorCreateView(CrispyViewMixin, MessageMixin, CreateViewPermissionRequired):
     form_class = AuthorCreateForm
     cv_viewset = cv_author
     cv_message = "Created author »{object}«"
@@ -94,7 +94,7 @@ class AuthorCreateForm(CrispyModelForm):
 Add `MessageMixin` to show a success message after creation:
 
 ```python
-class AuthorCreateView(CrispyModelViewMixin, MessageMixin, CreateViewPermissionRequired):
+class AuthorCreateView(CrispyViewMixin, MessageMixin, CreateViewPermissionRequired):
     form_class = AuthorCreateForm
     cv_viewset = cv_author
     cv_message = "Created author »{object}«"
@@ -110,7 +110,7 @@ set the parent reference:
 ```python
 from crud_views.lib.views import CreateViewParentMixin
 
-class BookCreateView(CrispyModelViewMixin, MessageMixin, CreateViewParentMixin, CreateViewPermissionRequired):
+class BookCreateView(CrispyViewMixin, MessageMixin, CreateViewParentMixin, CreateViewPermissionRequired):
     form_class = BookCreateForm
     cv_viewset = cv_book
 ```

--- a/docs/reference/custom_form_view.md
+++ b/docs/reference/custom_form_view.md
@@ -22,7 +22,7 @@ Define a form, then a view with `cv_key` and `cv_path` set:
 ```python
 from django.forms.fields import CharField
 from django.utils.translation import gettext as _
-from crud_views.lib.crispy import Column12, CrispyModelForm, CrispyModelViewMixin
+from crud_views.lib.crispy import Column12, CrispyModelForm, CrispyViewMixin
 from crud_views.lib.views import MessageMixin
 from crud_views.lib.views.form import CustomFormViewPermissionRequired
 from crud_views.lib.viewset import ViewSet
@@ -45,7 +45,7 @@ class AuthorContactForm(CrispyModelForm):
         return Column12("subject"), Column12("body")
 
 
-class AuthorContactView(MessageMixin, CrispyModelViewMixin, CustomFormViewPermissionRequired):
+class AuthorContactView(MessageMixin, CrispyViewMixin, CustomFormViewPermissionRequired):
     cv_key = "contact"
     cv_path = "contact"
     cv_icon_action = "fa-solid fa-envelope"
@@ -96,7 +96,7 @@ After `cv_form_valid_hook`, the view redirects to `cv_success_key` (default: `"l
 Combine with `MessageMixin` to display a flash message after a successful submission:
 
 ```python
-class AuthorContactView(MessageMixin, CrispyModelViewMixin, CustomFormViewPermissionRequired):
+class AuthorContactView(MessageMixin, CrispyViewMixin, CustomFormViewPermissionRequired):
     ...
     cv_message_template_code = "Successfully contacted author »{object}«"
 ```
@@ -108,7 +108,7 @@ Use `CustomFormNoObjectView` when the form is not tied to a specific model insta
 ```python
 from crud_views.lib.views.form import CustomFormNoObjectViewPermissionRequired
 
-class SiteFeedbackView(CrispyModelViewMixin, CustomFormNoObjectViewPermissionRequired):
+class SiteFeedbackView(CrispyViewMixin, CustomFormNoObjectViewPermissionRequired):
     cv_key = "feedback"
     cv_path = "feedback"
     cv_viewset = cv_site
@@ -119,14 +119,14 @@ class SiteFeedbackView(CrispyModelViewMixin, CustomFormNoObjectViewPermissionReq
         pass
 ```
 
-## CrispyModelViewMixin
+## CrispyViewMixin
 
-`CrispyModelViewMixin` (alias of `CrispyViewMixin`) enables crispy-forms support for the view's form. When added to a view, it passes the current view instance (`cv_view`) as an extra argument when constructing the form. This allows the form to generate context-aware submit and cancel buttons.
+`CrispyViewMixin` (alias of `CrispyViewMixin`) enables crispy-forms support for the view's form. When added to a view, it passes the current view instance (`cv_view`) as an extra argument when constructing the form. This allows the form to generate context-aware submit and cancel buttons.
 
 Add it to any view that uses a `CrispyModelForm` or `CrispyForm`:
 
 ```python
-class AuthorContactView(CrispyModelViewMixin, CustomFormViewPermissionRequired):
+class AuthorContactView(CrispyViewMixin, CustomFormViewPermissionRequired):
     form_class = AuthorContactForm  # must extend CrispyModelForm or CrispyForm
     ...
 ```

--- a/docs/reference/custom_form_view.md
+++ b/docs/reference/custom_form_view.md
@@ -121,7 +121,7 @@ class SiteFeedbackView(CrispyViewMixin, CustomFormNoObjectViewPermissionRequired
 
 ## CrispyViewMixin
 
-`CrispyViewMixin` (alias of `CrispyViewMixin`) enables crispy-forms support for the view's form. When added to a view, it passes the current view instance (`cv_view`) as an extra argument when constructing the form. This allows the form to generate context-aware submit and cancel buttons.
+`CrispyViewMixin` enables crispy-forms support for the view's form. When added to a view, it passes the current view instance (`cv_view`) as an extra argument when constructing the form. This allows the form to generate context-aware submit and cancel buttons.
 
 Add it to any view that uses a `CrispyModelForm` or `CrispyForm`:
 

--- a/docs/reference/delete_view.md
+++ b/docs/reference/delete_view.md
@@ -6,11 +6,11 @@ deleting.
 ## Basic Usage
 
 ```python
-from crud_views.lib.crispy import CrispyModelViewMixin, CrispyDeleteForm
+from crud_views.lib.crispy import CrispyViewMixin, CrispyDeleteForm
 from crud_views.lib.views import DeleteViewPermissionRequired, MessageMixin
 
 
-class AuthorDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionRequired):
+class AuthorDeleteView(CrispyViewMixin, MessageMixin, DeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_author
     cv_message = "Deleted author »{object}«"
@@ -45,7 +45,7 @@ the object is deleted:
 ```python
 from crud_views.lib.crispy import CrispyDeleteForm
 
-class AuthorDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionRequired):
+class AuthorDeleteView(CrispyViewMixin, MessageMixin, DeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_author
 ```
@@ -58,7 +58,7 @@ logic.
 Add `MessageMixin` to show a success message after deletion:
 
 ```python
-class AuthorDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionRequired):
+class AuthorDeleteView(CrispyViewMixin, MessageMixin, DeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_author
     cv_message = "Deleted author »{object}«"
@@ -77,7 +77,7 @@ Show users what related objects will be deleted when they delete an object (simi
 This feature is opt-in.
 
 ```python
-class PublisherDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionRequired):
+class PublisherDeleteView(CrispyViewMixin, MessageMixin, DeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_publisher
     cv_show_related_objects = True  # show what will be cascade-deleted
@@ -94,7 +94,7 @@ When enabled, the delete confirmation page displays:
 Optionally render related objects as links to their detail views:
 
 ```python
-class PublisherDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionRequired):
+class PublisherDeleteView(CrispyViewMixin, MessageMixin, DeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_publisher
     cv_show_related_objects = True
@@ -130,7 +130,7 @@ Add custom business logic to prevent deletion.
 Override `cv_check_delete_protection()` to return error messages:
 
 ```python
-class PublisherDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionRequired):
+class PublisherDeleteView(CrispyViewMixin, MessageMixin, DeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_publisher
 

--- a/docs/reference/guardian.md
+++ b/docs/reference/guardian.md
@@ -186,7 +186,7 @@ list is filtered using per-object `view` permissions instead of model-level perm
 - Objects the user lacks per-object `view` permission for: shown as aggregated counts
 
 ```python
-class PublisherDeleteView(CrispyModelViewMixin, GuardianDeleteViewPermissionRequired):
+class PublisherDeleteView(CrispyViewMixin, GuardianDeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_publisher
     cv_show_related_objects = True

--- a/docs/reference/modals.md
+++ b/docs/reference/modals.md
@@ -4,7 +4,7 @@ Views can opt in to Bootstrap 5 modal rendering: action buttons then open the vi
 dialog instead of navigating to a full page.
 
 ```python
-class AuthorDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionRequired):
+class AuthorDeleteView(CrispyViewMixin, MessageMixin, DeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_author
     cv_modal = True                 # opt in

--- a/docs/reference/polymorphic_view.md
+++ b/docs/reference/polymorphic_view.md
@@ -53,7 +53,7 @@ class Truck(Vehicle):
 from django.forms import modelform_factory
 
 from crud_views.lib.viewset import ViewSet
-from crud_views.lib.crispy import CrispyModelViewMixin
+from crud_views.lib.crispy import CrispyViewMixin
 from crud_views.lib.crispy.form import CrispyDeleteForm
 from crud_views_polymorphic.lib import (
     PolymorphicCreateViewPermissionRequired,
@@ -72,12 +72,12 @@ CarForm = modelform_factory(Car, fields=["name", "doors"])
 TruckForm = modelform_factory(Truck, fields=["name", "payload_tons"])
 
 
-class VehicleCreateSelectView(CrispyModelViewMixin, PolymorphicCreateSelectViewPermissionRequired):
+class VehicleCreateSelectView(CrispyViewMixin, PolymorphicCreateSelectViewPermissionRequired):
     form_class = PolymorphicContentTypeForm
     cv_viewset = cv_vehicle
 
 
-class VehicleCreateView(CrispyModelViewMixin, PolymorphicCreateViewPermissionRequired):
+class VehicleCreateView(CrispyViewMixin, PolymorphicCreateViewPermissionRequired):
     cv_viewset = cv_vehicle
     polymorphic_forms = {
         Car: CarForm,
@@ -85,7 +85,7 @@ class VehicleCreateView(CrispyModelViewMixin, PolymorphicCreateViewPermissionReq
     }
 
 
-class VehicleUpdateView(CrispyModelViewMixin, PolymorphicUpdateViewPermissionRequired):
+class VehicleUpdateView(CrispyViewMixin, PolymorphicUpdateViewPermissionRequired):
     cv_viewset = cv_vehicle
     polymorphic_forms = {
         Car: CarForm,
@@ -93,7 +93,7 @@ class VehicleUpdateView(CrispyModelViewMixin, PolymorphicUpdateViewPermissionReq
     }
 
 
-class VehicleDeleteView(CrispyModelViewMixin, PolymorphicDeleteViewPermissionRequired):
+class VehicleDeleteView(CrispyViewMixin, PolymorphicDeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_vehicle
 

--- a/docs/reference/resources.md
+++ b/docs/reference/resources.md
@@ -283,12 +283,12 @@ There is no `DeleteView` port for Resources — `CustomFormView` plus a
 required before the `POST` is accepted):
 
 ```python
-from crud_views.lib.crispy import CrispyDeleteForm, CrispyModelViewMixin
+from crud_views.lib.crispy import CrispyDeleteForm, CrispyViewMixin
 from crud_views.lib.views import MessageMixin
 from crud_views.lib.views.form import CustomFormViewPermissionRequired
 
 
-class S3FileDeleteView(ResourceViewMixin, CrispyModelViewMixin, MessageMixin, CustomFormViewPermissionRequired):
+class S3FileDeleteView(ResourceViewMixin, CrispyViewMixin, MessageMixin, CustomFormViewPermissionRequired):
     cv_key = "delete"
     cv_path = "delete"
     cv_viewset = cv_s3file

--- a/docs/reference/update_view.md
+++ b/docs/reference/update_view.md
@@ -8,7 +8,7 @@ the [CreateView](create_view.md), using Django's form handling and
 
 ```python
 from django.utils.translation import gettext as _
-from crud_views.lib.crispy import CrispyModelForm, CrispyModelViewMixin, Column4
+from crud_views.lib.crispy import CrispyModelForm, CrispyViewMixin, Column4
 from crud_views.lib.views import UpdateViewPermissionRequired, MessageMixin
 from crispy_forms.layout import Row
 
@@ -24,7 +24,7 @@ class AuthorUpdateForm(CrispyModelForm):
         return Row(Column4("first_name"), Column4("last_name"), Column4("pseudonym"))
 
 
-class AuthorUpdateView(CrispyModelViewMixin, MessageMixin, UpdateViewPermissionRequired):
+class AuthorUpdateView(CrispyViewMixin, MessageMixin, UpdateViewPermissionRequired):
     form_class = AuthorUpdateForm
     cv_viewset = cv_author
     cv_message = "Updated author »{object}«"
@@ -75,7 +75,7 @@ class AuthorUpdateForm(AuthorCreateForm):
 Add `MessageMixin` to show a success message after updating:
 
 ```python
-class AuthorUpdateView(CrispyModelViewMixin, MessageMixin, UpdateViewPermissionRequired):
+class AuthorUpdateView(CrispyViewMixin, MessageMixin, UpdateViewPermissionRequired):
     form_class = AuthorUpdateForm
     cv_viewset = cv_author
     cv_message = "Updated author »{object}«"

--- a/docs/reference/workflow_view.md
+++ b/docs/reference/workflow_view.md
@@ -102,7 +102,7 @@ class Campaign(WorkflowModelMixin, models.Model):
 ### 2. Define the ViewSet and views
 
 ```python
-from crud_views.lib.crispy import CrispyModelViewMixin
+from crud_views.lib.crispy import CrispyViewMixin
 from crud_views.lib.views import MessageMixin
 from crud_views.lib.viewset import ViewSet
 from crud_views_workflow.lib.forms import WorkflowForm
@@ -117,7 +117,7 @@ class CampaignWorkflowForm(WorkflowForm):
         model = Campaign
 
 
-class CampaignWorkflowView(CrispyModelViewMixin, MessageMixin, WorkflowView):
+class CampaignWorkflowView(CrispyViewMixin, MessageMixin, WorkflowView):
     cv_context_actions = ["list", "detail", "workflow"]
     cv_viewset = cv_campaign
     form_class = CampaignWorkflowForm
@@ -149,7 +149,7 @@ Use `WorkflowViewPermissionRequired` for production views:
 ```python
 from crud_views_workflow.lib.views import WorkflowViewPermissionRequired
 
-class CampaignWorkflowView(CrispyModelViewMixin, MessageMixin, WorkflowViewPermissionRequired):
+class CampaignWorkflowView(CrispyViewMixin, MessageMixin, WorkflowViewPermissionRequired):
     cv_context_actions = ["list", "detail", "workflow"]
     cv_viewset = cv_campaign
     form_class = CampaignWorkflowForm
@@ -324,7 +324,7 @@ from `CrudViewPermissionRequiredMixin`.
 Override `on_transition` to run custom logic after a successful transition:
 
 ```python
-class CampaignWorkflowView(CrispyModelViewMixin, MessageMixin, WorkflowView):
+class CampaignWorkflowView(CrispyViewMixin, MessageMixin, WorkflowView):
     cv_viewset = cv_campaign
     form_class = CampaignWorkflowForm
 

--- a/examples/bootstrap5/app/views/author.py
+++ b/examples/bootstrap5/app/views/author.py
@@ -5,7 +5,7 @@ from django.forms.fields import CharField
 from django.utils.translation import gettext_lazy as _
 
 from app.models import Author
-from crud_views.lib.crispy import Column4, CrispyModelForm, CrispyModelViewMixin, CrispyDeleteForm, Column12
+from crud_views.lib.crispy import Column4, CrispyModelForm, CrispyViewMixin, CrispyDeleteForm, Column12
 from crud_views.lib.table import Table, LinkChildColumn, UUIDLinkDetailColumn
 from crud_views.lib.table.columns import NaturalTimeColumn, NaturalDayColumn
 from crud_views.lib.views import (
@@ -92,19 +92,19 @@ class AuthorListView(ListViewTableMixin, ListViewTableFilterMixin, GuardianListV
     cv_context_actions = GuardianListViewPermissionRequired.cv_context_actions
 
 
-class AuthorCreateView(CrispyModelViewMixin, MessageMixin, GuardianCreateViewPermissionRequired):
+class AuthorCreateView(CrispyViewMixin, MessageMixin, GuardianCreateViewPermissionRequired):
     form_class = AuthorCreateForm
     cv_viewset = cv_author
     cv_message = _("Created author »{object}«")
 
 
-class AuthorUpdateView(CrispyModelViewMixin, MessageMixin, GuardianUpdateViewPermissionRequired):
+class AuthorUpdateView(CrispyViewMixin, MessageMixin, GuardianUpdateViewPermissionRequired):
     form_class = AuthorUpdateForm
     cv_viewset = cv_author
     cv_message = _("Updated author »{object}«")
 
 
-class AuthorDeleteView(CrispyModelViewMixin, MessageMixin, GuardianDeleteViewPermissionRequired):
+class AuthorDeleteView(CrispyViewMixin, MessageMixin, GuardianDeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_author
     cv_message = _("Deleted author »{object}«")
@@ -183,7 +183,7 @@ class AuthorContactForm(CrispyModelForm):
         return Column12("subject"), Column12("body")
 
 
-class AuthorContactView(MessageMixin, CrispyModelViewMixin, CustomFormViewPermissionRequired):
+class AuthorContactView(MessageMixin, CrispyViewMixin, CustomFormViewPermissionRequired):
     cv_key = "contact"
     cv_path = "contact"
     cv_icon_action = "fa-solid fa-envelope"

--- a/examples/bootstrap5/app/views/bar.py
+++ b/examples/bootstrap5/app/views/bar.py
@@ -3,7 +3,7 @@ from crispy_forms.layout import Row
 from django.utils.translation import gettext_lazy as _
 
 from app.models import Bar
-from crud_views.lib.crispy import CrispyModelForm, Column4, CrispyModelViewMixin, CrispyDeleteForm
+from crud_views.lib.crispy import CrispyModelForm, Column4, CrispyViewMixin, CrispyDeleteForm
 from crud_views.lib.table import Table, LinkChildColumn, LinkDetailColumn
 from crud_views.lib.views import (
     DetailViewPermissionRequired,
@@ -77,20 +77,20 @@ class BarDetailView(DetailViewPermissionRequired):
     ]
 
 
-class BarUpdateView(CrispyModelViewMixin, UpdateViewPermissionRequired):
+class BarUpdateView(CrispyViewMixin, UpdateViewPermissionRequired):
     model = Bar
     form_class = BarForm
 
     cv_viewset = cv_bar
 
 
-class BarCreateView(CrispyModelViewMixin, CreateViewParentMixin, CreateViewPermissionRequired):
+class BarCreateView(CrispyViewMixin, CreateViewParentMixin, CreateViewPermissionRequired):
     model = Bar
     form_class = BarForm
     cv_viewset = cv_bar
 
 
-class BarDeleteView(CrispyModelViewMixin, DeleteViewPermissionRequired):
+class BarDeleteView(CrispyViewMixin, DeleteViewPermissionRequired):
     model = Bar
     form_class = CrispyDeleteForm
     cv_viewset = cv_bar

--- a/examples/bootstrap5/app/views/baz.py
+++ b/examples/bootstrap5/app/views/baz.py
@@ -3,7 +3,7 @@ from crispy_forms.layout import Row
 from django.utils.translation import gettext_lazy as _
 
 from app.models import Baz
-from crud_views.lib.crispy import CrispyModelForm, Column4, CrispyModelViewMixin, CrispyDeleteForm
+from crud_views.lib.crispy import CrispyModelForm, Column4, CrispyViewMixin, CrispyDeleteForm
 from crud_views.lib.table import Table, LinkDetailColumn
 from crud_views.lib.views import (
     DetailViewPermissionRequired,
@@ -61,20 +61,20 @@ class BazDetailView(DetailViewPermissionRequired):
     ]
 
 
-class BazUpdateView(CrispyModelViewMixin, UpdateViewPermissionRequired):
+class BazUpdateView(CrispyViewMixin, UpdateViewPermissionRequired):
     model = Baz
     form_class = BazForm
 
     cv_viewset = cv_baz
 
 
-class BazCreateView(CrispyModelViewMixin, CreateViewParentMixin, CreateViewPermissionRequired):
+class BazCreateView(CrispyViewMixin, CreateViewParentMixin, CreateViewPermissionRequired):
     model = Baz
     form_class = BazForm
     cv_viewset = cv_baz
 
 
-class BazDeleteView(CrispyModelViewMixin, DeleteViewPermissionRequired):
+class BazDeleteView(CrispyViewMixin, DeleteViewPermissionRequired):
     model = Baz
     form_class = CrispyDeleteForm
     cv_viewset = cv_baz

--- a/examples/bootstrap5/app/views/book.py
+++ b/examples/bootstrap5/app/views/book.py
@@ -3,7 +3,7 @@ from crispy_forms.layout import Row, Layout
 from django.utils.translation import gettext_lazy as _
 
 from app.models import Book
-from crud_views.lib.crispy import CrispyModelForm, Column4, Column2, CrispyModelViewMixin, CrispyDeleteForm
+from crud_views.lib.crispy import CrispyModelForm, Column4, Column2, CrispyViewMixin, CrispyDeleteForm
 from crud_views.lib.view import CardAction
 from crud_views.lib.views import (
     ListViewTableFilterMixin,
@@ -86,7 +86,7 @@ class BookDetailView(GuardianDetailCustomViewPermissionRequired):
     template_name = "app/book_detail.html"
 
 
-class BookUpdateView(CrispyModelViewMixin, MessageMixin, GuardianUpdateViewPermissionRequired):
+class BookUpdateView(CrispyViewMixin, MessageMixin, GuardianUpdateViewPermissionRequired):
     form_class = BookUpdateForm
     cv_viewset = cv_book
     cv_context_actions = ["card", "detail", "update", "delete"]
@@ -94,7 +94,7 @@ class BookUpdateView(CrispyModelViewMixin, MessageMixin, GuardianUpdateViewPermi
     cv_cancel_key = "card"
 
 
-class BookCreateView(CrispyModelViewMixin, MessageMixin, CreateViewParentMixin, GuardianCreateViewPermissionRequired):
+class BookCreateView(CrispyViewMixin, MessageMixin, CreateViewParentMixin, GuardianCreateViewPermissionRequired):
     form_class = BookCreateForm
     cv_viewset = cv_book
     cv_context_actions = ["card", "create"]
@@ -102,7 +102,7 @@ class BookCreateView(CrispyModelViewMixin, MessageMixin, CreateViewParentMixin, 
     cv_cancel_key = "card"
 
 
-class BookDeleteView(CrispyModelViewMixin, MessageMixin, GuardianDeleteViewPermissionRequired):
+class BookDeleteView(CrispyViewMixin, MessageMixin, GuardianDeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_book
     cv_context_actions = ["card", "detail", "update", "delete"]

--- a/examples/bootstrap5/app/views/book_review.py
+++ b/examples/bootstrap5/app/views/book_review.py
@@ -1,7 +1,7 @@
 from django.utils.translation import gettext_lazy as _
 
 from app.models import BookReview
-from crud_views.lib.crispy import CrispyModelForm, CrispyDeleteForm, CrispyModelViewMixin, Column4, Column6
+from crud_views.lib.crispy import CrispyModelForm, CrispyDeleteForm, CrispyViewMixin, Column4, Column6
 from crud_views.lib.view import CardAction
 from crud_views.lib.views import (
     CreateViewParentMixin,
@@ -67,18 +67,16 @@ class BookReviewDetailView(GuardianDetailViewPermissionRequired):
     ]
 
 
-class BookReviewCreateView(
-    CrispyModelViewMixin, MessageMixin, CreateViewParentMixin, GuardianCreateViewPermissionRequired
-):
+class BookReviewCreateView(CrispyViewMixin, MessageMixin, CreateViewParentMixin, GuardianCreateViewPermissionRequired):
     form_class = BookReviewForm
     cv_viewset = cv_book_review
 
 
-class BookReviewUpdateView(CrispyModelViewMixin, MessageMixin, GuardianUpdateViewPermissionRequired):
+class BookReviewUpdateView(CrispyViewMixin, MessageMixin, GuardianUpdateViewPermissionRequired):
     form_class = BookReviewForm
     cv_viewset = cv_book_review
 
 
-class BookReviewDeleteView(CrispyModelViewMixin, MessageMixin, GuardianDeleteViewPermissionRequired):
+class BookReviewDeleteView(CrispyViewMixin, MessageMixin, GuardianDeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_book_review

--- a/examples/bootstrap5/app/views/campaign.py
+++ b/examples/bootstrap5/app/views/campaign.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext_lazy as _
 from django_object_detail import PropertyConfig
 
 from app.models.campaign import Campaign
-from crud_views.lib.crispy import CrispyModelForm, Column4, CrispyModelViewMixin, CrispyDeleteForm
+from crud_views.lib.crispy import CrispyModelForm, Column4, CrispyViewMixin, CrispyDeleteForm
 from crud_views.lib.table import Table, LinkDetailColumn
 from crud_views.lib.views import (
     DetailViewPermissionRequired,
@@ -68,18 +68,18 @@ class CampaignDetailView(DetailViewPermissionRequired):
     ]
 
 
-class CampaignUpdateView(CrispyModelViewMixin, MessageMixin, UpdateViewPermissionRequired):
+class CampaignUpdateView(CrispyViewMixin, MessageMixin, UpdateViewPermissionRequired):
     cv_context_actions = ["home", "detail", "update", "workflow", "delete"]
     form_class = CampaignUpdateForm
     cv_viewset = cv_campaign
 
 
-class CampaignCreateView(CrispyModelViewMixin, MessageMixin, CreateViewPermissionRequired):
+class CampaignCreateView(CrispyViewMixin, MessageMixin, CreateViewPermissionRequired):
     form_class = CampaignForm
     cv_viewset = cv_campaign
 
 
-class CampaignDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionRequired):
+class CampaignDeleteView(CrispyViewMixin, MessageMixin, DeleteViewPermissionRequired):
     cv_context_actions = ["home", "detail", "update", "workflow", "delete"]
     form_class = CrispyDeleteForm
     cv_viewset = cv_campaign
@@ -90,7 +90,7 @@ class CampaignWorkflowForm(WorkflowForm):
         model = Campaign
 
 
-class CampaignWorkflowView(CrispyModelViewMixin, MessageMixin, WorkflowViewPermissionRequired):
+class CampaignWorkflowView(CrispyViewMixin, MessageMixin, WorkflowViewPermissionRequired):
     cv_context_actions = ["list", "detail", "update", "workflow"]
     cv_viewset = cv_campaign
     form_class = CampaignWorkflowForm

--- a/examples/bootstrap5/app/views/detail.py
+++ b/examples/bootstrap5/app/views/detail.py
@@ -3,7 +3,7 @@ from crispy_forms.layout import Row, Fieldset
 from django.utils.translation import gettext_lazy as _
 
 from app.models import Author, Detail
-from crud_views.lib.crispy import Column4, CrispyModelForm, CrispyModelViewMixin, CrispyDeleteForm, Column8
+from crud_views.lib.crispy import Column4, CrispyModelForm, CrispyViewMixin, CrispyDeleteForm, Column8
 from crud_views.lib.table import Table, UUIDLinkDetailColumn
 from crud_views.lib.views import (
     DetailViewPermissionRequired,
@@ -47,21 +47,21 @@ class DetailListView(ListViewTableMixin, ListViewPermissionRequired):
     table_class = DetailTable
 
 
-class DetailCreateView(CrispyModelViewMixin, MessageMixin, CreateViewPermissionRequired):
+class DetailCreateView(CrispyViewMixin, MessageMixin, CreateViewPermissionRequired):
     model = Author
     form_class = DetailForm
     cv_viewset = cv_detail
     cv_message = _("Created detail »{object}«")
 
 
-class DetailUpdateView(CrispyModelViewMixin, MessageMixin, UpdateViewPermissionRequired):
+class DetailUpdateView(CrispyViewMixin, MessageMixin, UpdateViewPermissionRequired):
     model = Detail
     form_class = DetailForm
     cv_viewset = cv_detail
     cv_message = _("Updated detail »{object}«")
 
 
-class DetailDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionRequired):
+class DetailDeleteView(CrispyViewMixin, MessageMixin, DeleteViewPermissionRequired):
     model = Detail
     form_class = CrispyDeleteForm
     cv_viewset = cv_detail

--- a/examples/bootstrap5/app/views/foo.py
+++ b/examples/bootstrap5/app/views/foo.py
@@ -3,7 +3,7 @@ from crispy_forms.layout import Row
 from django.utils.translation import gettext_lazy as _
 
 from app.models import Foo
-from crud_views.lib.crispy import CrispyModelForm, Column4, CrispyModelViewMixin, CrispyDeleteForm
+from crud_views.lib.crispy import CrispyModelForm, Column4, CrispyViewMixin, CrispyDeleteForm
 from crud_views.lib.table import Table, LinkChildColumn, LinkDetailColumn
 from crud_views.lib.views import (
     DetailViewPermissionRequired,
@@ -59,19 +59,19 @@ class FooDetailView(DetailViewPermissionRequired):
     ]
 
 
-class FooUpdateView(CrispyModelViewMixin, UpdateViewPermissionRequired):
+class FooUpdateView(CrispyViewMixin, UpdateViewPermissionRequired):
     model = Foo
     form_class = FooForm
     cv_viewset = cv_foo
 
 
-class FooCreateView(CrispyModelViewMixin, CreateViewPermissionRequired):
+class FooCreateView(CrispyViewMixin, CreateViewPermissionRequired):
     model = Foo
     form_class = FooForm
     cv_viewset = cv_foo
 
 
-class FooDeleteView(CrispyModelViewMixin, DeleteViewPermissionRequired):
+class FooDeleteView(CrispyViewMixin, DeleteViewPermissionRequired):
     model = Foo
     form_class = CrispyDeleteForm
     cv_viewset = cv_foo

--- a/examples/bootstrap5/app/views/formset/__init__.py
+++ b/examples/bootstrap5/app/views/formset/__init__.py
@@ -10,7 +10,7 @@ from django.forms.models import inlineformset_factory
 from django.utils.translation import gettext_lazy as _
 
 from app.models.poly import Poly, PolyOne, PolyTwo, PolyTwoChoice, PolyThree, PolyAnswerText, PolyAnswerNumber
-from crud_views.lib.crispy import Column4, CrispyModelViewMixin, Column8
+from crud_views.lib.crispy import Column4, CrispyViewMixin, Column8
 from crud_views.lib.crispy.form import CrispyForm, CrispyModelForm
 from crud_views.lib.formsets import FormSet, FormSets, InlineFormSet
 from crud_views.lib.formsets.mixins import PolymorphicFormSetsViewMixin
@@ -129,14 +129,14 @@ class CrispyPolymorphicContentTypeForm(CrispyForm, PolymorphicContentTypeForm):
         return Row(Column4("polymorphic_ctype_id"))
 
 
-class PolyCreateSelectView(CrispyModelViewMixin, PolymorphicCreateSelectView):
+class PolyCreateSelectView(CrispyViewMixin, PolymorphicCreateSelectView):
     model = Poly
     form_class = CrispyPolymorphicContentTypeForm
     cv_viewset = cv_poly_formset
 
 
 class PolyCreateView(
-    CrispyModelViewMixin, CreateViewParentMixin, PolymorphicFormSetsViewMixin, PolymorphicCreateViewPermissionRequired
+    CrispyViewMixin, CreateViewParentMixin, PolymorphicFormSetsViewMixin, PolymorphicCreateViewPermissionRequired
 ):
     model = Poly
     cv_viewset = cv_poly_formset
@@ -161,7 +161,7 @@ class PolyCreateView(
             PolyAnswerNumber.objects.create(poly=self.object)
 
 
-class PolyUpdateView(CrispyModelViewMixin, PolymorphicFormSetsViewMixin, PolymorphicUpdateViewPermissionRequired):
+class PolyUpdateView(CrispyViewMixin, PolymorphicFormSetsViewMixin, PolymorphicUpdateViewPermissionRequired):
     model = Poly
     cv_viewset = cv_poly_formset
     cv_formsets_required: bool = False

--- a/examples/bootstrap5/app/views/formset/parent.py
+++ b/examples/bootstrap5/app/views/formset/parent.py
@@ -3,7 +3,7 @@ from crispy_forms.layout import Row
 from django.utils.translation import gettext_lazy as _
 
 from app.models.poly import Parent
-from crud_views.lib.crispy import CrispyModelViewMixin, CrispyDeleteForm, CrispyModelForm, Column4
+from crud_views.lib.crispy import CrispyViewMixin, CrispyDeleteForm, CrispyModelForm, Column4
 from crud_views.lib.table import Table, UUIDLinkDetailColumn
 from crud_views.lib.views import (
     ListViewTableMixin,
@@ -60,19 +60,19 @@ class ParentDetailView(DetailViewPermissionRequired):
     ]
 
 
-class ParentCreateView(CrispyModelViewMixin, CreateViewPermissionRequired):
+class ParentCreateView(CrispyViewMixin, CreateViewPermissionRequired):
     model = Parent
     form_class = ParentForm
     cv_viewset = cv_poly_parent_formset
 
 
-class ParentUpdateView(CrispyModelViewMixin, UpdateViewPermissionRequired):
+class ParentUpdateView(CrispyViewMixin, UpdateViewPermissionRequired):
     model = Parent
     form_class = ParentForm
     cv_viewset = cv_poly_parent_formset
 
 
-class ParentDeleteView(CrispyModelViewMixin, DeleteViewPermissionRequired):
+class ParentDeleteView(CrispyViewMixin, DeleteViewPermissionRequired):
     model = Parent
     form_class = CrispyDeleteForm
     cv_viewset = cv_poly_parent_formset

--- a/examples/bootstrap5/app/views/formset/question.py
+++ b/examples/bootstrap5/app/views/formset/question.py
@@ -4,7 +4,7 @@ from typing import List
 import django_tables2 as tables
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Row, LayoutObject
-from crud_views.lib.crispy import CrispyModelForm, Column4, CrispyModelViewMixin, CrispyDeleteForm, Column8
+from crud_views.lib.crispy import CrispyModelForm, Column4, CrispyViewMixin, CrispyDeleteForm, Column8
 from crud_views.lib.table import Table, LinkDetailColumn
 from crud_views.lib.views import (
     DetailViewPermissionRequired,
@@ -205,21 +205,21 @@ cv_formsets: FormSets = FormSets(
 )
 
 
-class QuestionUpdateView(CrispyModelViewMixin, FormSetMixin, UpdateViewPermissionRequired):
+class QuestionUpdateView(CrispyViewMixin, FormSetMixin, UpdateViewPermissionRequired):
     model = Question
     form_class = QuestionForm
     cv_viewset = cv_question
     cv_formsets: FormSets = cv_formsets
 
 
-class QuestionCreateView(CrispyModelViewMixin, FormSetMixin, CreateViewPermissionRequired):
+class QuestionCreateView(CrispyViewMixin, FormSetMixin, CreateViewPermissionRequired):
     model = Question
     form_class = QuestionForm
     cv_viewset = cv_question
     cv_formsets: FormSets = cv_formsets
 
 
-class QuestionDeleteView(CrispyModelViewMixin, DeleteViewPermissionRequired):
+class QuestionDeleteView(CrispyViewMixin, DeleteViewPermissionRequired):
     model = Question
     form_class = CrispyDeleteForm
     cv_viewset = cv_question

--- a/examples/bootstrap5/app/views/group.py
+++ b/examples/bootstrap5/app/views/group.py
@@ -3,7 +3,7 @@ from crispy_forms.layout import Row
 from django.utils.translation import gettext_lazy as _
 
 from app.models import Group
-from crud_views.lib.crispy import Column4, CrispyModelForm, CrispyModelViewMixin, CrispyDeleteForm
+from crud_views.lib.crispy import Column4, CrispyModelForm, CrispyViewMixin, CrispyDeleteForm
 from crud_views.lib.table import Table, LinkDetailColumn
 from crud_views.lib.views import (
     DetailViewPermissionRequired,
@@ -53,21 +53,21 @@ class GroupListView(ListViewTableMixin, ListViewPermissionRequired):
     table_class = GroupTable
 
 
-class GroupCreateView(CrispyModelViewMixin, MessageMixin, CreateViewPermissionRequired):
+class GroupCreateView(CrispyViewMixin, MessageMixin, CreateViewPermissionRequired):
     model = Group
     form_class = GroupCreateForm
     cv_viewset = cv_group
     cv_message = _("Created group »{object}«")
 
 
-class GroupUpdateView(CrispyModelViewMixin, MessageMixin, UpdateViewPermissionRequired):
+class GroupUpdateView(CrispyViewMixin, MessageMixin, UpdateViewPermissionRequired):
     model = Group
     form_class = GroupUpdateForm
     cv_viewset = cv_group
     cv_message = _("Updated group »{object}«")
 
 
-class GroupDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionRequired):
+class GroupDeleteView(CrispyViewMixin, MessageMixin, DeleteViewPermissionRequired):
     model = Group
     form_class = CrispyDeleteForm
     cv_viewset = cv_group

--- a/examples/bootstrap5/app/views/group_members.py
+++ b/examples/bootstrap5/app/views/group_members.py
@@ -5,7 +5,7 @@ from crispy_forms.layout import Row
 from django.utils.translation import gettext_lazy as _
 
 from app.models import Person
-from crud_views.lib.crispy import Column4, CrispyModelForm, CrispyModelViewMixin, CrispyDeleteForm
+from crud_views.lib.crispy import Column4, CrispyModelForm, CrispyViewMixin, CrispyDeleteForm
 from crud_views.lib.table import Table, LinkDetailColumn
 from crud_views.lib.views import (
     DetailViewPermissionRequired,
@@ -62,7 +62,7 @@ class PersonListView(ListViewTableMixin, ListViewPermissionRequired):
     table_class = PersonTable
 
 
-class PersonCreateView(CrispyModelViewMixin, MessageMixin, CreateViewParentMixin, CreateViewPermissionRequired):
+class PersonCreateView(CrispyViewMixin, MessageMixin, CreateViewParentMixin, CreateViewPermissionRequired):
     model = Person
     form_class = PersonForm
     cv_viewset = cv_person
@@ -79,14 +79,14 @@ class PersonCreateView(CrispyModelViewMixin, MessageMixin, CreateViewParentMixin
         return defaults
 
 
-class PersonUpdateView(CrispyModelViewMixin, MessageMixin, UpdateViewPermissionRequired):
+class PersonUpdateView(CrispyViewMixin, MessageMixin, UpdateViewPermissionRequired):
     model = Person
     form_class = PersonForm
     cv_viewset = cv_person
     cv_message = _("Updated person »{object}«")
 
 
-class PersonDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionRequired):
+class PersonDeleteView(CrispyViewMixin, MessageMixin, DeleteViewPermissionRequired):
     model = Person
     form_class = CrispyDeleteForm
     cv_viewset = cv_person

--- a/examples/bootstrap5/app/views/poly/__init__.py
+++ b/examples/bootstrap5/app/views/poly/__init__.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext_lazy as _
 from app.models.poly import Poly, PolyOne, PolyTwo
 from app.views.poly.one import PolyOneForm
 from app.views.poly.two import PolyTwoForm
-from crud_views.lib.crispy import Column4, CrispyModelViewMixin
+from crud_views.lib.crispy import Column4, CrispyViewMixin
 from crud_views.lib.crispy.form import CrispyForm
 from crud_views_polymorphic.lib import (
     PolymorphicCreateSelectView,
@@ -45,20 +45,20 @@ class CrispyPolymorphicContentTypeForm(CrispyForm, PolymorphicContentTypeForm):
         return Row(Column4("polymorphic_ctype_id"))
 
 
-class PolyCreateSelectView(CrispyModelViewMixin, PolymorphicCreateSelectView):
+class PolyCreateSelectView(CrispyViewMixin, PolymorphicCreateSelectView):
     model = Poly
     form_class = CrispyPolymorphicContentTypeForm
     cv_viewset = cv_poly
 
 
-class PolyCreateView(CrispyModelViewMixin, PolymorphicCreateViewPermissionRequired):
+class PolyCreateView(CrispyViewMixin, PolymorphicCreateViewPermissionRequired):
     model = Poly
     cv_viewset = cv_poly
     cv_context_actions = ["home"]
     polymorphic_forms = {PolyOne: PolyOneForm, PolyTwo: PolyTwoForm}
 
 
-class PolyUpdateView(CrispyModelViewMixin, PolymorphicUpdateViewPermissionRequired):
+class PolyUpdateView(CrispyViewMixin, PolymorphicUpdateViewPermissionRequired):
     model = Poly
     cv_viewset = cv_poly
     polymorphic_forms = {PolyOne: PolyOneForm, PolyTwo: PolyTwoForm}

--- a/examples/bootstrap5/app/views/qux.py
+++ b/examples/bootstrap5/app/views/qux.py
@@ -3,7 +3,7 @@ from crispy_forms.layout import Row
 from django.utils.translation import gettext_lazy as _
 
 from app.models import Qux
-from crud_views.lib.crispy import CrispyModelForm, Column4, CrispyModelViewMixin, CrispyDeleteForm
+from crud_views.lib.crispy import CrispyModelForm, Column4, CrispyViewMixin, CrispyDeleteForm
 from crud_views.lib.table import Table, LinkDetailColumn
 from crud_views.lib.view import SiblingContextButton
 from crud_views.lib.views import (
@@ -66,19 +66,19 @@ class QuxDetailView(DetailViewPermissionRequired):
     ]
 
 
-class QuxUpdateView(CrispyModelViewMixin, UpdateViewPermissionRequired):
+class QuxUpdateView(CrispyViewMixin, UpdateViewPermissionRequired):
     model = Qux
     form_class = QuxForm
     cv_viewset = cv_qux
 
 
-class QuxCreateView(CrispyModelViewMixin, CreateViewParentMixin, CreateViewPermissionRequired):
+class QuxCreateView(CrispyViewMixin, CreateViewParentMixin, CreateViewPermissionRequired):
     model = Qux
     form_class = QuxForm
     cv_viewset = cv_qux
 
 
-class QuxDeleteView(CrispyModelViewMixin, DeleteViewPermissionRequired):
+class QuxDeleteView(CrispyViewMixin, DeleteViewPermissionRequired):
     model = Qux
     form_class = CrispyDeleteForm
     cv_viewset = cv_qux

--- a/examples/bootstrap5/app/views/s3.py
+++ b/examples/bootstrap5/app/views/s3.py
@@ -10,7 +10,7 @@ import hashlib
 
 import django_tables2 as tables
 
-from crud_views.lib.crispy import CrispyModelViewMixin, CrispyDeleteForm
+from crud_views.lib.crispy import CrispyViewMixin, CrispyDeleteForm
 from crud_views.lib.resource import Resource, ResourceViewMixin
 from crud_views.lib.table import Table
 from crud_views.lib.views import (
@@ -83,7 +83,7 @@ class S3FileDetailView(ResourceViewMixin, DetailCustomViewPermissionRequired):
     template_name = "app/s3file_detail.html"
 
 
-class S3FileDeleteView(ResourceViewMixin, CrispyModelViewMixin, MessageMixin, CustomFormViewPermissionRequired):
+class S3FileDeleteView(ResourceViewMixin, CrispyViewMixin, MessageMixin, CustomFormViewPermissionRequired):
     cv_key = "delete"
     cv_path = "delete"
     cv_viewset = cv_s3file

--- a/src/crud_views/lib/crispy/__init__.py
+++ b/src/crud_views/lib/crispy/__init__.py
@@ -12,7 +12,7 @@ from .table import (
     Column11,
     Column12,
 )
-from .form import CrispyModelForm, CrispyViewMixin, CrispyModelViewMixin, CrispyForm, CrispyDeleteForm
+from .form import CrispyModelForm, CrispyViewMixin, CrispyForm, CrispyDeleteForm
 
 __all__ = [
     "Column1",
@@ -30,6 +30,5 @@ __all__ = [
     "CrispyModelForm",
     "CrispyForm",
     "CrispyDeleteForm",
-    "CrispyModelViewMixin",
     "CrispyViewMixin",
 ]

--- a/src/crud_views/lib/crispy/form.py
+++ b/src/crud_views/lib/crispy/form.py
@@ -29,7 +29,7 @@ class CrispyFormMixin:
         - save
         - cancel, which is linked to the cancel key defined the CrudView
 
-    The mixin for CrudView(s) adds the view context cv_view to the form. CrispyModelViewMixin,
+    The mixin for CrudView(s) adds the view context cv_view to the form. CrispyViewMixin,
     when added to a CrudView, sets this extra argument for the form in get_form_kwargs.
     """
 
@@ -141,8 +141,3 @@ class CrispyViewMixin:
         if issubclass(form_class, (CrispyModelForm, CrispyForm)):
             kwargs["cv_view"] = self
         return kwargs
-
-
-# Deprecated alias kept for backwards compatibility, see issue #34
-class CrispyModelViewMixin(CrispyViewMixin):
-    pass

--- a/src/crud_views/lib/view/base.py
+++ b/src/crud_views/lib/view/base.py
@@ -58,7 +58,7 @@ class CrudView(metaclass=CrudViewMetaClass):
     cv_home_key: str | None = "list"  # home url, defaults to list
     cv_success_key: str | None = "list"  # success url, defaults to list
     cv_cancel_key: str | None = "list"  # cancel url, defaults to list
-    cv_parent_key: str | None = "list"  # parent key, defaults to list todo: does this make sense at all?
+    cv_parent_key: str | None = "list"  # parent key; default under review for 1.x, see issue #74
 
     cv_extends_template: str | None = None  # template to extend
 

--- a/src/crud_views_workflow/lib/views.py
+++ b/src/crud_views_workflow/lib/views.py
@@ -79,7 +79,7 @@ class WorkflowView(CustomFormView):
         context["has_workflow_choices"] = self.object.workflow_has_any_possible_transition(self.request.user)
         return context
 
-    def cv_form_valid_hook(self, context: dict):
+    def cv_form_valid(self, context: dict):
         """
         Process workflow transition
         """

--- a/tests/test1/app/resources.py
+++ b/tests/test1/app/resources.py
@@ -2,7 +2,7 @@ import hashlib
 
 import django_tables2 as tables
 
-from crud_views.lib.crispy import CrispyDeleteForm, CrispyModelViewMixin
+from crud_views.lib.crispy import CrispyDeleteForm, CrispyViewMixin
 from crud_views.lib.resource import Resource, ResourceViewMixin
 from crud_views.lib.table import Table
 from crud_views.lib.views import (
@@ -86,7 +86,7 @@ class S3FileDetailView(ResourceViewMixin, DetailCustomViewPermissionRequired):
     template_name = "app/s3file_detail.html"
 
 
-class S3FileDeleteView(ResourceViewMixin, CrispyModelViewMixin, MessageMixin, CustomFormViewPermissionRequired):
+class S3FileDeleteView(ResourceViewMixin, CrispyViewMixin, MessageMixin, CustomFormViewPermissionRequired):
     """
     Delete-with-confirm as a custom form view (spec decision 3: no DeleteView
     port — CustomFormView + dev hook IS the delete story for Resources).

--- a/tests/test1/app/views.py
+++ b/tests/test1/app/views.py
@@ -8,7 +8,7 @@ from django.forms.fields import CharField
 from django.core.exceptions import ValidationError
 
 from tests.test1.app.models import Author, Publisher, Book, Vehicle, Car, Truck, Campaign
-from crud_views.lib.crispy import CrispyModelViewMixin, CrispyDeleteForm, CrispyModelForm
+from crud_views.lib.crispy import CrispyViewMixin, CrispyDeleteForm, CrispyModelForm
 from crud_views.lib.crispy.form import CrispyForm
 from crud_views.lib.table import Table, UUIDLinkDetailColumn, LinkDetailColumn
 from crud_views.lib.views import (
@@ -112,17 +112,17 @@ class AuthorForm(CrispyModelForm):
         return Row(Column4("first_name"), Column4("last_name"), Column4("pseudonym"))
 
 
-class AuthorCreateView(CrispyModelViewMixin, CreateViewPermissionRequired):
+class AuthorCreateView(CrispyViewMixin, CreateViewPermissionRequired):
     form_class = AuthorForm
     cv_viewset = cv_author
 
 
-class AuthorUpdateView(CrispyModelViewMixin, UpdateViewPermissionRequired):
+class AuthorUpdateView(CrispyViewMixin, UpdateViewPermissionRequired):
     form_class = AuthorForm
     cv_viewset = cv_author
 
 
-class AuthorDeleteView(CrispyModelViewMixin, DeleteViewPermissionRequired):
+class AuthorDeleteView(CrispyViewMixin, DeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_author
 
@@ -200,7 +200,7 @@ class AuthorContactForm(CrispyModelForm):
         return Column12("subject"), Column12("body")
 
 
-class AuthorContactView(CrispyModelViewMixin, MessageMixin, CustomFormViewPermissionRequired):
+class AuthorContactView(CrispyViewMixin, MessageMixin, CustomFormViewPermissionRequired):
     cv_key = "contact"
     cv_path = "contact"
     cv_viewset = cv_author
@@ -230,7 +230,7 @@ class AuthorWideCardDetailView(DetailViewPermissionRequired):
     cv_viewset = cv_author_wide_card
 
 
-class AuthorWideCardCreateView(CrispyModelViewMixin, CreateViewPermissionRequired):
+class AuthorWideCardCreateView(CrispyViewMixin, CreateViewPermissionRequired):
     form_class = AuthorForm
     cv_viewset = cv_author_wide_card
 
@@ -303,17 +303,17 @@ class PublisherForm(CrispyModelForm):
         return Row(Column4("name"))
 
 
-class PublisherCreateView(CrispyModelViewMixin, MessageMixin, CreateViewPermissionRequired):
+class PublisherCreateView(CrispyViewMixin, MessageMixin, CreateViewPermissionRequired):
     form_class = PublisherForm
     cv_viewset = cv_publisher
 
 
-class PublisherUpdateView(CrispyModelViewMixin, MessageMixin, UpdateViewPermissionRequired):
+class PublisherUpdateView(CrispyViewMixin, MessageMixin, UpdateViewPermissionRequired):
     form_class = PublisherForm
     cv_viewset = cv_publisher
 
 
-class PublisherDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionRequired):
+class PublisherDeleteView(CrispyViewMixin, MessageMixin, DeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_publisher
 
@@ -393,17 +393,17 @@ class BookForm(CrispyModelForm):
         return Row(Column4("title"))
 
 
-class BookCreateView(CrispyModelViewMixin, CreateViewParentMixin, CreateViewPermissionRequired):
+class BookCreateView(CrispyViewMixin, CreateViewParentMixin, CreateViewPermissionRequired):
     form_class = BookForm
     cv_viewset = cv_book
 
 
-class BookUpdateView(CrispyModelViewMixin, UpdateViewPermissionRequired):
+class BookUpdateView(CrispyViewMixin, UpdateViewPermissionRequired):
     form_class = BookForm
     cv_viewset = cv_book
 
 
-class BookDeleteView(CrispyModelViewMixin, DeleteViewPermissionRequired):
+class BookDeleteView(CrispyViewMixin, DeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_book
 
@@ -484,12 +484,12 @@ class CrispyVehicleContentTypeForm(CrispyForm, PolymorphicContentTypeForm):
         return Row(Column4("polymorphic_ctype_id"))
 
 
-class VehicleCreateSelectView(CrispyModelViewMixin, PolymorphicCreateSelectViewPermissionRequired):
+class VehicleCreateSelectView(CrispyViewMixin, PolymorphicCreateSelectViewPermissionRequired):
     form_class = CrispyVehicleContentTypeForm
     cv_viewset = cv_vehicle
 
 
-class VehicleCreateView(CrispyModelViewMixin, PolymorphicCreateViewPermissionRequired):
+class VehicleCreateView(CrispyViewMixin, PolymorphicCreateViewPermissionRequired):
     cv_viewset = cv_vehicle
     cv_context_actions = ["home"]
     polymorphic_forms = {
@@ -498,7 +498,7 @@ class VehicleCreateView(CrispyModelViewMixin, PolymorphicCreateViewPermissionReq
     }
 
 
-class VehicleUpdateView(CrispyModelViewMixin, PolymorphicUpdateViewPermissionRequired):
+class VehicleUpdateView(CrispyViewMixin, PolymorphicUpdateViewPermissionRequired):
     cv_viewset = cv_vehicle
     polymorphic_forms = {
         Car: CarForm,
@@ -506,7 +506,7 @@ class VehicleUpdateView(CrispyModelViewMixin, PolymorphicUpdateViewPermissionReq
     }
 
 
-class VehicleDeleteView(CrispyModelViewMixin, PolymorphicDeleteViewPermissionRequired):
+class VehicleDeleteView(CrispyViewMixin, PolymorphicDeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_vehicle
 
@@ -556,7 +556,7 @@ class CampaignWorkflowForm(WorkflowForm):
         model = Campaign
 
 
-class CampaignWorkflowView(CrispyModelViewMixin, MessageMixin, WorkflowViewPermissionRequired):
+class CampaignWorkflowView(CrispyViewMixin, MessageMixin, WorkflowViewPermissionRequired):
     cv_context_actions = ["list", "detail", "workflow"]
     cv_viewset = cv_campaign
     form_class = CampaignWorkflowForm
@@ -581,17 +581,17 @@ class GuardianAuthorDetailView(GuardianDetailViewPermissionRequired):
     cv_viewset = cv_guardian_author
 
 
-class GuardianAuthorCreateView(CrispyModelViewMixin, GuardianCreateViewPermissionRequired):
+class GuardianAuthorCreateView(CrispyViewMixin, GuardianCreateViewPermissionRequired):
     form_class = AuthorForm
     cv_viewset = cv_guardian_author
 
 
-class GuardianAuthorUpdateView(CrispyModelViewMixin, GuardianUpdateViewPermissionRequired):
+class GuardianAuthorUpdateView(CrispyViewMixin, GuardianUpdateViewPermissionRequired):
     form_class = AuthorForm
     cv_viewset = cv_guardian_author
 
 
-class GuardianAuthorDeleteView(CrispyModelViewMixin, GuardianDeleteViewPermissionRequired):
+class GuardianAuthorDeleteView(CrispyViewMixin, GuardianDeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_guardian_author
 
@@ -621,17 +621,17 @@ class GuardianPublisherDetailView(GuardianDetailViewPermissionRequired):
     cv_viewset = cv_guardian_publisher
 
 
-class GuardianPublisherCreateView(CrispyModelViewMixin, GuardianCreateViewPermissionRequired):
+class GuardianPublisherCreateView(CrispyViewMixin, GuardianCreateViewPermissionRequired):
     form_class = PublisherForm
     cv_viewset = cv_guardian_publisher
 
 
-class GuardianPublisherUpdateView(CrispyModelViewMixin, GuardianUpdateViewPermissionRequired):
+class GuardianPublisherUpdateView(CrispyViewMixin, GuardianUpdateViewPermissionRequired):
     form_class = PublisherForm
     cv_viewset = cv_guardian_publisher
 
 
-class GuardianPublisherDeleteView(CrispyModelViewMixin, GuardianDeleteViewPermissionRequired):
+class GuardianPublisherDeleteView(CrispyViewMixin, GuardianDeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_guardian_publisher
 
@@ -664,17 +664,17 @@ class GuardianBookDetailView(GuardianDetailViewPermissionRequired):
     cv_viewset = cv_guardian_book
 
 
-class GuardianBookCreateView(CrispyModelViewMixin, CreateViewParentMixin, GuardianCreateViewPermissionRequired):
+class GuardianBookCreateView(CrispyViewMixin, CreateViewParentMixin, GuardianCreateViewPermissionRequired):
     form_class = BookForm
     cv_viewset = cv_guardian_book
 
 
-class GuardianBookUpdateView(CrispyModelViewMixin, GuardianUpdateViewPermissionRequired):
+class GuardianBookUpdateView(CrispyViewMixin, GuardianUpdateViewPermissionRequired):
     form_class = BookForm
     cv_viewset = cv_guardian_book
 
 
-class GuardianBookDeleteView(CrispyModelViewMixin, GuardianDeleteViewPermissionRequired):
+class GuardianBookDeleteView(CrispyViewMixin, GuardianDeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_guardian_book
 
@@ -693,7 +693,7 @@ class GuardianPublisherCascadeListView(ListViewTableMixin, GuardianListViewPermi
     cv_viewset = cv_guardian_publisher_cascade
 
 
-class GuardianPublisherCascadeDeleteView(CrispyModelViewMixin, GuardianDeleteViewPermissionRequired):
+class GuardianPublisherCascadeDeleteView(CrispyViewMixin, GuardianDeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_guardian_publisher_cascade
     cv_show_related_objects = True
@@ -712,7 +712,7 @@ class PublisherCascadeListView(ListViewTableMixin, ListViewPermissionRequired):
     cv_viewset = cv_publisher_cascade
 
 
-class PublisherCascadeDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionRequired):
+class PublisherCascadeDeleteView(CrispyViewMixin, MessageMixin, DeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_publisher_cascade
     cv_show_related_objects = True
@@ -731,7 +731,7 @@ class PublisherProtectedListView(ListViewTableMixin, ListViewPermissionRequired)
     cv_viewset = cv_publisher_protected
 
 
-class PublisherProtectedDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionRequired):
+class PublisherProtectedDeleteView(CrispyViewMixin, MessageMixin, DeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_publisher_protected
     cv_show_related_objects = True
@@ -755,7 +755,7 @@ class ProtectedDeleteForm(CrispyDeleteForm):
         return cleaned_data
 
 
-class PublisherFormProtectedDeleteView(CrispyModelViewMixin, DeleteViewPermissionRequired):
+class PublisherFormProtectedDeleteView(CrispyViewMixin, DeleteViewPermissionRequired):
     form_class = ProtectedDeleteForm
     cv_viewset = cv_publisher_form_protected
 
@@ -778,7 +778,7 @@ class PublisherLinkedListView(ListViewTableMixin, ListViewPermissionRequired):
     cv_viewset = cv_publisher_linked
 
 
-class PublisherLinkedDeleteView(CrispyModelViewMixin, DeleteViewPermissionRequired):
+class PublisherLinkedDeleteView(CrispyViewMixin, DeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_publisher_linked
     cv_show_related_objects = True
@@ -821,7 +821,7 @@ class AuthorModalDetailView(DetailViewPermissionRequired):
     ]
 
 
-class AuthorModalDeleteView(CrispyModelViewMixin, MessageMixin, DeleteViewPermissionRequired):
+class AuthorModalDeleteView(CrispyViewMixin, MessageMixin, DeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_author_modal
     cv_modal = True
@@ -841,7 +841,7 @@ class AuthorModalContactForm(CrispyModelForm):
         return Column12("subject"), Column12("body")
 
 
-class AuthorModalContactView(MessageMixin, CrispyModelViewMixin, CustomFormViewPermissionRequired):
+class AuthorModalContactView(MessageMixin, CrispyViewMixin, CustomFormViewPermissionRequired):
     cv_key = "contact"
     cv_path = "contact"
     cv_viewset = cv_author_modal
@@ -868,7 +868,7 @@ class PublisherModalProtectedListView(ListViewTableMixin, ListViewPermissionRequ
     cv_viewset = cv_publisher_modal_protected
 
 
-class PublisherModalProtectedDeleteView(CrispyModelViewMixin, DeleteViewPermissionRequired):
+class PublisherModalProtectedDeleteView(CrispyViewMixin, DeleteViewPermissionRequired):
     form_class = CrispyDeleteForm
     cv_viewset = cv_publisher_modal_protected
     cv_modal = True

--- a/tests/test1/app/views_formset.py
+++ b/tests/test1/app/views_formset.py
@@ -15,7 +15,7 @@ import django_tables2 as tables
 from crispy_forms.layout import LayoutObject, Row
 from django.forms.models import inlineformset_factory
 
-from crud_views.lib.crispy import Column4, Column8, CrispyModelForm, CrispyModelViewMixin
+from crud_views.lib.crispy import Column4, Column8, CrispyModelForm, CrispyViewMixin
 from crud_views.lib.formsets import FormSet, FormSetMixin, FormSets, Formsets, InlineFormSet
 from crud_views.lib.table import LinkDetailColumn, Table
 from crud_views.lib.views import (
@@ -117,13 +117,13 @@ class PublisherFormSetListView(ListViewTableMixin, ListViewPermissionRequired):
     cv_viewset = cv_publisher_formset
 
 
-class PublisherFormSetCreateView(CrispyModelViewMixin, FormSetMixin, CreateViewPermissionRequired):
+class PublisherFormSetCreateView(CrispyViewMixin, FormSetMixin, CreateViewPermissionRequired):
     form_class = PublisherFormSetForm
     cv_viewset = cv_publisher_formset
     cv_formsets: FormSets = publisher_formsets
 
 
-class PublisherFormSetUpdateView(CrispyModelViewMixin, FormSetMixin, UpdateViewPermissionRequired):
+class PublisherFormSetUpdateView(CrispyViewMixin, FormSetMixin, UpdateViewPermissionRequired):
     form_class = PublisherFormSetForm
     cv_viewset = cv_publisher_formset
     cv_formsets: FormSets = publisher_formsets

--- a/tests/test1/test_custom_form_view.py
+++ b/tests/test1/test_custom_form_view.py
@@ -1,5 +1,5 @@
 """
-Tests for CustomFormView / CustomFormViewPermissionRequired and CrispyModelViewMixin.
+Tests for CustomFormView / CustomFormViewPermissionRequired and CrispyViewMixin.
 """
 
 import pytest
@@ -50,14 +50,14 @@ def test_custom_form_view_permission_required(client: Client, author_douglas_ada
 
 
 # ---------------------------------------------------------------------------
-# CrispyModelViewMixin — verifies cv_view is injected into the form
+# CrispyViewMixin — verifies cv_view is injected into the form
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.django_db
 def test_crispy_model_view_mixin_injects_cv_view(client_user_author_view: Client, author_douglas_adams):
     """
-    CrispyModelViewMixin.get_form_kwargs injects cv_view into the form kwargs,
+    CrispyViewMixin.get_form_kwargs injects cv_view into the form kwargs,
     allowing CrispyModelForm to build the cancel button URL from the view context.
     We verify this by checking that the rendered contact form page contains the
     submit button label rendered by the crispy helper.
@@ -75,7 +75,7 @@ def test_crispy_model_view_mixin_injects_cv_view(client_user_author_view: Client
 @pytest.mark.django_db
 def test_crispy_model_view_mixin_on_create_view(client_user_author_add: Client):
     """
-    CrispyModelViewMixin works correctly on CreateView: the rendered form
+    CrispyViewMixin works correctly on CreateView: the rendered form
     contains the expected fields.
     """
     response = client_user_author_add.get("/author/create/")
@@ -87,7 +87,7 @@ def test_crispy_model_view_mixin_on_create_view(client_user_author_add: Client):
 @pytest.mark.django_db
 def test_crispy_model_view_mixin_on_update_view(client_user_author_change: Client, author_douglas_adams):
     """
-    CrispyModelViewMixin works correctly on UpdateView: the rendered form
+    CrispyViewMixin works correctly on UpdateView: the rendered form
     is pre-populated with the existing object data.
     """
     pk = author_douglas_adams.pk

--- a/tests/test1/test_custom_form_view.py
+++ b/tests/test1/test_custom_form_view.py
@@ -55,7 +55,7 @@ def test_custom_form_view_permission_required(client: Client, author_douglas_ada
 
 
 @pytest.mark.django_db
-def test_crispy_model_view_mixin_injects_cv_view(client_user_author_view: Client, author_douglas_adams):
+def test_crispy_view_mixin_injects_cv_view(client_user_author_view: Client, author_douglas_adams):
     """
     CrispyViewMixin.get_form_kwargs injects cv_view into the form kwargs,
     allowing CrispyModelForm to build the cancel button URL from the view context.
@@ -73,7 +73,7 @@ def test_crispy_model_view_mixin_injects_cv_view(client_user_author_view: Client
 
 
 @pytest.mark.django_db
-def test_crispy_model_view_mixin_on_create_view(client_user_author_add: Client):
+def test_crispy_view_mixin_on_create_view(client_user_author_add: Client):
     """
     CrispyViewMixin works correctly on CreateView: the rendered form
     contains the expected fields.
@@ -85,7 +85,7 @@ def test_crispy_model_view_mixin_on_create_view(client_user_author_add: Client):
 
 
 @pytest.mark.django_db
-def test_crispy_model_view_mixin_on_update_view(client_user_author_change: Client, author_douglas_adams):
+def test_crispy_view_mixin_on_update_view(client_user_author_change: Client, author_douglas_adams):
     """
     CrispyViewMixin works correctly on UpdateView: the rendered form
     is pre-populated with the existing object data.

--- a/tests/test1/test_workflow.py
+++ b/tests/test1/test_workflow.py
@@ -262,8 +262,8 @@ def test_workflow_view_post_activate(client_user_campaign_change: Client, campai
 def test_workflow_view_post_emits_success_message(client_user_campaign_change: Client, campaign_new):
     """
     A WorkflowView that mixes in MessageMixin (as CampaignWorkflowView does) emits its
-    configured success message after a transition. MessageMixin precedes WorkflowView in the
-    MRO, so its cv_form_valid_hook wraps WorkflowView's transition processing and then emits.
+    configured success message after a transition. MessageMixin's cv_form_valid_hook runs
+    after WorkflowView.cv_form_valid has processed the transition, then emits the message.
     Regression guard for GitHub #52 (reported as "message never emitted" — it is emitted under
     the documented MessageMixin opt-in, exactly like Create/Update/Delete views).
     """
@@ -637,3 +637,41 @@ def test_workflow_view_checks_model_missing_state_badges():
     NoBadgesView.cv_viewset = mock_viewset
 
     assert "viewset.E235" in _error_ids(NoBadgesView)
+
+
+# ---------------------------------------------------------------------------
+# Hook placement (issue #31): transition logic must live in cv_form_valid,
+# leaving cv_form_valid_hook free as the user extension point.
+# ---------------------------------------------------------------------------
+
+
+def test_transition_logic_lives_in_cv_form_valid():
+    """
+    WorkflowView must do its framework work in cv_form_valid (like Create/Update/FormSet views)
+    and must NOT occupy cv_form_valid_hook, which is reserved for user subclasses.
+    """
+    from crud_views_workflow.lib.views import WorkflowView
+
+    assert "cv_form_valid" in vars(WorkflowView)
+    assert "cv_form_valid_hook" not in vars(WorkflowView)
+
+
+@pytest.mark.django_db
+def test_user_hook_override_keeps_transition(client_user_campaign_change: Client, campaign_new, monkeypatch):
+    """
+    A user subclass overriding cv_form_valid_hook (without calling super()) must not destroy
+    transition execution — regression guard for issue #31.
+    """
+    from tests.test1.app.views import CampaignWorkflowView
+
+    calls = []
+    monkeypatch.setattr(CampaignWorkflowView, "cv_form_valid_hook", lambda self, context: calls.append("hook"))
+
+    response = client_user_campaign_change.post(
+        f"/campaign/{campaign_new.pk}/workflow/",
+        {"transition": "wf_activate", "comment": ""},
+    )
+    assert response.status_code == 302
+    campaign_new.refresh_from_db()
+    assert campaign_new.state == CampaignState.ACTIVE
+    assert calls == ["hook"]


### PR DESCRIPTION
Implements M2 of the release-1 milestone (spec: superpowers/specs/2026-07-16-m2-api-stability-design.md).

- Remove deprecated `CrispyModelViewMixin` alias — use `CrispyViewMixin`. Closes #34.
- Move `WorkflowView` transition logic from `cv_form_valid_hook` to `cv_form_valid` (#31, breaking half; remainder deferred to 1.x).
- Add API stability statement (`docs/development/stability.md`) + index blurb.
- CHANGELOG for 0.14.0 (two breaking changes, migration hints included).

Backlog triage recorded on #28 (deferred to 1.x) and #31 (rescoped).