### PR TITLE
ci: reap the detached example server on Windows (defensive; flake cause unconfirmed)

### DIFF
--- a/.github/workflows/readme-examples.yml
+++ b/.github/workflows/readme-examples.yml
@@ -12,10 +12,10 @@
 #   - Windows redirects runserver output to runserver.log instead of the
 #     inherited console handle; the redirection is what prevents the step from
 #     hanging on that inherited handle
-#   - a separate Windows cleanup step kills the server (no README analog).
-#     Relying on the runner's job cleanup is not enough: that runs *after* the
-#     setup-python/checkout post-run steps, so the still-live server keeps
-#     handles open on .venv and those steps fail intermittently.
+#   - a separate Windows cleanup step reaps the server (no README analog).
+#     `start /b` detaches it, so nothing in the step guarantees it is gone.
+#     In practice it has been observed already dead by the next step, so this
+#     is defensive tidying, not a proven fix for anything.
 name: readme-examples
 
 on:
@@ -75,14 +75,21 @@ jobs:
           python manage.py seed
           start /b python manage.py runserver --noreload > runserver.log 2>&1 < nul
           python ..\..\scripts\wait_for_server.py http://127.0.0.1:8000/login/ 60
-      # `start /b` detaches the server, so it outlives the step above and keeps
-      # handles open on .venv — which makes the actions' post-run cleanup fail
-      # intermittently (seen on PR #94). Reap it here, before those steps run.
-      # always() so the server is killed even when the step above failed.
+      # `start /b` detaches the server; nothing in the step above guarantees it
+      # is gone. This reaps it explicitly, before the actions' post-run steps.
+      #
+      # NOT a proven fix for the intermittent post-run failure seen on PR #94:
+      # on the first run with this step, tasklist reported no surviving python
+      # process, so the step had nothing to kill. That failure produced no
+      # diagnostic output and both post-run steps failed within the same second,
+      # which looks more like an infrastructure blip than a file lock. Keep this
+      # as cheap insurance against a detached server lingering; if the flake
+      # recurs, the tasklist output here is the first thing to read.
+      #
+      # always() so the server is reaped even when the step above failed.
       # Matching on the image name is safe: nothing later in the job needs
-      # Python, and the runner is disposable. tasklist first so the log shows
-      # whether the server really was still alive; `exit /b 0` keeps cleanup
-      # from ever failing the job.
+      # Python, and the runner is disposable. `exit /b 0` keeps cleanup from
+      # ever failing the job.
       - name: Stop example server (Windows)
         if: always() && runner.os == 'Windows'
         shell: cmd

--- a/.github/workflows/readme-examples.yml
+++ b/.github/workflows/readme-examples.yml
@@ -10,9 +10,12 @@
 #     human opening the browser
 #   - `kill %1 || true` cleanup on Linux/macOS (no README analog)
 #   - Windows redirects runserver output to runserver.log instead of the
-#     inherited console handle, and has no explicit kill: `start /b`'s child
-#     is terminated by the runner's job cleanup, and the redirection is what
-#     prevents the step from hanging on that inherited handle
+#     inherited console handle; the redirection is what prevents the step from
+#     hanging on that inherited handle
+#   - a separate Windows cleanup step kills the server (no README analog).
+#     Relying on the runner's job cleanup is not enough: that runs *after* the
+#     setup-python/checkout post-run steps, so the still-live server keeps
+#     handles open on .venv and those steps fail intermittently.
 name: readme-examples
 
 on:
@@ -72,3 +75,18 @@ jobs:
           python manage.py seed
           start /b python manage.py runserver --noreload > runserver.log 2>&1 < nul
           python ..\..\scripts\wait_for_server.py http://127.0.0.1:8000/login/ 60
+      # `start /b` detaches the server, so it outlives the step above and keeps
+      # handles open on .venv — which makes the actions' post-run cleanup fail
+      # intermittently (seen on PR #94). Reap it here, before those steps run.
+      # always() so the server is killed even when the step above failed.
+      # Matching on the image name is safe: nothing later in the job needs
+      # Python, and the runner is disposable. tasklist first so the log shows
+      # whether the server really was still alive; `exit /b 0` keeps cleanup
+      # from ever failing the job.
+      - name: Stop example server (Windows)
+        if: always() && runner.os == 'Windows'
+        shell: cmd
+        run: |
+          tasklist /FI "IMAGENAME eq python.exe"
+          taskkill /F /IM python.exe
+          exit /b 0


### PR DESCRIPTION
## Status: this does NOT demonstrably fix the flake

I opened this claiming the detached server held handles on `.venv` and caused the intermittent post-run failures. **The evidence disproves that.** Read this section before deciding whether to merge.

The cleanup step prints `tasklist` before killing, precisely so the claim could be checked. On the first run:

```
INFO: No tasks are running which match the specified criteria.
ERROR: The process "python.exe" not found.
```

The server was already gone. The step had nothing to kill, so it cannot have fixed anything on that run.

Re-examining the original failure on #94 undermines the theory further: both post-run steps failed **within the same second** (`06:45:13Z` → `06:45:13Z`) and produced **no diagnostic output whatsoever**. A file-lock problem reports `EPERM`/`EBUSY` and takes time. This looks more like an infrastructure blip. **The real cause is unknown.**

## What this PR is now

Defensive tidying, honestly labelled:

- `start /b` detaches the server and nothing in the step guarantees it is gone. Reaping it explicitly is correct hygiene regardless of the flake.
- `if: always()` so it runs even when the main step failed.
- `exit /b 0` so cleanup can never itself fail the job.
- `tasklist` before `taskkill` so that **if the flake recurs, the log already answers whether a server was alive** — the diagnostic that was missing the first time.

It also corrects the header comment, which asserted that no kill was needed because "the runner's job cleanup terminates the child". That rationale was unverified. I replaced it with what is actually known — rather than substituting my own confident-but-wrong explanation, which was the original defect.

## Reasonable options

1. **Merge** — harmless hygiene plus a diagnostic for the next occurrence.
2. **Close** — the flake is unexplained and this does not fix it; a single re-run cleared it.

I lean (1) for the diagnostic value, but it should not be described as a flake fix. Deliberately not merging without a decision.

## Verification

All checks green. YAML parses; cleanup step ordered last so it precedes the post-run steps. The behaviour cannot be reproduced locally (Windows-only, intermittent), and a green run does not prove a flake is gone.