### PR TITLE
Expand Django system checks (#28)

### DIFF
--- a/src/crud_views/lib/check.py
+++ b/src/crud_views/lib/check.py
@@ -118,6 +118,35 @@ class CheckAttributeType(CheckAttribute):
             yield Error(id=self.get_id(), msg=self.get_message())
 
 
+class CheckMapping(CheckAttribute):
+    """
+    Check attribute is a dict mapping keys (subclasses of key_type) to values (instances of value_type)
+    """
+
+    id: str = "E205"
+    key_type: type | tuple[type, ...]
+    value_type: type | tuple[type, ...]
+    msg: str = "Attribute »{attribute}» at »{context}» is not a valid mapping: {detail}"
+
+    def _error(self, detail: str) -> Error:
+        kwargs = self.get_message_context()
+        return Error(id=self.get_id(), msg=self.msg.format(detail=detail, **kwargs))
+
+    def messages(self) -> Iterable[CheckMessage]:
+        yield from super().messages()
+        if not self.exists or self.value is None:
+            return
+        value = self.value
+        if not isinstance(value, dict):
+            yield self._error(f"expected a dict, got {type(value).__name__}")
+            return
+        for key, val in value.items():
+            if not isinstance(key, type) or not issubclass(key, self.key_type):
+                yield self._error(f"key »{key!r}» is not a subclass of {self.key_type}")
+            if not isinstance(val, self.value_type):
+                yield self._error(f"value for »{key!r}» is not of type {self.value_type}")
+
+
 class CheckEitherAttribute(Check):
     """
     Check for either attribute

--- a/src/crud_views/lib/check.py
+++ b/src/crud_views/lib/check.py
@@ -98,6 +98,26 @@ class CheckAttributeReg(CheckAttribute):
             yield Error(id=f"viewset.{self.id}", msg=self.get_message())
 
 
+class CheckAttributeType(CheckAttribute):
+    """
+    Check attribute value is an instance of the expected type
+    """
+
+    id: str = "E101"
+    expected_type: type | tuple[type, ...]
+    msg: str = "Attribute »{attribute}» value »{value}» is not of type »{expected_type}» at »{context}»"
+
+    def get_message_context(self) -> dict:
+        context = super().get_message_context()
+        context.update(expected_type=self.expected_type)
+        return context
+
+    def messages(self) -> Iterable[CheckMessage]:
+        yield from super().messages()
+        if self.exists and self.value is not None and not isinstance(self.value, self.expected_type):
+            yield Error(id=self.get_id(), msg=self.get_message())
+
+
 class CheckEitherAttribute(Check):
     """
     Check for either attribute

--- a/src/crud_views/lib/check.py
+++ b/src/crud_views/lib/check.py
@@ -251,17 +251,33 @@ class CheckTemplate(Check):
 class ContextActionCheck(Check):
     """
     Checks for context action
+
+    A ``cv_context_actions`` entry resolves either to a sibling view registered on the
+    ViewSet (``ViewSet.has_view``) or to a context button (view-level ``cv_context_buttons``
+    or viewset-level ``context_buttons``, e.g. "home", "parent", "filter") — mirroring the
+    two-path resolution performed at render time by ``CrudView.cv_get_context()``. Only
+    actions resolving to neither are misconfigurations.
+
+    ``cv_viewset`` may legitimately be unset (e.g. isolated check-only test view classes not
+    wired to a real ViewSet); in that case there is nothing to validate against, so no
+    message is emitted.
     """
 
-    msg: str = "Attribute »{attribute}» does not exist or is not set at »{context}»"
+    id: str = "E203"
+    msg: str = "Context action »{action}» does not resolve to a view or context button in the viewset at »{context}»"
 
     def messages(self) -> Iterable[CheckMessage]:
-        viewset = self.context.cv  # noqa
-        actions = self.context.cv_context_actions or list()  # noqa
-        for action in actions:  # noqa
-            is_view = viewset.has_view(action)
-            if not is_view:
-                yield Error(id=f"viewset.{self.id}", msg=f"{self.msg} at {self.context}: {action}")
+        viewset = getattr(self.context, "cv_viewset", None)
+        if viewset is None:
+            return
+        actions = self.context.cv_context_actions or list()
+        button_keys = {cb.key for cb in getattr(self.context, "cv_context_buttons", None) or []}
+        button_keys |= {cb.key for cb in getattr(viewset, "context_buttons", None) or []}
+        for action in actions:
+            if action in button_keys:
+                continue
+            if not viewset.has_view(action):
+                yield Error(id=self.get_id(), msg=self.msg.format(action=action, context=self.context))
 
 
 class CheckExpression(Check):

--- a/src/crud_views/lib/check.py
+++ b/src/crud_views/lib/check.py
@@ -248,38 +248,6 @@ class CheckTemplate(Check):
                 yield Error(id=self.get_id(), msg=msg)
 
 
-class ContextActionCheck(Check):
-    """
-    Checks for context action
-
-    A ``cv_context_actions`` entry resolves either to a sibling view registered on the
-    ViewSet (``ViewSet.has_view``) or to a context button (view-level ``cv_context_buttons``
-    or viewset-level ``context_buttons``, e.g. "home", "parent", "filter") — mirroring the
-    two-path resolution performed at render time by ``CrudView.cv_get_context()``. Only
-    actions resolving to neither are misconfigurations.
-
-    ``cv_viewset`` may legitimately be unset (e.g. isolated check-only test view classes not
-    wired to a real ViewSet); in that case there is nothing to validate against, so no
-    message is emitted.
-    """
-
-    id: str = "E203"
-    msg: str = "Context action »{action}» does not resolve to a view or context button in the viewset at »{context}»"
-
-    def messages(self) -> Iterable[CheckMessage]:
-        viewset = getattr(self.context, "cv_viewset", None)
-        if viewset is None:
-            return
-        actions = self.context.cv_context_actions or list()
-        button_keys = {cb.key for cb in getattr(self.context, "cv_context_buttons", None) or []}
-        button_keys |= {cb.key for cb in getattr(viewset, "context_buttons", None) or []}
-        for action in actions:
-            if action in button_keys:
-                continue
-            if not viewset.has_view(action):
-                yield Error(id=self.get_id(), msg=self.msg.format(action=action, context=self.context))
-
-
 class CheckExpression(Check):
     expression: bool
     msg: str = "foo"

--- a/src/crud_views/lib/formsets/mixins.py
+++ b/src/crud_views/lib/formsets/mixins.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Dict, Type, Iterable
 
-from crud_views.lib.check import Check, CheckAttribute
+from crud_views.lib.check import Check, CheckAttribute, CheckAttributeType, CheckMapping
 from django.core.exceptions import BadRequest
 from django.db.models import Model
 from django.forms.models import ModelForm
@@ -20,7 +20,7 @@ class FormSetMixinBase:
         Iterator of checks for the view
         """
         yield from super().checks()
-        yield CheckAttribute(context=cls, id="E200", attribute="cv_formsets_required")
+        yield CheckAttribute(context=cls, id="E206", attribute="cv_formsets_required")
 
     def get_context_data(self, **kwargs):
         """
@@ -147,7 +147,7 @@ class FormSetMixin(FormSetMixinBase):
         Iterator of checks for the view
         """
         yield from super().checks()
-        yield CheckAttribute(context=cls, id="E200", attribute="cv_formsets")
+        yield CheckAttributeType(context=cls, id="E204", attribute="cv_formsets", expected_type=FormSets)
 
     def cv_get_formsets(self) -> FormSets:
         return self.cv_formsets.clone(cv_view=self)  # noqa
@@ -162,7 +162,13 @@ class PolymorphicFormSetsViewMixin(FormSetMixinBase):
         Iterator of checks for the view
         """
         yield from super().checks()
-        yield CheckAttribute(context=cls, id="E200", attribute="cv_polymorphic_formsets")
+        yield CheckMapping(
+            context=cls,
+            id="E205",
+            attribute="cv_polymorphic_formsets",
+            key_type=Model,
+            value_type=FormSets,
+        )
 
     def cv_get_formsets(self) -> FormSets | None:
         model = self.polymorphic_model

--- a/src/crud_views/lib/view/base.py
+++ b/src/crud_views/lib/view/base.py
@@ -15,7 +15,6 @@ from crud_views.lib.check import (
     CheckTemplateOrCode,
     CheckTemplate,
     CheckExpression,
-    ContextActionCheck,
 )
 from crud_views.lib.exceptions import cv_raise, ParentViewSetError, CrudViewError, ViewSetKeyFoundError
 from django.contrib.auth.mixins import PermissionRequiredMixin
@@ -97,7 +96,6 @@ class CrudView(metaclass=CrudViewMetaClass):
         yield CheckAttributeReg(context=cls, id="E200", attribute="cv_key", **check.REGS["name"])
         yield CheckAttributeReg(context=cls, id="E201", attribute="cv_path", **check.REGS["path"])
         yield CheckTemplate(context=cls, id="E111", attribute="cv_extends_template")
-        yield ContextActionCheck(context=cls, id="E203")
 
         # templates are required for frontend views
         is_frontend = not cls.cv_backend_only

--- a/src/crud_views/lib/view/base.py
+++ b/src/crud_views/lib/view/base.py
@@ -15,6 +15,7 @@ from crud_views.lib.check import (
     CheckTemplateOrCode,
     CheckTemplate,
     CheckExpression,
+    ContextActionCheck,
 )
 from crud_views.lib.exceptions import cv_raise, ParentViewSetError, CrudViewError, ViewSetKeyFoundError
 from django.contrib.auth.mixins import PermissionRequiredMixin
@@ -96,6 +97,7 @@ class CrudView(metaclass=CrudViewMetaClass):
         yield CheckAttributeReg(context=cls, id="E200", attribute="cv_key", **check.REGS["name"])
         yield CheckAttributeReg(context=cls, id="E201", attribute="cv_path", **check.REGS["path"])
         yield CheckTemplate(context=cls, id="E111", attribute="cv_extends_template")
+        yield ContextActionCheck(context=cls, id="E203")
 
         # templates are required for frontend views
         is_frontend = not cls.cv_backend_only

--- a/src/crud_views/lib/views/list.py
+++ b/src/crud_views/lib/views/list.py
@@ -1,6 +1,9 @@
+from typing import Iterable
+
 from django.utils.translation import gettext as _
 from django.views import generic
 
+from crud_views.lib.check import Check, CheckTemplateOrCode
 from crud_views.lib.view import CrudView, CrudViewPermissionRequiredMixin
 from crud_views.lib.settings import crud_views_settings
 
@@ -52,6 +55,11 @@ class ListView(CrudView, generic.ListView):
             self.cv_filter_header_template,
             self.cv_filter_header_template_code,
         )
+
+    @classmethod
+    def checks(cls) -> Iterable[Check]:
+        yield from super().checks()
+        yield CheckTemplateOrCode(context=cls, attribute="cv_filter_header_template")
 
 
 class ListViewPermissionRequired(CrudViewPermissionRequiredMixin, ListView):

--- a/src/crud_views_workflow/apps.py
+++ b/src/crud_views_workflow/apps.py
@@ -7,5 +7,4 @@ class CrudViewsWorkflowConfig(AppConfig):
     label = "cvw"
 
     def ready(self):
-        # import crud_views.checks  # noqa
-        pass
+        import crud_views_workflow.checks  # noqa

--- a/src/crud_views_workflow/checks.py
+++ b/src/crud_views_workflow/checks.py
@@ -1,0 +1,39 @@
+import importlib.util
+
+from django.apps import apps
+from django.core.checks import Error, register
+
+TAG = "crud_views_workflow"
+
+
+def _importable(name: str) -> bool:
+    """True if the named top-level module can be imported."""
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+@register(TAG)
+def check_workflow_dependencies(app_configs=None, **kwargs):
+    """Error when crud_views_workflow is installed but its runtime deps are missing."""
+    errors = []
+    if not apps.is_installed("crud_views_workflow"):
+        return errors
+    if not _importable("django_fsm"):
+        errors.append(
+            Error(
+                "django-fsm-2 is required by crud_views_workflow but is not installed.",
+                hint="Install the optional extra: pip install django-crud-views[workflow]",
+                id="crud_views_workflow.E001",
+            )
+        )
+    if not _importable("fsm_admin"):
+        errors.append(
+            Error(
+                "django-fsm-2-admin is required by crud_views_workflow but is not installed.",
+                hint="Install the optional extra: pip install django-crud-views[workflow]",
+                id="crud_views_workflow.E002",
+            )
+        )
+    return errors

--- a/superpowers/plans/2026-07-17-expand-system-checks.md
+++ b/superpowers/plans/2026-07-17-expand-system-checks.md
@@ -363,7 +363,18 @@ git commit -m "feat(checks): type/mapping checks for cv_formsets & cv_polymorphi
 
 ---
 
-### Task 4: Reactivate `ContextActionCheck` (E203)
+### Task 4: ~~Reactivate `ContextActionCheck` (E203)~~ — DROPPED as obsolete
+
+> **Outcome (2026-07-17):** This task was NOT completed as written. During
+> implementation it was found that `CrudView.cv_get_context()` (`base.py:409`)
+> deliberately treats an unresolvable `cv_context_actions` key as "not a
+> misconfiguration" and skips it, and that the framework's default context
+> actions (all include `"home"`) plus the common partial-viewset pattern would
+> make E203 false-positive on legitimate configs. Per human decision, gap #3 is
+> closed as **obsolete**: the dead `ContextActionCheck` class was removed from
+> `check.py`, no wiring was added, and the `CampaignDetailView` fixture cleanup
+> was retained. See design spec section 3. The steps below are retained for
+> historical context only — do not execute them.
 
 **Files:**
 - Modify: `src/crud_views/lib/check.py` (repair `ContextActionCheck.messages()`)

--- a/superpowers/plans/2026-07-17-expand-system-checks.md
+++ b/superpowers/plans/2026-07-17-expand-system-checks.md
@@ -1,0 +1,723 @@
+# Expand Django System Checks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the five remaining check gaps from issue #28 — a type-validating check class, formset type/mapping checks, a reactivated context-action check, a filter-header template check, and workflow dependency checks.
+
+**Architecture:** Checks are pydantic `Check` subclasses that yield `django.core.checks.Error` messages from a `messages()` method; view/mixin `checks()` classmethods yield instances, collected via `ViewSet.checks_all()`. New check classes go in `crud_views/lib/check.py`; wiring goes in the relevant view/mixin; the workflow app gets its own `checks.py` registered from `apps.py:ready()`. Tests follow the repo idiom: instantiate a check with a dummy `context` object and assert on `list(check.messages())`.
+
+**Tech Stack:** Python 3.12+, Django 4.2/5.2/6.0, pydantic, pytest. Test app under `tests/test1/`.
+
+## Global Constraints
+
+- Line length 120, double quotes, `ruff format` clean (pre-commit runs `ruff-format`).
+- All `CrudView` class attributes use the `cv_` prefix.
+- Check ids resolve through `Check.get_id()` to `viewset.<id>` for core checks; workflow checks use literal `crud_views_workflow.Exxx` ids.
+- Run tests from `tests/`: `cd tests && pytest`.
+- Test app imports: `from tests.test1.app.models import Book, Publisher`, `from crud_views.lib.formsets import FormSet, FormSets`.
+- Do NOT touch gap #4 — `cv_extends_template` (view) and `extends` (viewset) are already validated by E111.
+
+## File Structure
+
+- `src/crud_views/lib/check.py` — add `CheckAttributeType` (E101) and `CheckMapping` (E205); repair `ContextActionCheck` (E203).
+- `src/crud_views/lib/view/base.py` — wire `ContextActionCheck` into `CrudView.checks()`.
+- `src/crud_views/lib/formsets/mixins.py` — replace colliding E200 declarations with E204/E205/E206.
+- `src/crud_views/lib/views/list.py` — add filter-header `CheckTemplateOrCode` to a `ListView.checks()` override.
+- `src/crud_views_workflow/checks.py` — NEW: dependency checks (E001/E002).
+- `src/crud_views_workflow/apps.py` — register the new checks module in `ready()`.
+- `tests/test1/test_expand_checks.py` — NEW: all unit tests for this work.
+
+---
+
+### Task 1: `CheckAttributeType` (E101)
+
+**Files:**
+- Modify: `src/crud_views/lib/check.py` (add class after `CheckAttributeReg`)
+- Test: `tests/test1/test_expand_checks.py` (new file)
+
+**Interfaces:**
+- Consumes: `CheckAttribute` (existing base: fields `context`, `id`, `attribute`, `nullable`; properties `exists`, `value`; `messages()`).
+- Produces: `CheckAttributeType(context, id, attribute, expected_type)` — `expected_type: type | tuple[type, ...]`; yields the base existence error(s) plus one `Error` (id `viewset.<id>`) when the attribute exists, is non-None, and `isinstance(value, expected_type)` is False.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test1/test_expand_checks.py`:
+
+```python
+from crud_views.lib.check import CheckAttributeType
+
+
+class GoodType:
+    attr = "a string"
+
+
+class BadType:
+    attr = 123
+
+
+class NoneType:
+    attr = None
+
+
+def test_check_attribute_type_correct_emits_no_message():
+    check = CheckAttributeType(context=GoodType, id="E101", attribute="attr", expected_type=str)
+    assert list(check.messages()) == []
+
+
+def test_check_attribute_type_wrong_emits_error():
+    check = CheckAttributeType(context=BadType, id="E101", attribute="attr", expected_type=str)
+    messages = list(check.messages())
+    assert len(messages) == 1
+    assert messages[0].id == "viewset.E101"
+    assert "is not of type" in messages[0].msg
+
+
+def test_check_attribute_type_none_defers_to_existence_only():
+    # nullable=True so the existence check passes; type check must not fire on None
+    check = CheckAttributeType(context=NoneType, id="E101", attribute="attr", expected_type=str, nullable=True)
+    assert list(check.messages()) == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tests && pytest test1/test_expand_checks.py -v`
+Expected: FAIL with `ImportError: cannot import name 'CheckAttributeType'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/crud_views/lib/check.py`, add after the `CheckAttributeReg` class (ends line ~98):
+
+```python
+class CheckAttributeType(CheckAttribute):
+    """
+    Check attribute value is an instance of the expected type
+    """
+
+    id: str = "E101"
+    expected_type: type | tuple[type, ...]
+    msg: str = "Attribute »{attribute}» value »{value}» is not of type »{expected_type}» at »{context}»"
+
+    def get_message_context(self) -> dict:
+        context = super().get_message_context()
+        context.update(expected_type=self.expected_type)
+        return context
+
+    def messages(self) -> Iterable[CheckMessage]:
+        yield from super().messages()
+        if self.exists and self.value is not None and not isinstance(self.value, self.expected_type):
+            yield Error(id=self.get_id(), msg=self.get_message())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd tests && pytest test1/test_expand_checks.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/crud_views/lib/check.py tests/test1/test_expand_checks.py
+git commit -m "feat(checks): add CheckAttributeType (E101) for value-type validation (#28)"
+```
+
+---
+
+### Task 2: `CheckMapping` (E205)
+
+**Files:**
+- Modify: `src/crud_views/lib/check.py` (add class after `CheckAttributeType`)
+- Test: `tests/test1/test_expand_checks.py`
+
+**Interfaces:**
+- Consumes: `CheckAttribute` base.
+- Produces: `CheckMapping(context, id, attribute, key_type, value_type)` — validates the attribute is a `dict`; every key is a **subclass** of `key_type` (guarded by `isinstance(key, type)` so a non-class key yields an error instead of raising `TypeError`); every value is an **instance** of `value_type`. Yields one `Error` per violation (id `viewset.<id>`).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test1/test_expand_checks.py`:
+
+```python
+from crud_views.lib.check import CheckMapping
+from django.db.models import Model
+from tests.test1.app.models import Book
+
+
+class NotADict:
+    attr = ["not", "a", "dict"]
+
+
+class NonClassKey:
+    attr = {"strkey": "v"}
+
+
+class NonSubclassKey:
+    attr = {int: "v"}
+
+
+class BadValue:
+    attr = {Book: 123}
+
+
+class ValidMapping:
+    attr = {Book: "v"}
+
+
+def test_check_mapping_not_a_dict_errors():
+    check = CheckMapping(context=NotADict, id="E205", attribute="attr", key_type=Model, value_type=str)
+    messages = list(check.messages())
+    assert len(messages) == 1
+    assert messages[0].id == "viewset.E205"
+
+
+def test_check_mapping_non_class_key_errors_without_raising():
+    check = CheckMapping(context=NonClassKey, id="E205", attribute="attr", key_type=Model, value_type=str)
+    messages = list(check.messages())
+    assert len(messages) == 1
+    assert messages[0].id == "viewset.E205"
+
+
+def test_check_mapping_non_subclass_key_errors():
+    check = CheckMapping(context=NonSubclassKey, id="E205", attribute="attr", key_type=Model, value_type=str)
+    assert len(list(check.messages())) == 1
+
+
+def test_check_mapping_bad_value_errors():
+    check = CheckMapping(context=BadValue, id="E205", attribute="attr", key_type=Model, value_type=str)
+    assert len(list(check.messages())) == 1
+
+
+def test_check_mapping_valid_emits_no_message():
+    check = CheckMapping(context=ValidMapping, id="E205", attribute="attr", key_type=Model, value_type=str)
+    assert list(check.messages()) == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tests && pytest test1/test_expand_checks.py -k mapping -v`
+Expected: FAIL with `ImportError: cannot import name 'CheckMapping'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/crud_views/lib/check.py`, add after `CheckAttributeType`:
+
+```python
+class CheckMapping(CheckAttribute):
+    """
+    Check attribute is a dict mapping keys (subclasses of key_type) to values (instances of value_type)
+    """
+
+    id: str = "E205"
+    key_type: type | tuple[type, ...]
+    value_type: type | tuple[type, ...]
+    msg: str = "Attribute »{attribute}» at »{context}» is not a valid mapping: {detail}"
+
+    def _error(self, detail: str) -> Error:
+        kwargs = self.get_message_context()
+        return Error(id=self.get_id(), msg=self.msg.format(detail=detail, **kwargs))
+
+    def messages(self) -> Iterable[CheckMessage]:
+        yield from super().messages()
+        if not self.exists or self.value is None:
+            return
+        value = self.value
+        if not isinstance(value, dict):
+            yield self._error(f"expected a dict, got {type(value).__name__}")
+            return
+        for key, val in value.items():
+            if not isinstance(key, type) or not issubclass(key, self.key_type):
+                yield self._error(f"key »{key!r}» is not a subclass of {self.key_type}")
+            if not isinstance(val, self.value_type):
+                yield self._error(f"value for »{key!r}» is not of type {self.value_type}")
+```
+
+Note: `get_message_context()` (inherited from `CheckAttribute`) includes a `value` key; `_error` passes `detail` explicitly and spreads the rest — `msg` references only `{attribute}`, `{context}`, `{detail}`, so extra keys are harmless.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd tests && pytest test1/test_expand_checks.py -k mapping -v`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/crud_views/lib/check.py tests/test1/test_expand_checks.py
+git commit -m "feat(checks): add CheckMapping (E205) for dict key/value type validation (#28)"
+```
+
+---
+
+### Task 3: Formsets checks wiring (E204 / E205 / E206)
+
+**Files:**
+- Modify: `src/crud_views/lib/formsets/mixins.py` (three `checks()` methods)
+- Test: `tests/test1/test_expand_checks.py`
+
+**Interfaces:**
+- Consumes: `CheckAttributeType` (Task 1), `CheckMapping` (Task 2), existing `CheckAttribute`.
+- Produces: `FormSetMixinBase.checks()` yields `CheckAttribute(id="E206", attribute="cv_formsets_required")`; `FormSetMixin.checks()` yields `CheckAttributeType(id="E204", attribute="cv_formsets", expected_type=FormSets)`; `PolymorphicFormSetsViewMixin.checks()` yields `CheckMapping(id="E205", attribute="cv_polymorphic_formsets", key_type=Model, value_type=FormSets)`. All ids distinct from `cv_key`'s E200.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test1/test_expand_checks.py`:
+
+```python
+from crud_views.lib.check import CheckAttributeType as _CAT, CheckMapping as _CM
+from crud_views.lib.formsets.formsets import FormSets
+from tests.test1.app.views_formset import PublisherFormSetCreateView
+
+
+def test_formset_create_view_yields_e204_typed_check():
+    checks = list(PublisherFormSetCreateView.checks())
+    e204 = [c for c in checks if getattr(c, "id", None) == "E204"]
+    assert len(e204) == 1
+    assert isinstance(e204[0], _CAT)
+    assert e204[0].attribute == "cv_formsets"
+    assert e204[0].expected_type is FormSets
+
+
+def test_formset_checks_do_not_reuse_e200_for_formsets():
+    # E200 belongs to cv_key; formsets must not collide with it
+    checks = list(PublisherFormSetCreateView.checks())
+    e200_attrs = {getattr(c, "attribute", None) for c in checks if getattr(c, "id", None) == "E200"}
+    assert "cv_formsets" not in e200_attrs
+    assert "cv_formsets_required" not in e200_attrs
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tests && pytest test1/test_expand_checks.py -k formset -v`
+Expected: FAIL — no check with id `E204` (currently `cv_formsets` is declared under `E200`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/crud_views/lib/formsets/mixins.py`:
+
+Update the import line (currently `from crud_views.lib.check import Check, CheckAttribute`):
+
+```python
+from crud_views.lib.check import Check, CheckAttribute, CheckAttributeType, CheckMapping
+from crud_views.lib.formsets.formsets import FormSets
+from django.db.models import Model
+```
+
+(Keep existing imports; add `Model` and `FormSets` if not already imported. `FormSets` is imported lazily elsewhere via `.formsets` — verify no circular import; if one occurs, import `FormSets`/`Model` inside the `checks()` method instead.)
+
+In `FormSetMixinBase.checks()` change:
+
+```python
+        yield CheckAttribute(context=cls, id="E200", attribute="cv_formsets_required")
+```
+
+to:
+
+```python
+        yield CheckAttribute(context=cls, id="E206", attribute="cv_formsets_required")
+```
+
+In `FormSetMixin.checks()` change:
+
+```python
+        yield CheckAttribute(context=cls, id="E200", attribute="cv_formsets")
+```
+
+to:
+
+```python
+        yield CheckAttributeType(context=cls, id="E204", attribute="cv_formsets", expected_type=FormSets)
+```
+
+In `PolymorphicFormSetsViewMixin.checks()` change:
+
+```python
+        yield CheckAttribute(context=cls, id="E200", attribute="cv_polymorphic_formsets")
+```
+
+to:
+
+```python
+        yield CheckMapping(
+            context=cls,
+            id="E205",
+            attribute="cv_polymorphic_formsets",
+            key_type=Model,
+            value_type=FormSets,
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd tests && pytest test1/test_expand_checks.py -k formset -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Run the formsets regression suite**
+
+Run: `cd tests && pytest test1/test_formsets_bugs.py -q`
+Expected: PASS (no regressions from the id changes)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/crud_views/lib/formsets/mixins.py tests/test1/test_expand_checks.py
+git commit -m "feat(checks): type/mapping checks for cv_formsets & cv_polymorphic_formsets, fix E200 collision (#28)"
+```
+
+---
+
+### Task 4: Reactivate `ContextActionCheck` (E203)
+
+**Files:**
+- Modify: `src/crud_views/lib/check.py` (repair `ContextActionCheck.messages()`)
+- Modify: `src/crud_views/lib/view/base.py` (wire into `CrudView.checks()`)
+- Test: `tests/test1/test_expand_checks.py`
+
+**Interfaces:**
+- Consumes: `ViewSet.has_view(name) -> bool`; view attributes `cv_viewset`, `cv_context_actions: list[str] | None`.
+- Produces: `ContextActionCheck(context=cls, id="E203")` yields one `Error` (id `viewset.E203`) per `cv_context_actions` entry that does not resolve via `cv_viewset.has_view(...)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test1/test_expand_checks.py`:
+
+```python
+from crud_views.lib.check import ContextActionCheck
+
+
+class FakeViewset:
+    def __init__(self, keys):
+        self._keys = keys
+
+    def has_view(self, name):
+        return name in self._keys
+
+
+class CtxActionsValid:
+    cv_viewset = FakeViewset(["update", "delete"])
+    cv_context_actions = ["update", "delete"]
+
+
+class CtxActionsBad:
+    cv_viewset = FakeViewset(["update"])
+    cv_context_actions = ["update", "does_not_exist"]
+
+
+class CtxActionsNone:
+    cv_viewset = FakeViewset(["update"])
+    cv_context_actions = None
+
+
+def test_context_action_check_valid_emits_no_message():
+    check = ContextActionCheck(context=CtxActionsValid, id="E203")
+    assert list(check.messages()) == []
+
+
+def test_context_action_check_missing_view_emits_error():
+    check = ContextActionCheck(context=CtxActionsBad, id="E203")
+    messages = list(check.messages())
+    assert len(messages) == 1
+    assert messages[0].id == "viewset.E203"
+    assert "does_not_exist" in messages[0].msg
+
+
+def test_context_action_check_none_emits_no_message():
+    check = ContextActionCheck(context=CtxActionsNone, id="E203")
+    assert list(check.messages()) == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tests && pytest test1/test_expand_checks.py -k context_action -v`
+Expected: FAIL — `AttributeError: 'FakeViewset' object has no attribute ...` / the current body reads `self.context.cv` which does not exist on these contexts.
+
+- [ ] **Step 3: Repair the check class**
+
+In `src/crud_views/lib/check.py`, replace the `ContextActionCheck` body:
+
+```python
+class ContextActionCheck(Check):
+    """
+    Checks for context action
+    """
+
+    id: str = "E203"
+    msg: str = "Context action »{action}» does not resolve to a view in the viewset at »{context}»"
+
+    def messages(self) -> Iterable[CheckMessage]:
+        viewset = self.context.cv_viewset
+        actions = self.context.cv_context_actions or list()
+        for action in actions:
+            if not viewset.has_view(action):
+                yield Error(id=self.get_id(), msg=self.msg.format(action=action, context=self.context))
+```
+
+- [ ] **Step 4: Wire it into `CrudView.checks()`**
+
+In `src/crud_views/lib/view/base.py`, in `CrudView.checks()` (after the E111 yield at line ~98), add:
+
+```python
+        yield ContextActionCheck(context=cls, id="E203")
+```
+
+Add `ContextActionCheck` to the existing import block from `crud_views.lib.check` (lines 13-16).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd tests && pytest test1/test_expand_checks.py -k context_action -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 6: Run the full check suite for regressions**
+
+Run: `cd tests && pytest test1/test_check_messages.py test1/test_settings_checks.py -q`
+Expected: PASS. Then run `cd tests && pytest -q` to confirm no registered-check failures surface from real test views whose `cv_context_actions` must all resolve.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/crud_views/lib/check.py src/crud_views/lib/view/base.py tests/test1/test_expand_checks.py
+git commit -m "feat(checks): reactivate ContextActionCheck as E203 (#28)"
+```
+
+---
+
+### Task 5: Filter header template check (E110)
+
+**Files:**
+- Modify: `src/crud_views/lib/views/list.py` (add `ListView.checks()` override)
+- Test: `tests/test1/test_expand_checks.py`
+
+**Interfaces:**
+- Consumes: `CheckTemplateOrCode(context, attribute)` (existing; validates `<attr>` / `<attr>_code` pair, default id `E110`).
+- Produces: `ListView.checks()` yields everything from `super().checks()` plus `CheckTemplateOrCode(context=cls, attribute="cv_filter_header_template")`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test1/test_expand_checks.py`:
+
+```python
+from crud_views.lib.check import CheckTemplateOrCode
+
+
+class FilterHeaderMissing:
+    cv_filter_header_template = "does-not-exist.html"
+    cv_filter_header_template_code = None
+
+
+class FilterHeaderValid:
+    cv_filter_header_template = "crud_views/snippets/header/filter.html"
+    cv_filter_header_template_code = None
+
+
+def test_filter_header_missing_template_errors():
+    check = CheckTemplateOrCode(context=FilterHeaderMissing, attribute="cv_filter_header_template")
+    messages = list(check.messages())
+    assert len(messages) == 1
+    assert "does-not-exist.html" in messages[0].msg
+
+
+def test_filter_header_valid_template_emits_no_message():
+    check = CheckTemplateOrCode(context=FilterHeaderValid, attribute="cv_filter_header_template")
+    assert list(check.messages()) == []
+
+
+def test_list_view_checks_include_filter_header():
+    from crud_views.lib.views.list import ListView
+
+    checks = list(ListView.checks())
+    attrs = {getattr(c, "attribute", None) for c in checks if isinstance(c, CheckTemplateOrCode)}
+    assert "cv_filter_header_template" in attrs
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tests && pytest test1/test_expand_checks.py -k filter_header -v`
+Expected: The two `CheckTemplateOrCode`-behavior tests PASS (class already exists); `test_list_view_checks_include_filter_header` FAILS — `cv_filter_header_template` not yet yielded by `ListView.checks()`.
+
+- [ ] **Step 3: Add the `ListView.checks()` override**
+
+In `src/crud_views/lib/views/list.py`, add a `checks()` classmethod to `ListView` (after the `cv_filter_header` property, staying inside the class). First ensure the imports include `Check` and `CheckTemplateOrCode` and `Iterable`:
+
+```python
+from typing import Iterable
+from crud_views.lib.check import Check, CheckTemplateOrCode
+```
+
+Then add:
+
+```python
+    @classmethod
+    def checks(cls) -> Iterable[Check]:
+        yield from super().checks()
+        yield CheckTemplateOrCode(context=cls, attribute="cv_filter_header_template")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd tests && pytest test1/test_expand_checks.py -k filter_header -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/crud_views/lib/views/list.py tests/test1/test_expand_checks.py
+git commit -m "feat(checks): validate cv_filter_header_template on ListView (E110) (#28)"
+```
+
+---
+
+### Task 6: Workflow dependency checks (E001 / E002)
+
+**Files:**
+- Create: `src/crud_views_workflow/checks.py`
+- Modify: `src/crud_views_workflow/apps.py` (register in `ready()`)
+- Test: `tests/test1/test_expand_checks.py`
+
+**Interfaces:**
+- Produces: `crud_views_workflow.checks.check_workflow_dependencies(app_configs=None, **kwargs) -> list[Error]` — returns `[]` when the app is not installed; otherwise yields `Error(id="crud_views_workflow.E001")` if `django_fsm` is not importable and `Error(id="crud_views_workflow.E002")` if `fsm_admin` is not importable. Helper `_importable(name: str) -> bool` (monkeypatchable in tests).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test1/test_expand_checks.py`:
+
+```python
+def test_workflow_deps_all_present_no_errors():
+    from crud_views_workflow import checks as wf_checks
+
+    # dev env installs the [workflow] extra, so both deps import
+    assert wf_checks.check_workflow_dependencies() == []
+
+
+def test_workflow_missing_django_fsm_emits_e001(monkeypatch):
+    from crud_views_workflow import checks as wf_checks
+
+    monkeypatch.setattr(wf_checks, "_importable", lambda name: name != "django_fsm")
+    errors = wf_checks.check_workflow_dependencies()
+    assert any(e.id == "crud_views_workflow.E001" for e in errors)
+    assert all(e.id != "crud_views_workflow.E002" for e in errors)
+
+
+def test_workflow_missing_fsm_admin_emits_e002(monkeypatch):
+    from crud_views_workflow import checks as wf_checks
+
+    monkeypatch.setattr(wf_checks, "_importable", lambda name: name != "fsm_admin")
+    errors = wf_checks.check_workflow_dependencies()
+    assert any(e.id == "crud_views_workflow.E002" for e in errors)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tests && pytest test1/test_expand_checks.py -k workflow -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'crud_views_workflow.checks'`
+
+- [ ] **Step 3: Create the checks module**
+
+Create `src/crud_views_workflow/checks.py`:
+
+```python
+import importlib.util
+
+from django.apps import apps
+from django.core.checks import Error, register
+
+TAG = "crud_views_workflow"
+
+
+def _importable(name: str) -> bool:
+    """True if the named top-level module can be imported."""
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+@register(TAG)
+def check_workflow_dependencies(app_configs=None, **kwargs):
+    """Error when crud_views_workflow is installed but its runtime deps are missing."""
+    errors = []
+    if not apps.is_installed("crud_views_workflow"):
+        return errors
+    if not _importable("django_fsm"):
+        errors.append(
+            Error(
+                "django-fsm-2 is required by crud_views_workflow but is not installed.",
+                hint="Install the optional extra: pip install django-crud-views[workflow]",
+                id="crud_views_workflow.E001",
+            )
+        )
+    if not _importable("fsm_admin"):
+        errors.append(
+            Error(
+                "django-fsm-2-admin is required by crud_views_workflow but is not installed.",
+                hint="Install the optional extra: pip install django-crud-views[workflow]",
+                id="crud_views_workflow.E002",
+            )
+        )
+    return errors
+```
+
+- [ ] **Step 4: Register the checks module in `ready()`**
+
+In `src/crud_views_workflow/apps.py`, replace the `ready()` body:
+
+```python
+    def ready(self):
+        import crud_views_workflow.checks  # noqa
+```
+
+(Remove the `# import crud_views.checks  # noqa` comment and the `pass`.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd tests && pytest test1/test_expand_checks.py -k workflow -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/crud_views_workflow/checks.py src/crud_views_workflow/apps.py tests/test1/test_expand_checks.py
+git commit -m "feat(checks): workflow dependency checks for django-fsm-2 & fsm-admin (E001/E002) (#28)"
+```
+
+---
+
+### Task 7: Full-suite verification & lint
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the entire test suite**
+
+Run: `cd tests && pytest -q`
+Expected: All pass (existing baseline was 530 passed, 1 skipped; expect that plus the new `test_expand_checks.py` cases).
+
+- [ ] **Step 2: Run Django's own check command against the test project**
+
+Run: `cd tests && python -m pytest test1/test_expand_checks.py -q` (already covered) and confirm no uncaught exceptions during check collection by running the suite; the registered checks execute when the test app boots.
+
+- [ ] **Step 3: Lint & format**
+
+Run: `ruff format && ruff check --fix`
+Expected: clean, no changes needed beyond formatting.
+
+- [ ] **Step 4: Commit any lint fixes (if produced)**
+
+```bash
+git add -A
+git commit -m "style: ruff format for system-checks expansion (#28)" || echo "nothing to commit"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Gap #1 (type validation) → Task 1 (`CheckAttributeType`, E101). ✓
+- Gap #2 (formsets checks) → Task 2 (`CheckMapping`, E205) + Task 3 (wiring E204/E205/E206). ✓
+- Gap #3 (reactivate ContextActionCheck) → Task 4 (E203 repair + wiring). ✓
+- Gap #5 (filter header template) → Task 5 (E110 on `ListView`). ✓
+- Gap #6 (workflow deps) → Task 6 (E001/E002 + `ready()` registration). ✓
+- Gap #4 → intentionally out of scope (already covered by E111). ✓
+- ID table from spec fully realized: E101, E203, E204, E205, E206, E110, E001, E002. ✓
+- Testing section (TDD per gap, dummy-context idiom, monkeypatch for deps) → each task Step 1. ✓
+- Verification (pytest green, ruff clean, manual check) → Task 7. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; every command has expected output. ✓
+
+**Type consistency:** `CheckAttributeType(expected_type=...)`, `CheckMapping(key_type=, value_type=)`, `ContextActionCheck(id="E203")`, `check_workflow_dependencies()` / `_importable()` names are consistent across the tasks that define and consume them. Formsets ids E204/E205/E206 distinct from cv_key's E200. ✓

--- a/superpowers/specs/2026-07-17-expand-system-checks-design.md
+++ b/superpowers/specs/2026-07-17-expand-system-checks-design.md
@@ -1,0 +1,181 @@
+# Expand Django system checks (#28) — Design
+
+**Issue:** [#28 Expand Django system checks](https://github.com/jacob-consulting/django-crud-views/issues/28)
+**Date:** 2026-07-17
+**Status:** Approved (brainstorming complete)
+
+## Context
+
+`django-crud-views` validates ViewSet/CrudView configuration at startup through
+Django's system-check framework. Checks are declared as `checks()` classmethods
+that yield `Check` (pydantic) objects — `CheckAttribute`, `CheckAttributeReg`,
+`CheckTemplateOrCode`, `CheckTemplate`, `CheckExpression` — collected via
+`ViewSet.checks_all()` and surfaced by the `@register("crud_views")` functions in
+`crud_views/checks.py`.
+
+Issue #28 collects six check gaps from the 2026-06-10 audit triage. One of them
+(#4) is verified already implemented; the remaining five are the scope of this
+work. All items are additive dev-time tooling with no semver/runtime impact.
+
+## Ground-truth findings
+
+- **Gap #4 (cv_extends template) is already done.** `CheckTemplate` (E111)
+  already validates the view-level `cv_extends_template` (`lib/view/base.py:98`)
+  **and** the ViewSet-level `extends` (`lib/viewset/__init__.py:165`). No work
+  remains — this sub-item is closed with evidence, not reimplemented.
+- **`ContextActionCheck` exists but is wired nowhere** (`lib/check.py:202`) and is
+  stale: its body reads `self.context.cv`, which no longer matches the current
+  `cv_viewset` API. Its `viewset.has_view(action)` call *is* correct against
+  today's `ViewSet.has_view(name)` API.
+- **Formsets checks reuse `id="E200"`**, colliding with `cv_key`'s E200
+  (`lib/formsets/mixins.py`). They only assert existence, not type.
+- **Workflow dependency import names:** the optional extra `workflow` installs
+  `django-fsm-2` (imports as `django_fsm`) and `django-fsm-2-admin` (imports as
+  `fsm_admin`). `crud_views_workflow/apps.py:ready()` is currently a no-op `pass`.
+
+## Scope
+
+Five gaps: #1 type validation, #2 formsets checks, #3 reactivate context-action
+check, #5 filter header template check, #6 workflow dependency checks.
+Out of scope: #4 (already covered by E111).
+
+## Design
+
+### 1. `CheckAttributeType` — new check class (`lib/check.py`)
+
+New subclass of `CheckAttribute`, mirroring `CheckAttributeReg`:
+
+```python
+class CheckAttributeType(CheckAttribute):
+    id: str = "E101"
+    expected_type: type | tuple[type, ...]
+    msg: str = "Attribute »{attribute}» value »{value}» is not of type »{expected_type}» at »{context}»"
+
+    def get_message_context(self) -> dict:
+        context = super().get_message_context()
+        context.update(expected_type=self.expected_type)
+        return context
+
+    def messages(self) -> Iterable[CheckMessage]:
+        yield from super().messages()  # existence / None check
+        if self.exists and self.value is not None and not isinstance(self.value, self.expected_type):
+            yield Error(id=self.get_id(), msg=self.get_message())
+```
+
+Existence/None handling is inherited unchanged; the type assertion is additive
+and skips when the value is absent or None (those cases are the parent's concern).
+
+### 2. Formsets checks (`lib/formsets/mixins.py` + `lib/check.py`)
+
+- `FormSetMixin.cv_formsets` → `CheckAttributeType(context=cls, id="E204", attribute="cv_formsets", expected_type=FormSets)`.
+- `PolymorphicFormSetsViewMixin.cv_polymorphic_formsets` → new **`CheckMapping`**
+  check in `check.py`:
+
+```python
+class CheckMapping(CheckAttribute):
+    """Validate a dict attribute's key/value types."""
+    id: str = "E205"
+    key_type: type | tuple[type, ...]
+    value_type: type | tuple[type, ...]
+    # emits: not a dict; key not a subclass/instance of key_type; value not of value_type
+```
+
+  For `cv_polymorphic_formsets` the mapping is `Dict[Type[Model], FormSets]`:
+  keys are validated as `Model` **subclasses** (`issubclass`), values as
+  `FormSets` **instances** (`isinstance`). The check must handle the
+  subclass-vs-instance distinction for keys explicitly, and guard the key check
+  with `isinstance(key, type)` first — `issubclass` raises `TypeError` on a
+  non-class key (e.g. a stray string), which must surface as an E205 error, not
+  an uncaught exception during `manage.py check`.
+- **Side fix:** replace the two colliding `id="E200"` declarations with the
+  distinct IDs above (E204, E205). `FormSetMixinBase.cv_formsets_required` keeps
+  a plain `CheckAttribute` but moves off the colliding E200 — reassign to a fresh
+  id (E206) so all three formset checks are distinct.
+
+### 3. Reactivate `ContextActionCheck` as E203 (`lib/check.py` + `lib/view/base.py`)
+
+Repair the body: `self.context.cv` → `self.context.cv_viewset`. Keep the
+`has_view(action)` call. Wire into `CrudView.checks()`:
+
+```python
+yield ContextActionCheck(context=cls, id="E203")
+```
+
+Validates every key in `cv_context_actions` resolves to a real view in the
+ViewSet. Guard for `cv_context_actions is None` (already handled by
+`or list()`).
+
+### 4. Filter header template check (`lib/views/list.py`)
+
+`ListView` defines `cv_filter_header_template` / `cv_filter_header_template_code`
+(a template-or-code pair) but no check validates them. Add to `ListView.checks()`
+(overriding to call `super().checks()` then yielding one more):
+
+```python
+yield CheckTemplateOrCode(context=cls, attribute="cv_filter_header_template")
+```
+
+The default template resolves cleanly; the check catches a typo'd override.
+
+### 5. Workflow dependency checks (new `crud_views_workflow/checks.py`)
+
+```python
+@register("crud_views_workflow")
+def check_workflow_dependencies(app_configs=None, **kwargs):
+    from django.apps import apps
+    errors = []
+    if not apps.is_installed("crud_views_workflow"):
+        return errors
+    if not _importable("django_fsm"):
+        errors.append(Error("django-fsm-2 is required by crud_views_workflow but is not installed.",
+                            hint="pip install django-crud-views[workflow]", id="crud_views_workflow.E001"))
+    if not _importable("fsm_admin"):
+        errors.append(Error("django-fsm-2-admin is required by crud_views_workflow but is not installed.",
+                            hint="pip install django-crud-views[workflow]", id="crud_views_workflow.E002"))
+    return errors
+```
+
+`_importable(name)` uses `importlib.util.find_spec` inside a try/except so a
+missing dep never raises. Replace the `pass` in `apps.py:ready()` with
+`import crud_views_workflow.checks  # noqa` to register it.
+
+## Check ID summary
+
+| ID | Check | Where |
+|----|-------|-------|
+| `viewset.E101` | `CheckAttributeType` default | `lib/check.py` |
+| `viewset.E203` | `ContextActionCheck` (reactivated) | `lib/view/base.py` |
+| `viewset.E204` | `cv_formsets` is a `FormSets` | `lib/formsets/mixins.py` |
+| `viewset.E205` | `cv_polymorphic_formsets` mapping shape | `lib/formsets/mixins.py` |
+| `viewset.E206` | `cv_formsets_required` exists | `lib/formsets/mixins.py` |
+| `viewset.E110` | filter header template-or-code | `lib/views/list.py` |
+| `crud_views_workflow.E001` | `django_fsm` importable | `crud_views_workflow/checks.py` |
+| `crud_views_workflow.E002` | `fsm_admin` importable | `crud_views_workflow/checks.py` |
+
+## Testing
+
+TDD per gap — write the failing test first, then implement:
+
+- **CheckAttributeType:** a view/context with a wrong-typed attribute → asserts
+  E101 fires; correct type → no error; absent/None → deferred to existence check
+  (no E101).
+- **Formsets:** a `FormSetMixin` subclass with `cv_formsets = <not a FormSets>` →
+  E204; a `PolymorphicFormSetsViewMixin` with a bad mapping (non-Model key or
+  non-FormSets value) → E205; valid configs → clean.
+- **ContextActionCheck:** a view whose `cv_context_actions` names a non-existent
+  view key → E203; all-valid actions → clean.
+- **Filter header:** a `ListView` subclass with `cv_filter_header_template =
+  "does/not/exist.html"` → E110; default → clean.
+- **Workflow deps:** simulate `find_spec` returning None for `django_fsm` /
+  `fsm_admin` (monkeypatch) → asserts E001 / E002; both present → clean; app not
+  installed → clean.
+
+Tests live in `tests/test1/` following the existing check-test patterns. Run the
+full suite (`cd tests && pytest`) to confirm zero regressions.
+
+## Verification
+
+- `pytest` green across the check tests and the full suite.
+- `ruff format` / `ruff check --fix` clean.
+- Manual: a deliberately-misconfigured test app surfaces each new error id via
+  `manage.py check`.

--- a/superpowers/specs/2026-07-17-expand-system-checks-design.md
+++ b/superpowers/specs/2026-07-17-expand-system-checks-design.md
@@ -35,9 +35,11 @@ work. All items are additive dev-time tooling with no semver/runtime impact.
 
 ## Scope
 
-Five gaps: #1 type validation, #2 formsets checks, #3 reactivate context-action
-check, #5 filter header template check, #6 workflow dependency checks.
-Out of scope: #4 (already covered by E111).
+Originally five gaps: #1 type validation, #2 formsets checks, #3 reactivate
+context-action check, #5 filter header template check, #6 workflow dependency
+checks. During implementation **#3 was dropped as obsolete** (see section 3), so
+the shipped work is four gaps: #1, #2, #5, #6.
+Out of scope: #4 (already covered by E111), #3 (obsolete — no invariant to enforce).
 
 ## Design
 
@@ -92,18 +94,32 @@ class CheckMapping(CheckAttribute):
   a plain `CheckAttribute` but moves off the colliding E200 — reassign to a fresh
   id (E206) so all three formset checks are distinct.
 
-### 3. Reactivate `ContextActionCheck` as E203 (`lib/check.py` + `lib/view/base.py`)
+### 3. ~~Reactivate `ContextActionCheck` as E203~~ — DROPPED as obsolete
 
-Repair the body: `self.context.cv` → `self.context.cv_viewset`. Keep the
-`has_view(action)` call. Wire into `CrudView.checks()`:
+**Decision (2026-07-17, during implementation):** gap #3 is closed as
+**obsolete — no code**. Implementation revealed the check has no invariant left
+to enforce:
 
-```python
-yield ContextActionCheck(context=cls, id="E203")
-```
+- `CrudView.cv_get_context()` (`base.py:409`) resolves a `cv_context_actions`
+  entry via **two** paths — a context button (`cv_context_buttons` /
+  viewset-level `context_buttons`, e.g. `"home"`, `"parent"`, `"filter"`) or a
+  registered view key (`has_view`) — and, crucially, **deliberately treats an
+  entry resolving to neither as "not a misconfiguration" and silently skips
+  it** (explicit code comment). This resolution logic post-dates the original
+  `ContextActionCheck`, which only tested `has_view`.
+- The framework's own default context-action settings all include `"home"`
+  (a context button, not a view), so a `has_view`-only E203 would false-positive
+  on essentially every default-configured view.
+- Even a corrected two-path check contradicts the runtime's explicit
+  tolerance: it fires on the common, runtime-supported pattern of a read-mostly
+  partial ViewSet that doesn't register `update`/`delete` but inherits defaults
+  naming them (37 such fixtures exist in the test app alone). The rare value
+  (catching a typo in an explicitly-set action) is outweighed by punishing
+  legitimate configs the framework intentionally supports.
 
-Validates every key in `cv_context_actions` resolves to a real view in the
-ViewSet. Guard for `cv_context_actions is None` (already handled by
-`or list()`).
+The dead `ContextActionCheck` class is **removed** from `check.py` rather than
+left dormant. No wiring is added. The `CampaignDetailView` test fixture keeps a
+more-accurate explicit `cv_context_actions` as an incidental cleanup.
 
 ### 4. Filter header template check (`lib/views/list.py`)
 
@@ -144,7 +160,7 @@ missing dep never raises. Replace the `pass` in `apps.py:ready()` with
 | ID | Check | Where |
 |----|-------|-------|
 | `viewset.E101` | `CheckAttributeType` default | `lib/check.py` |
-| `viewset.E203` | `ContextActionCheck` (reactivated) | `lib/view/base.py` |
+| ~~`viewset.E203`~~ | ~~`ContextActionCheck`~~ — dropped as obsolete (gap #3) | — |
 | `viewset.E204` | `cv_formsets` is a `FormSets` | `lib/formsets/mixins.py` |
 | `viewset.E205` | `cv_polymorphic_formsets` mapping shape | `lib/formsets/mixins.py` |
 | `viewset.E206` | `cv_formsets_required` exists | `lib/formsets/mixins.py` |

--- a/tests/test1/app/views.py
+++ b/tests/test1/app/views.py
@@ -543,6 +543,9 @@ class CampaignListView(ListViewTableMixin, ListViewPermissionRequired):
 
 class CampaignDetailView(DetailViewPermissionRequired):
     cv_viewset = cv_campaign
+    # cv_campaign only registers list/detail/workflow (no update/delete) — override the
+    # DetailView default (which assumes update/delete exist) to match the real ViewSet.
+    cv_context_actions = ["list", "detail", "workflow"]
     cv_property_display = [
         {
             "title": "Attributes",

--- a/tests/test1/test_expand_checks.py
+++ b/tests/test1/test_expand_checks.py
@@ -1,4 +1,4 @@
-from crud_views.lib.check import CheckAttributeType, CheckMapping
+from crud_views.lib.check import CheckAttributeType, CheckMapping, ContextActionCheck
 from django.db.models import Model
 from tests.test1.app.models import Book
 from crud_views.lib.formsets.formsets import FormSets
@@ -100,3 +100,44 @@ def test_formset_checks_do_not_reuse_e200_for_formsets():
     e200_attrs = {getattr(c, "attribute", None) for c in checks if getattr(c, "id", None) == "E200"}
     assert "cv_formsets" not in e200_attrs
     assert "cv_formsets_required" not in e200_attrs
+
+
+class FakeViewset:
+    def __init__(self, keys):
+        self._keys = keys
+
+    def has_view(self, name):
+        return name in self._keys
+
+
+class CtxActionsValid:
+    cv_viewset = FakeViewset(["update", "delete"])
+    cv_context_actions = ["update", "delete"]
+
+
+class CtxActionsBad:
+    cv_viewset = FakeViewset(["update"])
+    cv_context_actions = ["update", "does_not_exist"]
+
+
+class CtxActionsNone:
+    cv_viewset = FakeViewset(["update"])
+    cv_context_actions = None
+
+
+def test_context_action_check_valid_emits_no_message():
+    check = ContextActionCheck(context=CtxActionsValid, id="E203")
+    assert list(check.messages()) == []
+
+
+def test_context_action_check_missing_view_emits_error():
+    check = ContextActionCheck(context=CtxActionsBad, id="E203")
+    messages = list(check.messages())
+    assert len(messages) == 1
+    assert messages[0].id == "viewset.E203"
+    assert "does_not_exist" in messages[0].msg
+
+
+def test_context_action_check_none_emits_no_message():
+    check = ContextActionCheck(context=CtxActionsNone, id="E203")
+    assert list(check.messages()) == []

--- a/tests/test1/test_expand_checks.py
+++ b/tests/test1/test_expand_checks.py
@@ -129,3 +129,27 @@ def test_list_view_checks_include_filter_header():
     checks = list(ListView.checks())
     attrs = {getattr(c, "attribute", None) for c in checks if isinstance(c, CheckTemplateOrCode)}
     assert "cv_filter_header_template" in attrs
+
+
+def test_workflow_deps_all_present_no_errors():
+    from crud_views_workflow import checks as wf_checks
+
+    # dev env installs the [workflow] extra, so both deps import
+    assert wf_checks.check_workflow_dependencies() == []
+
+
+def test_workflow_missing_django_fsm_emits_e001(monkeypatch):
+    from crud_views_workflow import checks as wf_checks
+
+    monkeypatch.setattr(wf_checks, "_importable", lambda name: name != "django_fsm")
+    errors = wf_checks.check_workflow_dependencies()
+    assert any(e.id == "crud_views_workflow.E001" for e in errors)
+    assert all(e.id != "crud_views_workflow.E002" for e in errors)
+
+
+def test_workflow_missing_fsm_admin_emits_e002(monkeypatch):
+    from crud_views_workflow import checks as wf_checks
+
+    monkeypatch.setattr(wf_checks, "_importable", lambda name: name != "fsm_admin")
+    errors = wf_checks.check_workflow_dependencies()
+    assert any(e.id == "crud_views_workflow.E002" for e in errors)

--- a/tests/test1/test_expand_checks.py
+++ b/tests/test1/test_expand_checks.py
@@ -1,4 +1,4 @@
-from crud_views.lib.check import CheckAttributeType, CheckMapping, ContextActionCheck
+from crud_views.lib.check import CheckAttributeType, CheckMapping
 from django.db.models import Model
 from tests.test1.app.models import Book
 from crud_views.lib.formsets.formsets import FormSets
@@ -100,44 +100,3 @@ def test_formset_checks_do_not_reuse_e200_for_formsets():
     e200_attrs = {getattr(c, "attribute", None) for c in checks if getattr(c, "id", None) == "E200"}
     assert "cv_formsets" not in e200_attrs
     assert "cv_formsets_required" not in e200_attrs
-
-
-class FakeViewset:
-    def __init__(self, keys):
-        self._keys = keys
-
-    def has_view(self, name):
-        return name in self._keys
-
-
-class CtxActionsValid:
-    cv_viewset = FakeViewset(["update", "delete"])
-    cv_context_actions = ["update", "delete"]
-
-
-class CtxActionsBad:
-    cv_viewset = FakeViewset(["update"])
-    cv_context_actions = ["update", "does_not_exist"]
-
-
-class CtxActionsNone:
-    cv_viewset = FakeViewset(["update"])
-    cv_context_actions = None
-
-
-def test_context_action_check_valid_emits_no_message():
-    check = ContextActionCheck(context=CtxActionsValid, id="E203")
-    assert list(check.messages()) == []
-
-
-def test_context_action_check_missing_view_emits_error():
-    check = ContextActionCheck(context=CtxActionsBad, id="E203")
-    messages = list(check.messages())
-    assert len(messages) == 1
-    assert messages[0].id == "viewset.E203"
-    assert "does_not_exist" in messages[0].msg
-
-
-def test_context_action_check_none_emits_no_message():
-    check = ContextActionCheck(context=CtxActionsNone, id="E203")
-    assert list(check.messages()) == []

--- a/tests/test1/test_expand_checks.py
+++ b/tests/test1/test_expand_checks.py
@@ -1,8 +1,9 @@
-from crud_views.lib.check import CheckAttributeType, CheckMapping
+from crud_views.lib.check import CheckAttributeType, CheckMapping, CheckTemplateOrCode
 from django.db.models import Model
 from tests.test1.app.models import Book
 from crud_views.lib.formsets.formsets import FormSets
 from tests.test1.app.views_formset import PublisherFormSetCreateView
+from crud_views.lib.views.list import ListView
 
 
 class GoodType:
@@ -100,3 +101,31 @@ def test_formset_checks_do_not_reuse_e200_for_formsets():
     e200_attrs = {getattr(c, "attribute", None) for c in checks if getattr(c, "id", None) == "E200"}
     assert "cv_formsets" not in e200_attrs
     assert "cv_formsets_required" not in e200_attrs
+
+
+class FilterHeaderMissing:
+    cv_filter_header_template = "does-not-exist.html"
+    cv_filter_header_template_code = None
+
+
+class FilterHeaderValid:
+    cv_filter_header_template = "crud_views/snippets/header/filter.html"
+    cv_filter_header_template_code = None
+
+
+def test_filter_header_missing_template_errors():
+    check = CheckTemplateOrCode(context=FilterHeaderMissing, attribute="cv_filter_header_template")
+    messages = list(check.messages())
+    assert len(messages) == 1
+    assert "does-not-exist.html" in messages[0].msg
+
+
+def test_filter_header_valid_template_emits_no_message():
+    check = CheckTemplateOrCode(context=FilterHeaderValid, attribute="cv_filter_header_template")
+    assert list(check.messages()) == []
+
+
+def test_list_view_checks_include_filter_header():
+    checks = list(ListView.checks())
+    attrs = {getattr(c, "attribute", None) for c in checks if isinstance(c, CheckTemplateOrCode)}
+    assert "cv_filter_header_template" in attrs

--- a/tests/test1/test_expand_checks.py
+++ b/tests/test1/test_expand_checks.py
@@ -1,4 +1,6 @@
-from crud_views.lib.check import CheckAttributeType
+from crud_views.lib.check import CheckAttributeType, CheckMapping
+from django.db.models import Model
+from tests.test1.app.models import Book
 
 
 class GoodType:
@@ -29,4 +31,53 @@ def test_check_attribute_type_wrong_emits_error():
 def test_check_attribute_type_none_defers_to_existence_only():
     # nullable=True so the existence check passes; type check must not fire on None
     check = CheckAttributeType(context=NoneType, id="E101", attribute="attr", expected_type=str, nullable=True)
+    assert list(check.messages()) == []
+
+
+class NotADict:
+    attr = ["not", "a", "dict"]
+
+
+class NonClassKey:
+    attr = {"strkey": "v"}
+
+
+class NonSubclassKey:
+    attr = {int: "v"}
+
+
+class BadValue:
+    attr = {Book: 123}
+
+
+class ValidMapping:
+    attr = {Book: "v"}
+
+
+def test_check_mapping_not_a_dict_errors():
+    check = CheckMapping(context=NotADict, id="E205", attribute="attr", key_type=Model, value_type=str)
+    messages = list(check.messages())
+    assert len(messages) == 1
+    assert messages[0].id == "viewset.E205"
+
+
+def test_check_mapping_non_class_key_errors_without_raising():
+    check = CheckMapping(context=NonClassKey, id="E205", attribute="attr", key_type=Model, value_type=str)
+    messages = list(check.messages())
+    assert len(messages) == 1
+    assert messages[0].id == "viewset.E205"
+
+
+def test_check_mapping_non_subclass_key_errors():
+    check = CheckMapping(context=NonSubclassKey, id="E205", attribute="attr", key_type=Model, value_type=str)
+    assert len(list(check.messages())) == 1
+
+
+def test_check_mapping_bad_value_errors():
+    check = CheckMapping(context=BadValue, id="E205", attribute="attr", key_type=Model, value_type=str)
+    assert len(list(check.messages())) == 1
+
+
+def test_check_mapping_valid_emits_no_message():
+    check = CheckMapping(context=ValidMapping, id="E205", attribute="attr", key_type=Model, value_type=str)
     assert list(check.messages()) == []

--- a/tests/test1/test_expand_checks.py
+++ b/tests/test1/test_expand_checks.py
@@ -1,0 +1,32 @@
+from crud_views.lib.check import CheckAttributeType
+
+
+class GoodType:
+    attr = "a string"
+
+
+class BadType:
+    attr = 123
+
+
+class NoneType:
+    attr = None
+
+
+def test_check_attribute_type_correct_emits_no_message():
+    check = CheckAttributeType(context=GoodType, id="E101", attribute="attr", expected_type=str)
+    assert list(check.messages()) == []
+
+
+def test_check_attribute_type_wrong_emits_error():
+    check = CheckAttributeType(context=BadType, id="E101", attribute="attr", expected_type=str)
+    messages = list(check.messages())
+    assert len(messages) == 1
+    assert messages[0].id == "viewset.E101"
+    assert "is not of type" in messages[0].msg
+
+
+def test_check_attribute_type_none_defers_to_existence_only():
+    # nullable=True so the existence check passes; type check must not fire on None
+    check = CheckAttributeType(context=NoneType, id="E101", attribute="attr", expected_type=str, nullable=True)
+    assert list(check.messages()) == []

--- a/tests/test1/test_expand_checks.py
+++ b/tests/test1/test_expand_checks.py
@@ -1,6 +1,8 @@
 from crud_views.lib.check import CheckAttributeType, CheckMapping
 from django.db.models import Model
 from tests.test1.app.models import Book
+from crud_views.lib.formsets.formsets import FormSets
+from tests.test1.app.views_formset import PublisherFormSetCreateView
 
 
 class GoodType:
@@ -81,3 +83,20 @@ def test_check_mapping_bad_value_errors():
 def test_check_mapping_valid_emits_no_message():
     check = CheckMapping(context=ValidMapping, id="E205", attribute="attr", key_type=Model, value_type=str)
     assert list(check.messages()) == []
+
+
+def test_formset_create_view_yields_e204_typed_check():
+    checks = list(PublisherFormSetCreateView.checks())
+    e204 = [c for c in checks if getattr(c, "id", None) == "E204"]
+    assert len(e204) == 1
+    assert isinstance(e204[0], CheckAttributeType)
+    assert e204[0].attribute == "cv_formsets"
+    assert e204[0].expected_type is FormSets
+
+
+def test_formset_checks_do_not_reuse_e200_for_formsets():
+    # E200 belongs to cv_key; formsets must not collide with it
+    checks = list(PublisherFormSetCreateView.checks())
+    e200_attrs = {getattr(c, "attribute", None) for c in checks if getattr(c, "id", None) == "E200"}
+    assert "cv_formsets" not in e200_attrs
+    assert "cv_formsets_required" not in e200_attrs


### PR DESCRIPTION
## Summary

Expands the package's Django system checks per #28, closing four of the collected check gaps. Additive dev-time tooling only — no runtime/semver impact.

## Shipped (4 gaps)

- **#1 `CheckAttributeType` (E101)** — new `CheckAttribute` subclass asserting `isinstance(value, expected_type)`.
- **#2 formset checks** — `cv_formsets` → `CheckAttributeType` (E204); `cv_polymorphic_formsets` → new `CheckMapping` (E205) validating dict shape (keys are `Model` subclasses, values are `FormSets`, guarded against non-class keys). Also fixes a **pre-existing id collision**: all three formset checks previously reused `id="E200"` (which belongs to `cv_key`), now `E204`/`E205`/`E206`.
- **#5 filter-header template check (E110)** — `ListView.checks()` now validates `cv_filter_header_template` via `CheckTemplateOrCode`.
- **#6 workflow dependency checks** — new `crud_views_workflow/checks.py` errors when the app is installed but `django_fsm` (E001) or `fsm_admin` (E002) isn't importable; registered from `apps.py:ready()`.

## Decisions (documented in the design spec)

- **#4 — already done.** E111 already validates both the view-level `cv_extends_template` and the ViewSet-level `extends`. No work needed.
- **#3 (reactivate `ContextActionCheck`, E203) — dropped as obsolete.** During implementation we found `CrudView.cv_get_context()` (`base.py:409`) deliberately treats a `cv_context_actions` key that resolves to neither a context button nor a registered view as *"not a misconfiguration"* and silently skips it. The framework's own default context actions all include `"home"` (a context button, not a view), and the common partial-viewset pattern means an E203 error would false-positive on legitimate, runtime-supported configs (37 such fixtures exist in the test app alone). There is no invariant left to enforce, so the stale `ContextActionCheck` class was **removed** rather than wired. A minor `CampaignDetailView` fixture cleanup (more accurate `cv_context_actions`) was retained.

## Testing

- Full suite: **554 passed, 1 skipped**; `ruff format`/`ruff check` clean.
- Every check has TDD unit coverage in `tests/test1/test_expand_checks.py` (dummy-context idiom + wiring assertions on real views; workflow deps via `monkeypatch`).

## New check IDs

| ID | Check |
|----|-------|
| `viewset.E101` | `CheckAttributeType` (reusable) |
| `viewset.E204` | `cv_formsets` is a `FormSets` |
| `viewset.E205` | `cv_polymorphic_formsets` mapping shape |
| `viewset.E206` | `cv_formsets_required` exists (moved off the E200 collision) |
| `viewset.E110` | filter-header template-or-code on `ListView` |
| `crud_views_workflow.E001` / `E002` | `django_fsm` / `fsm_admin` importable |

Closes #28.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
