### PR TITLE
test(js): Vitest+jsdom unit-test harness for static JS; fix DELETE reorder bug

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -1,0 +1,19 @@
+name: JS Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  js-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npx vitest run

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ coverage.xml
 /insights
 TASKS.md
 .worktrees
+node_modules
+coverage-js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+
+- JS unit-test harness (Vitest + jsdom) for the package's static JavaScript
+  (`formset.js`, `modal.js`, `toggle.js`), with a `JS Tests` CI workflow and a
+  `task test-js` shortcut. Dev-only; does not affect the package.
+
 ### Fixed
 
 - `formset.js`: rows marked for deletion now lose their `ORDER` value during client-side

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Django CRUD Views - Changelog
 
+## Unreleased
+
+### Fixed
+
+- `formset.js`: rows marked for deletion now lose their `ORDER` value during client-side
+  reordering. The check read `.checked` on the hidden `DELETE` input (always false); it now
+  inspects the input type. No server-side impact — Django's `ordered_forms` already
+  excluded deleted forms.
+
 ## 0.18.0
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ task dev
 3. Run the tests:
    - quick: `cd tests && pytest`
    - full matrix (Python 3.12/3.13/3.14 × Django 4.2/5.2/6.0): `task test`
+   - JS unit tests (requires Node 20+): `task test-js`
 4. Format and lint before committing:
    - `task format` (ruff format)
    - `task check` (ruff check --fix)

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -18,6 +18,16 @@ git clone git@github.com:jacob-consulting/django-crud-views.git
 cd django-crud-views
 task dev
 ```
+
+## JS tests
+
+The package's static JavaScript (`formset.js`, `modal.js`, `toggle.js`) has a
+[Vitest](https://vitest.dev/) unit-test suite. It needs [Node.js](https://nodejs.org/) 20+:
+
+```bash
+task test-js
+```
+
 ## Run example application
 
 Now let's run the example application with the `bootstrap5` theme:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1808 @@
+{
+  "name": "django-crud-views-js-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "django-crud-views-js-tests",
+      "version": "1.0.0",
+      "devDependencies": {
+        "jquery": "^3.7.1",
+        "jsdom": "^29.1.1",
+        "vitest": "^4.1.10"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.21.tgz",
+      "integrity": "sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "django-crud-views-js-tests",
       "version": "1.0.0",
       "devDependencies": {
-        "jquery": "^3.7.1",
+        "jquery": "~3.7.1",
         "jsdom": "^29.1.1",
         "vitest": "^4.1.10"
       },

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   },
   "scripts": {
     "test": "vitest run",
-    "test:watch": "vitest",
-    "coverage": "vitest run --coverage"
+    "test:watch": "vitest"
   },
   "private": true,
   "engines": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">=20"
   },
   "devDependencies": {
-    "jquery": "^3.7.1",
+    "jquery": "~3.7.1",
     "jsdom": "^29.1.1",
     "vitest": "^4.1.10"
   }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "django-crud-views-js-tests",
+  "version": "1.0.0",
+  "description": "Dev-only JS unit-test harness (see superpowers/specs/2026-07-21-js-test-harness-design.md)",
+  "directories": {
+    "doc": "docs",
+    "example": "examples",
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "coverage": "vitest run --coverage"
+  },
+  "private": true,
+  "engines": {
+    "node": ">=20"
+  },
+  "devDependencies": {
+    "jquery": "^3.7.1",
+    "jsdom": "^29.1.1",
+    "vitest": "^4.1.10"
+  }
+}

--- a/src/crud_views/static/crud_views/js/formset.js
+++ b/src/crud_views/static/crud_views/js/formset.js
@@ -213,7 +213,6 @@ class XFormset extends XBase {
             empty_fields = me.fields,
             pk_name = me.pk_field,
             empty_fields_check = empty_fields.concat([pk_name]),  // check all fields and pk
-            delete_checkbox = true,  // todo: from json
             order_index = 1;
 
         // abort if formset is not ordered
@@ -253,7 +252,9 @@ class XFormset extends XBase {
                 }),
                 all_empty = empty.every((el) => el),
                 // is row deleted? (depends on input type)
-                deleted = delete_checkbox ? del.checked : del.value === "on";
+                // DELETE may render as a hidden input (crud_views default, value "1"/"0")
+                // or as Django's checkbox
+                deleted = del.type === "checkbox" ? del.checked : del.value === "1";
 
             // set order depending on visibility
             if (all_empty || deleted) {
@@ -608,3 +609,9 @@ $(function () {
         new CrudViewsFormset();
     }
 });
+
+// Test seam: expose the formset classes on a shared namespace. In the browser
+// these are top-level lexical globals reachable by other classic scripts but
+// not inspectable via window; this adds namespaced access for the unit tests.
+window.cv = window.cv || {};
+Object.assign(window.cv, {CVFSConst, XBase, XFormset, XForm, CrudViewsFormset});

--- a/src/crud_views/static/crud_views/js/modal.js
+++ b/src/crud_views/static/crud_views/js/modal.js
@@ -107,3 +107,9 @@ $(document).ready(function () {
         cvModalSubmit(this);
     });
 });
+
+// Test seam: expose the modal API on a shared namespace. The functions above
+// are already implicit window globals in the browser (top-level declarations);
+// this only adds `CVModalConst` and namespaced access for the unit tests.
+window.cv = window.cv || {};
+Object.assign(window.cv, {CVModalConst, cvModalElements, cvModalInject, cvModalOpen, cvModalSubmit});

--- a/superpowers/plans/2026-07-21-js-test-harness.md
+++ b/superpowers/plans/2026-07-21-js-test-harness.md
@@ -1,0 +1,1245 @@
+# JS Test Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Vitest + jsdom unit-test harness for the package's first-party browser scripts (`formset.js`, `toggle.js`, `modal.js`), plus CI and Taskfile integration.
+
+**Architecture:** Vitest runs pure unit tests in a jsdom environment. A `loadScript()` helper reads each shipped file verbatim from `src/crud_views/static/crud_views/js/` and executes it via `new Function("window", code)` against a window Proxy whose `location` is a stub (jsdom's real `location` is unforgeable and cannot be spied on). Because that wrapping hides top-level declarations, `formset.js` and `modal.js` get a short behavior-neutral `window.cv` attachment block. Fixtures mirror the real Django templates. Spec: `superpowers/specs/2026-07-21-js-test-harness-design.md`.
+
+**Tech Stack:** Vitest, jsdom, jQuery 3.7.x (real, devDependency), istanbul-lib-instrument (coverage), GitHub Actions, Taskfile.
+
+## Global Constraints
+
+- Source files under test are `src/crud_views/static/crud_views/js/{formset,toggle,modal}.js`. The ONLY allowed source edits: the `window.cv` attachment blocks (Tasks 3, 4) and the one-line DELETE-detection bugfix (Task 4). No other refactoring.
+- `toggle.js` gets **no** source edit.
+- jQuery devDependency pinned to 3.7.x (the version the example app loads).
+- `package.json`: `"private": true`, `"engines": { "node": ">=20" }`. CI uses Node 22.
+- **Commit `package-lock.json`** (CI runs `npm ci`). Gitignore `node_modules` and `coverage-js`.
+- JS style: 4-space indent, double quotes (match `modal.js`/`toggle.js`).
+- In tests, define globals visible to the scripts under test ONLY via `vi.stubGlobal(...)` — in Vitest's jsdom environment, bare-identifier lookups in evaluated code resolve against the Node global, and `vi.stubGlobal` sets the value on both `globalThis` and `window`. Plain `window.foo = ...` assignments in test code are NOT reliably visible as bare identifiers.
+- All `npm`/`npx` commands run from the repo root. Vitest commands: `npx vitest run` (all), `npx vitest run tests/js/<file>` (one file).
+- Python tests are untouched; never run `pytest` for this plan except when told to.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `package.json`, `package-lock.json` | dev-only Node tooling manifest |
+| `vitest.config.js` | jsdom environment, test include, setup file, (Task 7: coverage) |
+| `tests/js/helpers/setup.js` | jQuery global, console silencing, per-test nav reset |
+| `tests/js/helpers/load.js` | `loadScript()`, `nav` stub, window Proxy |
+| `tests/js/helpers/dom.js` | fixture builders mirroring the real templates |
+| `tests/js/harness.test.js` | loader smoke tests |
+| `tests/js/toggle.test.js` | toggle.js suite |
+| `tests/js/modal.test.js` | modal.js suite |
+| `tests/js/formset.test.js` | formset.js suite (Tasks 4–6) |
+| `.github/workflows/js.yml` | CI job |
+| `taskfile.yaml`, `CONTRIBUTING.md`, `docs/development/index.md`, `CHANGELOG.md` | integration + docs |
+
+---
+
+### Task 1: Harness scaffolding
+
+**Files:**
+- Create: `package.json` (via npm), `vitest.config.js`, `tests/js/helpers/setup.js`, `tests/js/helpers/load.js`, `tests/js/harness.test.js`
+- Modify: `.gitignore`
+
+**Interfaces:**
+- Produces: `loadScript(name: string): Promise<void>` — executes `src/crud_views/static/crud_views/js/<name>.js`, resolves after jQuery ready callbacks ran. `nav = { assign: vi.fn(), href: "" }` — the `window.location` seen by loaded scripts. `resetNav()` — reinstalls fresh spies (called automatically in a global `beforeEach`). All exported from `tests/js/helpers/load.js`.
+
+- [ ] **Step 1: Write the failing smoke test**
+
+Create `tests/js/harness.test.js`:
+
+```js
+import { describe, expect, it } from "vitest";
+import { loadScript } from "./helpers/load.js";
+
+describe("harness", () => {
+    it("executes shipped scripts against the jsdom window", async () => {
+        expect(window.__cvToggleInit).toBeUndefined();
+        await loadScript("toggle");
+        expect(window.__cvToggleInit).toBe(true);
+    });
+
+    it("provides real jQuery as a global", () => {
+        expect(window.$).toBeDefined();
+        expect(window.$.fn.jquery).toMatch(/^3\.7\./);
+    });
+});
+```
+
+- [ ] **Step 2: Run it to verify failure**
+
+Run: `npx vitest run` — Expected: FAIL (vitest not installed / config missing).
+
+- [ ] **Step 3: Install tooling and write config + helpers**
+
+```bash
+npm init -y
+npm pkg set private=true --json
+npm pkg set name="django-crud-views-js-tests" description="Dev-only JS unit-test harness (see superpowers/specs/2026-07-21-js-test-harness-design.md)" engines.node=">=20" scripts.test="vitest run" "scripts.test:watch"="vitest" scripts.coverage="vitest run --coverage"
+npm pkg delete main keywords author license
+npm install --save-dev vitest jsdom jquery@3.7.1
+```
+
+(Afterwards verify `package.json` contains `"private": true` as a boolean, not the string `"true"`; fix by hand if needed.)
+
+Create `vitest.config.js`:
+
+```js
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        environment: "jsdom",
+        include: ["tests/js/**/*.test.js"],
+        setupFiles: ["tests/js/helpers/setup.js"],
+    },
+});
+```
+
+Create `tests/js/helpers/setup.js`:
+
+```js
+import $ from "jquery";
+import { beforeEach, vi } from "vitest";
+import { resetNav } from "./load.js";
+
+// The shipped files resolve `$` / `jQuery` as bare globals; stubGlobal sets
+// them on both globalThis and the jsdom window.
+vi.stubGlobal("$", $);
+vi.stubGlobal("jQuery", $);
+
+// formset.js logs debug chatter via console.log/console.assert.
+vi.spyOn(console, "log").mockImplementation(() => {});
+vi.spyOn(console, "assert").mockImplementation(() => {});
+
+beforeEach(() => {
+    resetNav();
+});
+```
+
+Create `tests/js/helpers/load.js`:
+
+```js
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import { vi } from "vitest";
+
+const JS_DIR = fileURLToPath(new URL("../../../src/crud_views/static/crud_views/js/", import.meta.url));
+
+// jsdom's window.location is unforgeable (cannot be spied on or replaced) and
+// its navigation methods are no-ops. The shipped files always navigate via
+// `window.location.*`, so loadScript executes them against a Proxy whose
+// `location` is this stub; everything else falls through to the real window.
+export const nav = {
+    assign: vi.fn(),
+    href: "",
+};
+
+export function resetNav() {
+    nav.assign = vi.fn();
+    nav.href = "";
+}
+
+function testWindow() {
+    return new Proxy(window, {
+        get: (target, prop) => (prop === "location" ? nav : Reflect.get(target, prop)),
+        set: (target, prop, value) => Reflect.set(target, prop, value),
+    });
+}
+
+export async function loadScript(name) {
+    const code = fs.readFileSync(`${JS_DIR}${name}.js`, "utf-8");
+    new Function("window", code)(testWindow());
+    // jQuery defers $(document).ready() callbacks by a microtask even when the
+    // document is already complete; wait for them so wiring is done on return.
+    await new Promise((resolve) => window.jQuery(resolve));
+}
+```
+
+Append to `.gitignore`:
+
+```
+node_modules
+coverage-js
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run` — Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json package-lock.json vitest.config.js tests/js .gitignore
+git commit -m "test(js): add Vitest + jsdom harness scaffolding"
+```
+
+---
+
+### Task 2: toggle.js suite
+
+**Files:**
+- Create: `tests/js/toggle.test.js`
+- No source edits (spec: toggle.js is tested purely through events).
+
+**Interfaces:**
+- Consumes: `loadScript` from Task 1.
+- Produces: nothing used by later tasks.
+
+Background for the implementer: `toggle.js` (read it first) is an IIFE. On `DOMContentLoaded` or `cv:modal:loaded` it finds `[cv-data-toggle-group]` elements, locates the checkbox named by `cv-data-toggle-field` (exact name or `-<name>` suffix) within the nearest `<form>` (else document), then shows/enables or hides/disables the group's inputs on checkbox change — EXCEPT management-form inputs (`-TOTAL_FORMS`, `-INITIAL_FORMS`, `-MIN_NUM_FORMS`, `-MAX_NUM_FORMS` suffixes), which always stay enabled. The `DOMContentLoaded` event has already fired when tests run, so tests dispatch it manually.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/js/toggle.test.js`:
+
+```js
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadScript } from "./helpers/load.js";
+
+function fixture({ field = "active", checked = true, checkboxName = field } = {}) {
+    document.body.innerHTML = `
+        <form>
+            <input type="checkbox" name="${checkboxName}" ${checked ? "checked" : ""}>
+            <div cv-data-toggle-group cv-data-toggle-field="${field}">
+                <input type="text" name="title">
+                <select name="genre"></select>
+                <textarea name="notes"></textarea>
+                <input type="hidden" name="book-None-0-TOTAL_FORMS" value="2">
+            </div>
+        </form>`;
+    return {
+        group: document.querySelector("[cv-data-toggle-group]"),
+        checkbox: document.querySelector("input[type=checkbox]"),
+    };
+}
+
+function wire() {
+    document.dispatchEvent(new Event("DOMContentLoaded", { bubbles: true }));
+}
+
+describe("toggle.js", () => {
+    beforeAll(async () => {
+        await loadScript("toggle");
+    });
+
+    beforeEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("keeps a group with a checked toggle visible and enabled", () => {
+        const { group } = fixture({ checked: true });
+        wire();
+        expect(group.style.display).toBe("");
+        expect(group.querySelector("[name=title]").disabled).toBe(false);
+    });
+
+    it("hides and disables a group whose toggle is unchecked", () => {
+        const { group } = fixture({ checked: false });
+        wire();
+        expect(group.style.display).toBe("none");
+        expect(group.querySelector("[name=title]").disabled).toBe(true);
+        expect(group.querySelector("[name=genre]").disabled).toBe(true);
+        expect(group.querySelector("[name=notes]").disabled).toBe(true);
+    });
+
+    it("keeps management-form hidden inputs enabled even when the group is off", () => {
+        const { group } = fixture({ checked: false });
+        wire();
+        expect(group.querySelector("[name$=-TOTAL_FORMS]").disabled).toBe(false);
+    });
+
+    it("reacts to checkbox change in both directions", () => {
+        const { group, checkbox } = fixture({ checked: true });
+        wire();
+        checkbox.click();
+        expect(group.style.display).toBe("none");
+        expect(group.querySelector("[name=title]").disabled).toBe(true);
+        checkbox.click();
+        expect(group.style.display).toBe("");
+        expect(group.querySelector("[name=title]").disabled).toBe(false);
+    });
+
+    it("finds the checkbox by formset-prefixed suffix name", () => {
+        const { group } = fixture({ field: "active", checkboxName: "book-None-0-active", checked: false });
+        wire();
+        expect(group.style.display).toBe("none");
+    });
+
+    it("scopes the checkbox lookup to the nearest form", () => {
+        document.body.innerHTML = `
+            <form id="a"><input type="checkbox" name="active" checked></form>
+            <form id="b">
+                <input type="checkbox" name="active">
+                <div cv-data-toggle-group cv-data-toggle-field="active">
+                    <input type="text" name="title">
+                </div>
+            </form>`;
+        wire();
+        const group = document.querySelector("[cv-data-toggle-group]");
+        expect(group.style.display).toBe("none");
+        document.querySelector("#a input").click();
+        expect(group.style.display).toBe("none");
+    });
+
+    it("leaves a group without a matching checkbox untouched", () => {
+        document.body.innerHTML = `
+            <div cv-data-toggle-group cv-data-toggle-field="nope">
+                <input type="text" name="title">
+            </div>`;
+        expect(() => wire()).not.toThrow();
+        const group = document.querySelector("[cv-data-toggle-group]");
+        expect(group.style.display).toBe("");
+        expect(group.querySelector("[name=title]").disabled).toBe(false);
+    });
+
+    it("wires groups injected into the modal via cv:modal:loaded", () => {
+        document.body.innerHTML = `<div id="cv-modal-content"></div>`;
+        const content = document.getElementById("cv-modal-content");
+        content.innerHTML = `
+            <form>
+                <input type="checkbox" name="active">
+                <div cv-data-toggle-group cv-data-toggle-field="active">
+                    <input type="text" name="title">
+                </div>
+            </form>`;
+        content.dispatchEvent(new CustomEvent("cv:modal:loaded", { bubbles: true }));
+        expect(content.querySelector("[cv-data-toggle-group]").style.display).toBe("none");
+    });
+
+    it("does not double-bind an already-wired group", () => {
+        const { checkbox } = fixture();
+        const spy = vi.spyOn(checkbox, "addEventListener");
+        wire();
+        wire();
+        expect(spy.mock.calls.filter(([type]) => type === "change")).toHaveLength(1);
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify current state**
+
+Run: `npx vitest run tests/js/toggle.test.js` — Expected: all 9 PASS (toggle.js already implements this; these are characterization tests locking behavior in). If any test fails, STOP and debug the test — do not modify `toggle.js`.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `npx vitest run` — Expected: 11 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/js/toggle.test.js
+git commit -m "test(js): characterization tests for toggle.js conditional groups"
+```
+
+---
+
+### Task 3: modal.js attachment block + suite
+
+**Files:**
+- Create: `tests/js/helpers/dom.js`, `tests/js/modal.test.js`
+- Modify: `src/crud_views/static/crud_views/js/modal.js` (append attachment block only)
+
+**Interfaces:**
+- Consumes: `loadScript`, `nav` from Task 1.
+- Produces: `modalSkeleton()` in `tests/js/helpers/dom.js` (used only here). Source attachment: `window.cv.{CVModalConst, cvModalElements, cvModalInject, cvModalOpen, cvModalSubmit}`.
+
+Background: read `modal.js` first. Protocol: `cvModalOpen(url, size)` GETs with `X-CV-Modal: true`; 200 → inject partial into `#cv-modal-content`, set dialog size class + `data-cv-url`, dispatch `cv:modal:loaded`, `bootstrap.Modal.getOrCreateInstance(modal).show()`; non-OK response or network error → `window.location.assign(url)`. `cvModalSubmit(form)` POSTs FormData; `X-CV-Redirect` header → navigate there; 422 → re-inject partial; anything else / error → navigate to fallback (`data-cv-url`, else form action).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/js/helpers/dom.js` (markup mirrors `src/crud_views/templates/crud_views/tags/cv_config.html` — keep in sync when that template changes):
+
+```js
+export function modalSkeleton() {
+    document.body.innerHTML = `
+        <div id="cv-config" data-request-path="/books/" data-query-string="" data-csrf-token="test-token" hidden></div>
+        <div class="modal fade" id="cv-modal" tabindex="-1" aria-hidden="true">
+            <div class="modal-dialog" id="cv-modal-dialog">
+                <div class="modal-content" id="cv-modal-content"></div>
+            </div>
+        </div>`;
+}
+```
+
+Create `tests/js/modal.test.js`:
+
+```js
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadScript, nav } from "./helpers/load.js";
+import { modalSkeleton } from "./helpers/dom.js";
+
+function textResponse(html, { ok = true, status = 200, headers = {} } = {}) {
+    return {
+        ok,
+        status,
+        headers: { get: (name) => headers[name] ?? null },
+        text: () => Promise.resolve(html),
+    };
+}
+
+function stubFetch(responseOrError) {
+    const impl = responseOrError instanceof Error
+        ? () => Promise.reject(responseOrError)
+        : () => Promise.resolve(responseOrError);
+    const fetchMock = vi.fn(impl);
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+}
+
+describe("modal.js", () => {
+    let show;
+
+    beforeAll(async () => {
+        await loadScript("modal");
+    });
+
+    beforeEach(() => {
+        modalSkeleton();
+        show = vi.fn();
+        vi.stubGlobal("bootstrap", { Modal: { getOrCreateInstance: vi.fn(() => ({ show })) } });
+    });
+
+    describe("cvModalOpen", () => {
+        it("GETs the url with the X-CV-Modal header", async () => {
+            const fetchMock = stubFetch(textResponse("<p>hi</p>"));
+            window.cv.cvModalOpen("/books/create/", "");
+            await vi.waitFor(() => expect(show).toHaveBeenCalled());
+            expect(fetchMock).toHaveBeenCalledWith("/books/create/", { headers: { "X-CV-Modal": "true" } });
+        });
+
+        it("injects the partial, sets url + size and shows the modal on 200", async () => {
+            stubFetch(textResponse("<p>partial</p>"));
+            const loaded = vi.fn();
+            document.getElementById("cv-modal").addEventListener("cv:modal:loaded", loaded);
+            window.cv.cvModalOpen("/books/create/", "modal-lg");
+            await vi.waitFor(() => expect(show).toHaveBeenCalled());
+            expect(document.getElementById("cv-modal-content").innerHTML).toBe("<p>partial</p>");
+            expect(document.getElementById("cv-modal-dialog").className).toBe("modal-dialog modal-lg");
+            expect(document.getElementById("cv-modal").getAttribute("data-cv-url")).toBe("/books/create/");
+            expect(loaded).toHaveBeenCalled();
+            expect(nav.assign).not.toHaveBeenCalled();
+        });
+
+        it("resets the dialog class when no size is given", async () => {
+            stubFetch(textResponse("<p>x</p>"));
+            document.getElementById("cv-modal-dialog").className = "modal-dialog modal-lg";
+            window.cv.cvModalOpen("/books/create/", "");
+            await vi.waitFor(() => expect(show).toHaveBeenCalled());
+            expect(document.getElementById("cv-modal-dialog").className).toBe("modal-dialog");
+        });
+
+        it("falls back to full-page navigation on a non-OK response", async () => {
+            stubFetch(textResponse("boom", { ok: false, status: 500 }));
+            window.cv.cvModalOpen("/books/create/", "");
+            await vi.waitFor(() => expect(nav.assign).toHaveBeenCalledWith("/books/create/"));
+            expect(show).not.toHaveBeenCalled();
+            expect(document.getElementById("cv-modal-content").innerHTML).toBe("");
+        });
+
+        it("falls back to full-page navigation on a network error", async () => {
+            stubFetch(new Error("offline"));
+            window.cv.cvModalOpen("/books/create/", "");
+            await vi.waitFor(() => expect(nav.assign).toHaveBeenCalledWith("/books/create/"));
+        });
+    });
+
+    describe("cvModalSubmit", () => {
+        function modalForm({ action = "/books/create/", modalUrl = null } = {}) {
+            if (modalUrl) {
+                document.getElementById("cv-modal").setAttribute("data-cv-url", modalUrl);
+            }
+            document.getElementById("cv-modal-content").innerHTML =
+                `<form action="${action}"><input type="text" name="title" value="t"></form>`;
+            return document.querySelector("#cv-modal-content form");
+        }
+
+        it("POSTs FormData with the X-CV-Modal header", async () => {
+            const fetchMock = stubFetch(textResponse("", { status: 204, headers: { "X-CV-Redirect": "/books/" } }));
+            window.cv.cvModalSubmit(modalForm());
+            await vi.waitFor(() => expect(nav.assign).toHaveBeenCalled());
+            const [url, options] = fetchMock.mock.calls[0];
+            expect(url).toBe("/books/create/");
+            expect(options.method).toBe("POST");
+            expect(options.headers).toEqual({ "X-CV-Modal": "true" });
+            expect(options.body).toBeInstanceOf(FormData);
+        });
+
+        it("navigates to the X-CV-Redirect target on success", async () => {
+            stubFetch(textResponse("", { status: 204, headers: { "X-CV-Redirect": "/books/" } }));
+            window.cv.cvModalSubmit(modalForm());
+            await vi.waitFor(() => expect(nav.assign).toHaveBeenCalledWith("/books/"));
+        });
+
+        it("swaps in the re-rendered partial on 422", async () => {
+            stubFetch(textResponse("<form>errors</form>", { ok: false, status: 422 }));
+            window.cv.cvModalSubmit(modalForm());
+            await vi.waitFor(() =>
+                expect(document.getElementById("cv-modal-content").innerHTML).toBe("<form>errors</form>"));
+            expect(nav.assign).not.toHaveBeenCalled();
+        });
+
+        it("navigates to data-cv-url on an unexpected status", async () => {
+            stubFetch(textResponse("boom", { ok: false, status: 500 }));
+            window.cv.cvModalSubmit(modalForm({ modalUrl: "/books/create/?step=1" }));
+            await vi.waitFor(() => expect(nav.assign).toHaveBeenCalledWith("/books/create/?step=1"));
+        });
+
+        it("navigates to the form action when no data-cv-url is set", async () => {
+            stubFetch(textResponse("boom", { ok: false, status: 500 }));
+            window.cv.cvModalSubmit(modalForm());
+            await vi.waitFor(() => expect(nav.assign).toHaveBeenCalledWith("/books/create/"));
+        });
+
+        it("navigates to the fallback on a network error", async () => {
+            stubFetch(new Error("offline"));
+            window.cv.cvModalSubmit(modalForm({ modalUrl: "/books/create/" }));
+            await vi.waitFor(() => expect(nav.assign).toHaveBeenCalledWith("/books/create/"));
+        });
+    });
+
+    describe("guards", () => {
+        it("throws a descriptive error when #cv-modal is missing", () => {
+            document.body.innerHTML = "";
+            expect(() => window.cv.cvModalElements()).toThrow(/#cv-modal not found/);
+        });
+
+        it("throws a descriptive error when Bootstrap is missing", () => {
+            vi.stubGlobal("bootstrap", undefined);
+            expect(() => window.cv.cvModalElements()).toThrow(/Bootstrap 5 JavaScript not loaded/);
+        });
+    });
+
+    describe("delegated handlers", () => {
+        it("opens the modal from a [data-cv-modal] link click", async () => {
+            const fetchMock = stubFetch(textResponse("<p>x</p>"));
+            document.body.insertAdjacentHTML("beforeend",
+                `<a href="/books/1/delete/" data-cv-modal="true" data-cv-modal-size="modal-xl">del</a>`);
+            document.querySelector("a[data-cv-modal]").click();
+            await vi.waitFor(() => expect(show).toHaveBeenCalled());
+            expect(fetchMock).toHaveBeenCalledWith("/books/1/delete/", { headers: { "X-CV-Modal": "true" } });
+            expect(document.getElementById("cv-modal-dialog").className).toBe("modal-dialog modal-xl");
+        });
+
+        it("intercepts form submits inside the modal content", async () => {
+            const fetchMock = stubFetch(textResponse("", { status: 204, headers: { "X-CV-Redirect": "/done/" } }));
+            document.getElementById("cv-modal-content").innerHTML = `<form action="/books/create/"></form>`;
+            const form = document.querySelector("#cv-modal-content form");
+            const event = new Event("submit", { bubbles: true, cancelable: true });
+            form.dispatchEvent(event);
+            expect(event.defaultPrevented).toBe(true);
+            await vi.waitFor(() => expect(nav.assign).toHaveBeenCalledWith("/done/"));
+            expect(fetchMock.mock.calls[0][1].method).toBe("POST");
+        });
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/js/modal.test.js` — Expected: FAIL — `window.cv` is undefined (no attachment block yet).
+
+- [ ] **Step 3: Append the attachment block to modal.js**
+
+At the end of `src/crud_views/static/crud_views/js/modal.js` append:
+
+```js
+// Test seam: expose the modal API on a shared namespace. The functions above
+// are already implicit window globals in the browser (top-level declarations);
+// this only adds `CVModalConst` and namespaced access for the unit tests.
+window.cv = window.cv || {};
+Object.assign(window.cv, {CVModalConst, cvModalElements, cvModalInject, cvModalOpen, cvModalSubmit});
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run tests/js/modal.test.js` — Expected: 15 passed. Then `npx vitest run` — Expected: 26 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/js/modal.test.js tests/js/helpers/dom.js src/crud_views/static/crud_views/js/modal.js
+git commit -m "test(js): modal.js protocol tests; expose modal API on window.cv"
+```
+
+---
+
+### Task 4: formset fixtures + XFormset tests + DELETE reorder fix
+
+**Files:**
+- Modify: `tests/js/helpers/dom.js` (add formset builders), `src/crud_views/static/crud_views/js/formset.js` (attachment block + one-line bugfix), `CHANGELOG.md`
+- Create: `tests/js/formset.test.js`
+
+**Interfaces:**
+- Consumes: `loadScript` (Task 1).
+- Produces (used by Tasks 5 and 6, all in `tests/js/helpers/dom.js`):
+  - `formsetFixture(opts?): { prefix: string }` — renders a full `<form class="cv-form">` fixture into `document.body`. Options (all optional): `key="book"`, `pk="None"`, `index=0`, `rows=2`, `canOrder=true`, `canDelete=true`, `editOnly=false`, `fields=["name"]`, `pkField="id"`, `rowValues: string[]` (per-row `name` value; `""` makes a row empty; default `"row <i>"`), `rowDeleted: number[]` (row indices with `DELETE=1`).
+  - `rowHtml(i: number, opts?): string` — one `.cv-formset-row` HTML string (same options).
+  - `formsetPrefix(opts?): string` — `"<key>-<pk>-<index>"`, default `"book-None-0"`.
+  - Source attachment: `window.cv.{CVFSConst, XBase, XFormset, XForm, CrudViewsFormset}`.
+
+Background — read `formset.js` fully first. Key facts:
+- `XFormset` is constructed with `(ctl, prefix)`; it reads JSON config from the `cv-data-formset` attribute of `.cv-formset-content`, parses `pk`/`index` out of `prefix_key` via `RegExp("^(.*)(None|<pk>)-(\\d+)$")`, and reads management-form inputs by `attr("value")`.
+- `reorder()` numbers ORDER inputs 1..n for visible rows in DOM order; rows that are empty (all `fields` + pk field blank) or deleted get ORDER `""`.
+- **Known bug (fixed in this task):** the deleted check reads `del.checked`, but the package renders DELETE as a *hidden* input (`Field("DELETE", type="hidden")` in `src/crud_views/lib/formsets/inline_formset.py:82`) and `XForm.set_delete()` writes value `"1"`/`"0"`. `.checked` is always `false` on hidden inputs, so delete-marked rows wrongly keep ORDER numbers. Server-side impact is nil today (Django's `ordered_forms` excludes deleted forms) but the JS behavior contradicts its own intent.
+- The fixture markup mirrors `src/crud_views/templates/crud_views/formsets/formset.html` and `control.html`; JSON keys mirror `XFormSet.data` / `XForm.data` in `src/crud_views/lib/formsets/render_tree.py`.
+
+- [ ] **Step 1: Add formset builders to `tests/js/helpers/dom.js`**
+
+Append (and extend the file's header comment to mention the formset templates):
+
+```js
+// formsetFixture()/rowHtml() mirror:
+//   src/crud_views/templates/crud_views/formsets/formset.html (+ control.html)
+//   JSON: XFormSet.data / XForm.data in src/crud_views/lib/formsets/render_tree.py
+// Keep in sync when those change.
+const FORMSET_DEFAULTS = {
+    key: "book",
+    pk: "None",
+    index: 0,
+    rows: 2,
+    canOrder: true,
+    canDelete: true,
+    editOnly: false,
+    fields: ["name"],
+    pkField: "id",
+    rowValues: null,
+    rowDeleted: [],
+};
+
+export function formsetPrefix(opts = {}) {
+    const o = { ...FORMSET_DEFAULTS, ...opts };
+    return `${o.key}-${o.pk}-${o.index}`;
+}
+
+export function rowHtml(i, opts = {}) {
+    const o = { ...FORMSET_DEFAULTS, ...opts };
+    const prefix = formsetPrefix(o);
+    const formPrefix = `${prefix}-${i}`;
+    const value = o.rowValues?.[i] ?? `row ${i}`;
+    const deleted = o.rowDeleted.includes(i) ? "1" : "0";
+    const formData = JSON.stringify({
+        key: o.key,
+        prefix: formPrefix,
+        prefix_key: `${o.pk}-${o.index}-${i}`,
+        formset_prefix: prefix,
+        pk: o.pk,
+    });
+    const orderInput = o.canOrder
+        ? `<input type="hidden" name="${formPrefix}-ORDER" value="${i + 1}">`
+        : "";
+    const deleteInput = o.canDelete
+        ? `<input type="hidden" name="${formPrefix}-DELETE" value="${deleted}">`
+        : "";
+    const orderButtons = o.canOrder
+        ? `<button type="button" class="btn btn-light cv-form-ctrl-up" cv-data-formset-form-prefix="${formPrefix}"></button>
+           <button type="button" class="btn btn-light cv-form-ctrl-down" cv-data-formset-form-prefix="${formPrefix}"></button>`
+        : "";
+    const addButton = o.editOnly
+        ? ""
+        : `<button type="button" class="btn btn-light cv-form-ctrl-add" cv-data-formset-form-prefix="${formPrefix}"></button>`;
+    const deleteButton = o.canDelete
+        ? `<button type="button" class="btn btn-light cv-form-ctrl-delete" cv-data-formset-form-prefix="${formPrefix}"></button>`
+        : "";
+    return `
+        <div class="cv-formset-row" cv-data-formset-form='${formData}'
+             cv-data-formset-prefix="${prefix}" cv-data-formset-form-prefix="${formPrefix}">
+            <div class="cv-formset-form">
+                <input type="hidden" name="${formPrefix}-${o.pkField}" value="">
+                <input type="text" name="${formPrefix}-${o.fields[0]}" value="${value}">
+                ${orderInput}
+                ${deleteInput}
+                <div class="cv-form-ctrl">${orderButtons}${addButton}${deleteButton}</div>
+            </div>
+        </div>`;
+}
+
+export function formsetFixture(opts = {}) {
+    const o = { ...FORMSET_DEFAULTS, ...opts };
+    const prefix = formsetPrefix(o);
+    const data = JSON.stringify({
+        key: o.key,
+        prefix,
+        prefix_key: `${o.pk}-${o.index}`,
+        hierarchy: [o.key],
+        parent_prefix: "",
+        parent_prefix_key: "",
+        can_delete: o.canDelete,
+        can_delete_extra: true,
+        can_order: o.canOrder,
+        edit_only: o.editOnly,
+        path: "/formset-rows/",
+        fields: o.fields,
+        pk_field: o.pkField,
+        pk: o.pk,
+    });
+    const rowsHtml = Array.from({ length: o.rows }, (_, i) => rowHtml(i, o)).join("");
+    document.body.innerHTML = `
+        <form class="cv-form">
+            <fieldset class="cv-formset-fieldset" cv-data-formset-key="${o.key}" cv-data-formset-prefix="${prefix}">
+                <div class="cv-formset-content" cv-data-formset='${data}' cv-data-formset-prefix="${prefix}">
+                    <input type="hidden" name="${prefix}-TOTAL_FORMS" value="${o.rows}">
+                    <input type="hidden" name="${prefix}-INITIAL_FORMS" value="${o.rows}">
+                    <input type="hidden" name="${prefix}-MIN_NUM_FORMS" value="0">
+                    <input type="hidden" name="${prefix}-MAX_NUM_FORMS" value="1000">
+                    ${rowsHtml}
+                </div>
+            </fieldset>
+        </form>`;
+    return { prefix };
+}
+```
+
+- [ ] **Step 2: Write the failing XFormset tests**
+
+Create `tests/js/formset.test.js`:
+
+```js
+import { beforeAll, describe, expect, it } from "vitest";
+import { loadScript } from "./helpers/load.js";
+import { formsetFixture } from "./helpers/dom.js";
+
+function orderValues() {
+    return [...document.querySelectorAll("input[name$=-ORDER]")].map((el) => el.value);
+}
+
+describe("formset.js", () => {
+    beforeAll(async () => {
+        await loadScript("formset");
+    });
+
+    describe("XFormset", () => {
+        it("parses config, pk and index from the fixture", () => {
+            formsetFixture();
+            const fs = new window.cv.XFormset(null, "book-None-0");
+            expect(fs.prefix).toBe("book-None-0");
+            expect(fs.pk).toBeNull();
+            expect(fs.index).toBe(0);
+            expect(fs.can_order).toBe(true);
+            expect(fs.can_delete).toBe(true);
+            expect(fs.rows).toHaveLength(2);
+        });
+
+        it("parses a concrete parent pk", () => {
+            formsetFixture({ pk: "7" });
+            const fs = new window.cv.XFormset(null, "book-7-0");
+            expect(fs.pk).toBe("7");
+            expect(fs.index).toBe(0);
+        });
+
+        it("reads and writes the management form", () => {
+            formsetFixture({ rows: 2 });
+            const fs = new window.cv.XFormset(null, "book-None-0");
+            expect(fs.get_total_forms()).toBe(2);
+            expect(fs.get_initial_forms()).toBe(2);
+            expect(fs.get_min_num_forms()).toBe(0);
+            expect(fs.get_max_num_forms()).toBe(1000);
+            fs.increment_total_forms();
+            expect(fs.get_total_forms()).toBe(3);
+        });
+
+        it("renumbers ORDER inputs 1..n in DOM order", () => {
+            formsetFixture({ rows: 3 });
+            document.querySelectorAll("input[name$=-ORDER]").forEach((el) => (el.value = "9"));
+            new window.cv.XFormset(null, "book-None-0").reorder();
+            expect(orderValues()).toEqual(["1", "2", "3"]);
+        });
+
+        it("blanks ORDER for empty rows", () => {
+            formsetFixture({ rows: 3, rowValues: ["a", "", "b"] });
+            new window.cv.XFormset(null, "book-None-0").reorder();
+            expect(orderValues()).toEqual(["1", "", "2"]);
+        });
+
+        it("blanks ORDER for delete-marked rows (hidden DELETE input)", () => {
+            formsetFixture({ rows: 3, rowDeleted: [1] });
+            new window.cv.XFormset(null, "book-None-0").reorder();
+            expect(orderValues()).toEqual(["1", "", "2"]);
+        });
+
+        it("blanks ORDER for delete-marked rows (checkbox DELETE input)", () => {
+            formsetFixture({ rows: 2 });
+            const del = document.querySelector('input[name="book-None-0-1-DELETE"]');
+            del.type = "checkbox";
+            del.checked = true;
+            new window.cv.XFormset(null, "book-None-0").reorder();
+            expect(orderValues()).toEqual(["1", ""]);
+        });
+
+        it("does nothing when the formset is not orderable", () => {
+            formsetFixture({ canOrder: false });
+            const fs = new window.cv.XFormset(null, "book-None-0");
+            expect(() => fs.reorder()).not.toThrow();
+            expect(document.querySelectorAll("input[name$=-ORDER]")).toHaveLength(0);
+        });
+    });
+});
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `npx vitest run tests/js/formset.test.js` — Expected: FAIL — `window.cv.XFormset` is undefined.
+
+- [ ] **Step 4: Append the attachment block to formset.js**
+
+At the end of `src/crud_views/static/crud_views/js/formset.js`, AFTER the existing `$(function () {...})` block, append:
+
+```js
+// Test seam: expose the formset classes on a shared namespace. In the browser
+// these are top-level lexical globals reachable by other classic scripts but
+// not inspectable via window; this adds namespaced access for the unit tests.
+window.cv = window.cv || {};
+Object.assign(window.cv, {CVFSConst, XBase, XFormset, XForm, CrudViewsFormset});
+```
+
+- [ ] **Step 5: Run to isolate the RED bug test**
+
+Run: `npx vitest run tests/js/formset.test.js` — Expected: all pass EXCEPT `blanks ORDER for delete-marked rows (hidden DELETE input)` — actual `["1", "2", "3"]` because `del.checked` is always false on hidden inputs. This failure is the point: it reproduces the bug. (If the checkbox variant also fails, debug the fixture, not the source.)
+
+- [ ] **Step 6: Fix the DELETE detection in formset.js**
+
+In `XFormset.reorder()`, delete the line declaring `delete_checkbox = true,  // todo: from json` and change
+
+```js
+                deleted = delete_checkbox ? del.checked : del.value === "on";
+```
+
+to
+
+```js
+                // DELETE may render as a hidden input (crud_views default, value "1"/"0")
+                // or as Django's checkbox
+                deleted = del.type === "checkbox" ? del.checked : del.value === "1";
+```
+
+- [ ] **Step 7: Run to verify all pass**
+
+Run: `npx vitest run` — Expected: 34 passed.
+
+- [ ] **Step 8: Add the CHANGELOG entry**
+
+At the top of `CHANGELOG.md`, directly under the `# Django CRUD Views - Changelog` heading, insert:
+
+```markdown
+## Unreleased
+
+### Fixed
+
+- `formset.js`: rows marked for deletion now lose their `ORDER` value during client-side
+  reordering. The check read `.checked` on the hidden `DELETE` input (always false); it now
+  inspects the input type. No server-side impact — Django's `ordered_forms` already
+  excluded deleted forms.
+```
+
+(If an `## Unreleased` section already exists, add only the `### Fixed` entry to it.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tests/js/formset.test.js tests/js/helpers/dom.js src/crud_views/static/crud_views/js/formset.js CHANGELOG.md
+git commit -m "fix(formsets): blank ORDER for delete-marked rows in JS reorder; XFormset tests"
+```
+
+---
+
+### Task 5: XForm behavior tests
+
+**Files:**
+- Modify: `tests/js/formset.test.js` (add a `describe("XForm")` block)
+
+**Interfaces:**
+- Consumes: `formsetFixture`, `rowHtml` (Task 4); `window.cv.XForm` (constructed as `new window.cv.XForm(ctl, formPrefix)` — `ctl` only needs `add_form_control_for_new_rows(rows)` for `add()`; pass `null` elsewhere).
+- Produces: nothing used later.
+
+Background: `XForm` wraps one `.cv-formset-row`. `delete()` toggles the hidden DELETE input between `"1"`/`"0"` (via the `value` *attribute*) and swaps the delete button between `btn-danger`/`btn-light`. `up()`/`down()` move the row in the DOM, then reorder. `add()` calls `$.ajax` GET against the formset's `path` and inserts `response.html` after the last row (when invoked from the last row) or before `row_next` otherwise, increments TOTAL_FORMS, reorders, and calls `ctl.add_form_control_for_new_rows(response.rows)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/js/formset.test.js` (inside the outer `describe("formset.js")`; extend the imports line with `vi` from vitest and `rowHtml` from `./helpers/dom.js`):
+
+```js
+    describe("XForm", () => {
+        it("computes row position facts", () => {
+            formsetFixture({ rows: 3 });
+            const middle = new window.cv.XForm(null, "book-None-0-1");
+            expect(middle.rows_total).toBe(3);
+            expect(middle.row_index).toBe(1);
+            expect(middle.row_is_first).toBe(false);
+            expect(middle.row_is_last).toBe(false);
+            expect(middle.row_previous.attr("cv-data-formset-form-prefix")).toBe("book-None-0-0");
+            expect(middle.row_next.attr("cv-data-formset-form-prefix")).toBe("book-None-0-2");
+
+            const first = new window.cv.XForm(null, "book-None-0-0");
+            expect(first.row_is_first).toBe(true);
+            expect(first.row_previous).toBeNull();
+
+            const last = new window.cv.XForm(null, "book-None-0-2");
+            expect(last.row_is_last).toBe(true);
+            expect(last.row_next).toBeNull();
+        });
+
+        it("delete() toggles the hidden DELETE input and button styling", () => {
+            formsetFixture();
+            const del = document.querySelector('input[name="book-None-0-0-DELETE"]');
+            const btn = document.querySelector('button.cv-form-ctrl-delete[cv-data-formset-form-prefix="book-None-0-0"]');
+
+            new window.cv.XForm(null, "book-None-0-0").delete();
+            expect(del.getAttribute("value")).toBe("1");
+            expect(btn.classList.contains("btn-danger")).toBe(true);
+            expect(btn.classList.contains("btn-light")).toBe(false);
+
+            new window.cv.XForm(null, "book-None-0-0").delete();
+            expect(del.getAttribute("value")).toBe("0");
+            expect(btn.classList.contains("btn-light")).toBe(true);
+        });
+
+        function rowOrderInDom() {
+            return [...document.querySelectorAll(".cv-formset-row")]
+                .map((el) => el.getAttribute("cv-data-formset-form-prefix"));
+        }
+
+        it("up() moves the row before its predecessor and renumbers", () => {
+            formsetFixture({ rows: 3 });
+            new window.cv.XForm(null, "book-None-0-1").up();
+            expect(rowOrderInDom()).toEqual(["book-None-0-1", "book-None-0-0", "book-None-0-2"]);
+            expect(document.querySelector('input[name="book-None-0-1-ORDER"]').value).toBe("1");
+            expect(document.querySelector('input[name="book-None-0-0-ORDER"]').value).toBe("2");
+        });
+
+        it("up() on the first row is a no-op", () => {
+            formsetFixture({ rows: 2 });
+            new window.cv.XForm(null, "book-None-0-0").up();
+            expect(rowOrderInDom()).toEqual(["book-None-0-0", "book-None-0-1"]);
+        });
+
+        it("down() moves the row after its successor and renumbers", () => {
+            formsetFixture({ rows: 3 });
+            new window.cv.XForm(null, "book-None-0-1").down();
+            expect(rowOrderInDom()).toEqual(["book-None-0-0", "book-None-0-2", "book-None-0-1"]);
+            expect(document.querySelector('input[name="book-None-0-1-ORDER"]').value).toBe("3");
+        });
+
+        it("down() on the last row is a no-op", () => {
+            formsetFixture({ rows: 2 });
+            new window.cv.XForm(null, "book-None-0-1").down();
+            expect(rowOrderInDom()).toEqual(["book-None-0-0", "book-None-0-1"]);
+        });
+
+        describe("add()", () => {
+            function stubAjax(newIndex) {
+                return vi.spyOn($, "ajax").mockImplementation((options) => {
+                    options.success({ html: rowHtml(newIndex), rows: [`book-None-0-${newIndex}`] });
+                });
+            }
+
+            it("requests a new row with the formset's coordinates", () => {
+                formsetFixture({ rows: 2 });
+                const ajax = stubAjax(2);
+                const ctl = { add_form_control_for_new_rows: vi.fn() };
+                new window.cv.XForm(ctl, "book-None-0-1").add();
+                const options = ajax.mock.calls[0][0];
+                expect(options.url).toBe("/formset-rows/");
+                expect(options.type).toBe("get");
+                expect(options.data).toEqual({
+                    template: "book",
+                    pk: "None",
+                    num: 2,
+                    formset_parent_prefix_key: "",
+                });
+                ajax.mockRestore();
+            });
+
+            it("appends after the last row, bumps TOTAL_FORMS and wires controls", () => {
+                formsetFixture({ rows: 2 });
+                const ajax = stubAjax(2);
+                const ctl = { add_form_control_for_new_rows: vi.fn() };
+                new window.cv.XForm(ctl, "book-None-0-1").add();
+                expect(rowOrderInDom()).toEqual(["book-None-0-0", "book-None-0-1", "book-None-0-2"]);
+                expect(document.querySelector('input[name="book-None-0-TOTAL_FORMS"]').getAttribute("value")).toBe("3");
+                expect(ctl.add_form_control_for_new_rows).toHaveBeenCalledWith(["book-None-0-2"]);
+                ajax.mockRestore();
+            });
+
+            it("inserts before the next row when adding from a middle row", () => {
+                formsetFixture({ rows: 2 });
+                const ajax = stubAjax(2);
+                const ctl = { add_form_control_for_new_rows: vi.fn() };
+                new window.cv.XForm(ctl, "book-None-0-0").add();
+                expect(rowOrderInDom()).toEqual(["book-None-0-0", "book-None-0-2", "book-None-0-1"]);
+                ajax.mockRestore();
+            });
+        });
+    });
+```
+
+- [ ] **Step 2: Run to verify state**
+
+Run: `npx vitest run tests/js/formset.test.js` — Expected: all PASS (characterization of existing behavior — Task 4's fix already landed). If a test fails, debug the TEST/fixture first; only touch `formset.js` if you can demonstrate the browser would misbehave identically, and then STOP and report instead of fixing (out of this task's scope).
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `npx vitest run` — Expected: 44 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/js/formset.test.js
+git commit -m "test(js): XForm row behavior tests (move, delete, add)"
+```
+
+---
+
+### Task 6: CrudViewsFormset controller tests
+
+**Files:**
+- Modify: `tests/js/formset.test.js` (add a `describe("CrudViewsFormset")` block)
+
+**Interfaces:**
+- Consumes: `formsetFixture` (Task 4); `window.cv.CrudViewsFormset` (constructed with no arguments AFTER the fixture exists).
+
+Background: the constructor binds click handlers to the up/down/add/delete buttons and a submit handler on `form.cv-form` that reorders all formsets and calls `preventDefault()` if reordering fails. Regression guard (fixed 2026-07-19): on the *global* init pass, absent control types (e.g. no up/down buttons on a non-orderable formset) must NOT abort initialization.
+
+- [ ] **Step 1: Write the tests**
+
+Add to `tests/js/formset.test.js`:
+
+```js
+    describe("CrudViewsFormset", () => {
+        it("initializes on a non-orderable formset without aborting (regression)", () => {
+            formsetFixture({ canOrder: false });
+            expect(() => new window.cv.CrudViewsFormset()).not.toThrow();
+            // delete still works, proving handlers were bound despite missing up/down
+            document.querySelector("button.cv-form-ctrl-delete").click();
+            expect(document.querySelector('input[name="book-None-0-0-DELETE"]').getAttribute("value")).toBe("1");
+        });
+
+        it("initializes on an edit-only formset without an add button", () => {
+            formsetFixture({ editOnly: true });
+            expect(() => new window.cv.CrudViewsFormset()).not.toThrow();
+            document.querySelector("button.cv-form-ctrl-delete").click();
+            expect(document.querySelector('input[name="book-None-0-0-DELETE"]').getAttribute("value")).toBe("1");
+        });
+
+        it("wires the control buttons to row actions", () => {
+            formsetFixture({ rows: 2 });
+            new window.cv.CrudViewsFormset();
+            document.querySelector('button.cv-form-ctrl-down[cv-data-formset-form-prefix="book-None-0-0"]').click();
+            const prefixes = [...document.querySelectorAll(".cv-formset-row")]
+                .map((el) => el.getAttribute("cv-data-formset-form-prefix"));
+            expect(prefixes).toEqual(["book-None-0-1", "book-None-0-0"]);
+        });
+
+        it("reorders all formsets on submit and lets the submit proceed", () => {
+            formsetFixture({ rows: 2 });
+            new window.cv.CrudViewsFormset();
+            document.querySelectorAll("input[name$=-ORDER]").forEach((el) => (el.value = "9"));
+            const form = document.querySelector("form.cv-form");
+            const event = new Event("submit", { bubbles: true, cancelable: true });
+            form.dispatchEvent(event);
+            expect(event.defaultPrevented).toBe(false);
+            expect([...document.querySelectorAll("input[name$=-ORDER]")].map((el) => el.value)).toEqual(["1", "2"]);
+        });
+
+        it("blocks the submit when reordering fails outright", () => {
+            formsetFixture({ rows: 2 });
+            const controller = new window.cv.CrudViewsFormset();
+            const form = document.querySelector("form.cv-form");
+            // make reorder_formsets throw: the controller can no longer find form.cv-form
+            form.className = "";
+            const event = new Event("submit", { bubbles: true, cancelable: true });
+            form.dispatchEvent(event);
+            expect(event.defaultPrevented).toBe(true);
+        });
+    });
+```
+
+- [ ] **Step 2: Run to verify state**
+
+Run: `npx vitest run tests/js/formset.test.js` — Expected: all PASS (characterization). Note: the submit tests dispatch a native cancelable `submit` event; jQuery's handler runs and `defaultPrevented` reflects its decision. If the "blocks the submit" test fails because jQuery's submit binding no longer matches after the class removal, the handler was bound directly to the element and still fires — debug with `npx vitest run -t "blocks the submit"` before touching anything.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `npx vitest run` — Expected: 49 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/js/formset.test.js
+git commit -m "test(js): CrudViewsFormset controller init and submit tests"
+```
+
+---
+
+### Task 7: Coverage wiring
+
+**Files:**
+- Modify: `package.json` (deps), `vitest.config.js`, `tests/js/helpers/load.js`
+
+**Interfaces:**
+- Consumes: everything prior.
+- Produces: `npm run coverage` reporting on the three source files.
+
+Rationale: sources execute via `new Function`, which neither the v8 nor the istanbul provider can see on its own. The loader therefore instruments the source with `istanbul-lib-instrument` (keyed by the real file path); counters accumulate in `globalThis.__coverage__`, which Vitest's istanbul provider collects and reports.
+
+- [ ] **Step 1: Install coverage tooling**
+
+```bash
+npm install --save-dev @vitest/coverage-istanbul istanbul-lib-instrument
+```
+
+- [ ] **Step 2: Configure coverage**
+
+In `vitest.config.js`, add inside `test: {}`:
+
+```js
+        coverage: {
+            provider: "istanbul",
+            include: ["src/crud_views/static/crud_views/js/**"],
+            reporter: ["text", "html"],
+            reportsDirectory: "coverage-js",
+        },
+```
+
+- [ ] **Step 3: Instrument in the loader**
+
+In `tests/js/helpers/load.js`, add the import and change `loadScript`:
+
+```js
+import { createInstrumenter } from "istanbul-lib-instrument";
+
+const instrumenter = createInstrumenter({ esModules: false });
+```
+
+```js
+export async function loadScript(name) {
+    const file = `${JS_DIR}${name}.js`;
+    // Instrument for coverage: the code runs via new Function, invisible to the
+    // istanbul provider; instrumented counters land in globalThis.__coverage__
+    // where vitest collects them. Cheap enough to do unconditionally.
+    const code = instrumenter.instrumentSync(fs.readFileSync(file, "utf-8"), file);
+    new Function("window", code)(testWindow());
+    // jQuery defers $(document).ready() callbacks by a microtask even when the
+    // document is already complete; wait for them so wiring is done on return.
+    await new Promise((resolve) => window.jQuery(resolve));
+}
+```
+
+- [ ] **Step 4: Verify tests still pass, then verify coverage**
+
+Run: `npx vitest run` — Expected: 49 passed.
+Run: `npm run coverage` — Expected: 49 passed plus a text coverage table listing `formset.js`, `modal.js`, `toggle.js` with non-zero statement coverage (roughly 80%+ for toggle/modal; formset lower), and nothing outside `src/crud_views/static/crud_views/js/`.
+
+Contingency: if the table is empty, the provider is dropping externally-produced coverage entries. Check `coverage-js/index.html`; if genuinely empty, revert Steps 2–3 (`git checkout -- vitest.config.js tests/js/helpers/load.js`, `npm uninstall @vitest/coverage-istanbul istanbul-lib-instrument`), commit the plan WITHOUT coverage, and report coverage wiring as a follow-up — coverage is a local-only nice-to-have per the spec; do not burn time on it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json package-lock.json vitest.config.js tests/js/helpers/load.js
+git commit -m "test(js): istanbul coverage for the static JS sources"
+```
+
+---
+
+### Task 8: CI workflow, Taskfile, docs, changelog
+
+**Files:**
+- Create: `.github/workflows/js.yml`
+- Modify: `taskfile.yaml`, `CONTRIBUTING.md`, `docs/development/index.md`, `CHANGELOG.md`
+
+- [ ] **Step 1: Create the workflow**
+
+Create `.github/workflows/js.yml`:
+
+```yaml
+name: JS Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  js-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npx vitest run
+```
+
+- [ ] **Step 2: Add Taskfile tasks**
+
+In `taskfile.yaml`, after the existing `test:` task, add:
+
+```yaml
+  test-js:
+    desc: Run the JS unit tests (Vitest + jsdom, requires Node 20+)
+    cmds:
+      - test -d node_modules || npm ci
+      - npx vitest run
+    silent: true
+
+  test-js-watch:
+    desc: Run the JS unit tests in watch mode
+    cmds:
+      - test -d node_modules || npm ci
+      - npx vitest
+    silent: true
+```
+
+Verify: `task test-js` — Expected: 49 passed.
+
+- [ ] **Step 3: Document**
+
+In `CONTRIBUTING.md`, change the "Run the tests" list item:
+
+```markdown
+3. Run the tests:
+   - quick: `cd tests && pytest`
+   - full matrix (Python 3.12/3.13/3.14 × Django 4.2/5.2/6.0): `task test`
+   - JS unit tests (requires Node 20+): `task test-js`
+```
+
+In `docs/development/index.md`, after the `## Setup` section (before `## Run example application`), add:
+
+````markdown
+## JS tests
+
+The package's static JavaScript (`formset.js`, `modal.js`, `toggle.js`) has a
+[Vitest](https://vitest.dev/) unit-test suite. It needs [Node.js](https://nodejs.org/) 20+:
+
+```bash
+task test-js
+```
+````
+
+- [ ] **Step 4: Changelog**
+
+In `CHANGELOG.md`, inside the `## Unreleased` section created in Task 4, add an `### Added` subsection above `### Fixed`:
+
+```markdown
+### Added
+
+- JS unit-test harness (Vitest + jsdom) for the package's static JavaScript
+  (`formset.js`, `modal.js`, `toggle.js`), with a `JS Tests` CI workflow and a
+  `task test-js` shortcut. Dev-only; does not affect the package.
+```
+
+- [ ] **Step 5: Final verification**
+
+Run: `npx vitest run` — Expected: 49 passed.
+Run: `cd tests && pytest -q && cd ..` — Expected: all Python tests still pass (the formset.js/modal.js edits are the only source changes; Python tests don't execute JS, this is a sanity check).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/js.yml taskfile.yaml CONTRIBUTING.md docs/development/index.md CHANGELOG.md
+git commit -m "ci(js): JS test workflow, task test-js, contributor docs"
+```

--- a/superpowers/specs/2026-07-21-js-test-harness-design.md
+++ b/superpowers/specs/2026-07-21-js-test-harness-design.md
@@ -152,8 +152,8 @@ which templates it mirrors; template changes must update fixtures.
   `npx vitest run`) and `test-js-watch`. `task test` (nox) stays Python-only.
 - **Docs:** CONTRIBUTING/README dev-setup gains one line: "JS tests: `task test-js`
   (requires Node 22+)."
-- **package.json:** `private: true`, `engines: { node: ">=22" }`, scripts `test` /
-  `test:watch` / `coverage`.
+- **package.json:** `private: true`, `engines: { node: ">=20" }` (local dev machines run
+  Node 20; CI uses 22), scripts `test` / `test:watch` / `coverage`.
 - **Coverage:** generated locally via `npm run coverage` (v8 provider, scoped to the five
   source files). Not wired into codecov initially — the codecov patch gate is tuned for
   Python; adding a `javascript` flag is an explicit follow-up decision.

--- a/superpowers/specs/2026-07-21-js-test-harness-design.md
+++ b/superpowers/specs/2026-07-21-js-test-harness-design.md
@@ -1,0 +1,166 @@
+# JS Test Harness Design
+
+**Date:** 2026-07-21
+**Status:** Approved
+
+## Goal
+
+Add a JavaScript unit-test harness for the package's first-party browser scripts, which currently
+have zero test coverage. The harness tests JS logic fast and in isolation — jsdom DOM, stubbed
+transport — with no Django server and no real browser.
+
+First-party JS under test (`src/crud_views/static/crud_views/js/`):
+
+| File | Lines | Content |
+|---|---|---|
+| `formset.js` | 610 | jQuery classes for formset add/delete/reorder, management-form bookkeeping, AJAX row fetch |
+| `modal.js` | 109 | fetch-based Bootstrap 5 modal protocol (200/204+`X-CV-Redirect`/422) |
+| `toggle.js` | 62 | vanilla-JS conditional field groups; management fields stay enabled when hidden |
+| `list.filter.js` | 55 | jQuery filter bar glue |
+| `viewset.js` | 28 | `cvGetConfig()` + small jQuery glue |
+
+## Decisions
+
+- **Goal:** fast unit tests (not browser integration). Vitest browser mode (Playwright-driven
+  Chromium) is a possible future layer that composes with the same tests; out of scope here.
+- **Toolchain:** Node.js is acceptable. Dev-only; the published Python package is unaffected.
+- **Initial coverage scope:** the risky trio — `formset.js`, `toggle.js`, `modal.js`.
+  `viewset.js` / `list.filter.js` get tests later, when they change.
+- **Source edits:** light-touch, behavior-neutral attachment blocks are allowed so tests can
+  reach top-level declarations. No ES-module conversion; files stay classic scripts served by
+  Django unchanged.
+
+## Architecture
+
+**Runner:** Vitest with the jsdom environment. No build step, no bundler — Vitest is purely a
+runner; tests always exercise the exact files Django serves.
+
+### Repo layout
+
+```
+package.json              # private, engines node>=22; devDeps: vitest, jsdom, jquery
+vitest.config.js          # environment: jsdom, include: tests/js/**/*.test.js,
+                          # coverage scoped to src/crud_views/static/crud_views/js/*.js
+tests/js/
+  helpers/
+    load.js               # loadScript("formset") — read + execute the real source file
+    dom.js                # fixture builders (formset markup, toggle groups, modal skeleton)
+  formset.test.js
+  toggle.test.js
+  modal.test.js
+```
+
+`package.json` and `vitest.config.js` live at the repo root (standard tooling discovery for
+editors, CI, contributors); tests live in `tests/js/` mirroring the Python test convention.
+`node_modules/` is gitignored. Hatchling packaging is unaffected (only `src/` ships).
+
+### Dependencies
+
+- **jQuery:** real, as a pinned npm devDependency. jQuery is supplied by the consuming project,
+  not the package; the example app currently loads 3.7.1, so the harness pins jQuery 3.7.x —
+  `$` in tests is not a mock.
+- **Bootstrap:** stubbed, not installed. jsdom has no layout/transitions;
+  `bootstrap.Modal.getOrCreateInstance(...).show()` is a spy. Tests assert the modal *protocol*
+  (what our code does), not Bootstrap's rendering.
+- **fetch / `$.ajax` transport / `window.location` navigation:** stubbed per test with
+  `vi.stubGlobal` and spies (jsdom implements none of these usefully).
+
+## Script loading
+
+`loadScript(name)` reads `src/crud_views/static/crud_views/js/<name>.js` as text and executes it
+as a classic script against the jsdom window (wrapped in `new Function(code)`; `window`,
+`document`, `$` are already global in the Vitest jsdom environment). The helper is async and
+resolves after jQuery `$(document).ready()` callbacks have run (jQuery defers them by a
+microtask even on an already-loaded document).
+
+### Light-touch source edits
+
+`new Function` wrapping (like ES modules) makes top-level `const`/`class`/`function`
+declarations invisible to the outside, so each file under test gets a short attachment block at
+the end:
+
+- **`formset.js`:**
+  `window.cv = window.cv || {}; Object.assign(window.cv, { CVFSConst, XBase, XFormset, XForm, CrudViewsFormset });`
+  In the browser this only adds console/inspection discoverability — these were lexical globals
+  reachable by other classic scripts but not `window` properties. Behavior-neutral otherwise.
+- **`modal.js`:** same pattern for `CVModalConst`, `cvModalElements`, `cvModalInject`,
+  `cvModalOpen`, `cvModalSubmit`. The functions are already implicit `window` globals in the
+  browser (top-level function declarations), so this is strictly neutral.
+- **`toggle.js`:** no edit. It is an IIFE wired entirely through events; tests drive it the way
+  the browser does — dispatch `DOMContentLoaded` / `cv:modal:loaded` and assert
+  visibility/disabled state. Its `window.__cvToggleInit` re-entry guard is cleared in test setup
+  between loads.
+
+## Isolation model
+
+- Each test **file** gets a fresh jsdom window (Vitest default).
+- Within a file: the script is loaded once in `beforeAll` (so jQuery document-level delegated
+  handlers do not stack); each test rebuilds its DOM fixture in `beforeEach`.
+- Stateful entry points (`new cv.CrudViewsFormset()`, toggle wiring via event dispatch) are
+  invoked per test against the fresh fixture.
+- Harness setup silences `console.log` / `console.assert` noise from `formset.js` debug calls.
+
+## Initial test scope (~40–50 tests)
+
+### `toggle.test.js` — behavior-level, driven purely by events
+
+- checked toggle → group visible, inputs enabled; unchecked → hidden, inputs disabled
+- management-form hidden inputs (`-TOTAL_FORMS` etc.) stay **enabled** even when the group is
+  disabled (the regression rule documented in the file's own comment)
+- checkbox lookup by exact name and by `-name` suffix, scoped to the nearest `<form>`
+- missing checkbox → group untouched, no throw
+- `cv:modal:loaded` wires groups inside injected content; already-wired groups are not
+  double-bound
+
+### `modal.test.js` — protocol branches, stubbed `fetch`, spy `bootstrap.Modal`
+
+- open: GET carries `X-CV-Modal: true`; 200 → HTML injected, size class + `data-cv-url` set,
+  `cv:modal:loaded` dispatched (bubbling), `.show()` called
+- open: non-OK response and fetch rejection each fall back to full-page navigation
+- submit: `X-CV-Redirect` header → navigate; 422 → swap re-rendered partial; any other status
+  and network error → navigate to fallback URL (`data-cv-url`, else form action)
+- guard errors: missing `#cv-modal` / missing Bootstrap throw their descriptive messages
+- delegated handlers: click on `[data-cv-modal='true']` opens with href+size; submit inside
+  `#cv-modal-content` is intercepted
+
+### `formset.test.js` — deepest suite
+
+Fixture builder markup is derived from the real `crud_views` formset templates — minimal but
+structurally faithful. **This fixture fidelity is the harness's key risk:** if templates and
+fixtures drift, tests keep passing against stale markup. Mitigation: fixture builder documents
+which templates it mirrors; template changes must update fixtures.
+
+- `XFormset`: management-form get/set/increment; pk + index parsing from `prefix_key`
+- `reorder()`: filled rows numbered 1..n; empty rows and DELETE-marked rows get blank ORDER;
+  no-op when `can_order` is false
+- `XForm`: first/last/next/previous row math; `delete()` toggles the hidden DELETE value and
+  button styling; `up()`/`down()` move DOM rows and renumber; no-ops at the edges
+- `add()`: stubbed `$.ajax` success inserts returned HTML at the right position, increments
+  TOTAL_FORMS, wires new-row controls, reorders
+- `CrudViewsFormset`: form submit blocked when reorder fails; global init on a page with a
+  non-orderable/edit-only formset binds the controls that exist without aborting (regression
+  fixed 2026-07-19)
+
+## CI and developer workflow
+
+- **CI:** new workflow `.github/workflows/js.yml` (push to main + PRs, matching the other
+  workflows) with a single job: checkout → `actions/setup-node` (Node 22 LTS, npm cache) →
+  `npm ci` → `npx vitest run`. Separate from `tests.yml` so the Python matrix and the JS job
+  run independently and failures are attributable at a glance. No matrix — one Node version
+  suffices for browser-target JS.
+- **Taskfile:** new `test-js` task (`npm ci` if `node_modules` is missing, then
+  `npx vitest run`) and `test-js-watch`. `task test` (nox) stays Python-only.
+- **Docs:** CONTRIBUTING/README dev-setup gains one line: "JS tests: `task test-js`
+  (requires Node 22+)."
+- **package.json:** `private: true`, `engines: { node: ">=22" }`, scripts `test` /
+  `test:watch` / `coverage`.
+- **Coverage:** generated locally via `npm run coverage` (v8 provider, scoped to the five
+  source files). Not wired into codecov initially — the codecov patch gate is tuned for
+  Python; adding a `javascript` flag is an explicit follow-up decision.
+
+## Out of scope / follow-ups
+
+- Tests for `viewset.js` and `list.filter.js` (add when those files change)
+- Vitest browser mode (real Chromium via Playwright) as an integration layer
+- Codecov `javascript` flag
+- Any refactor of the JS files beyond the attachment blocks

--- a/superpowers/specs/2026-07-21-js-test-harness-design.md
+++ b/superpowers/specs/2026-07-21-js-test-harness-design.md
@@ -153,14 +153,17 @@ which templates it mirrors; template changes must update fixtures.
 - **Docs:** CONTRIBUTING/README dev-setup gains one line: "JS tests: `task test-js`
   (requires Node 22+)."
 - **package.json:** `private: true`, `engines: { node: ">=20" }` (local dev machines run
-  Node 20; CI uses 22), scripts `test` / `test:watch` / `coverage`.
-- **Coverage:** generated locally via `npm run coverage` (v8 provider, scoped to the five
-  source files). Not wired into codecov initially — the codecov patch gate is tuned for
-  Python; adding a `javascript` flag is an explicit follow-up decision.
+  Node 20; CI uses 22), scripts `test` / `test:watch`.
+- **Coverage:** dropped during implementation. The sources execute via `new Function` in the
+  test loader, which Vitest's coverage providers cannot see; instrumenting with
+  `istanbul-lib-instrument` in the loader produced counters in `globalThis.__coverage__`,
+  but the istanbul provider verifiably drops externally-produced entries (all-zero report).
+  Coverage wiring is a follow-up; candidate approach: standalone `nyc`/`istanbul-lib-report`
+  over the loader-produced `__coverage__` object.
 
 ## Out of scope / follow-ups
 
 - Tests for `viewset.js` and `list.filter.js` (add when those files change)
 - Vitest browser mode (real Chromium via Playwright) as an integration layer
-- Codecov `javascript` flag
+- Coverage reporting (dropped in implementation — see CI section) and a Codecov `javascript` flag
 - Any refactor of the JS files beyond the attachment blocks

--- a/superpowers/specs/2026-07-21-js-test-harness-design.md
+++ b/superpowers/specs/2026-07-21-js-test-harness-design.md
@@ -38,9 +38,8 @@ runner; tests always exercise the exact files Django serves.
 ### Repo layout
 
 ```
-package.json              # private, engines node>=22; devDeps: vitest, jsdom, jquery
-vitest.config.js          # environment: jsdom, include: tests/js/**/*.test.js,
-                          # coverage scoped to src/crud_views/static/crud_views/js/*.js
+package.json              # private, engines node>=20; devDeps: vitest, jsdom, jquery
+vitest.config.js          # environment: jsdom, include: tests/js/**/*.test.js
 tests/js/
   helpers/
     load.js               # loadScript("formset") — read + execute the real source file
@@ -151,7 +150,7 @@ which templates it mirrors; template changes must update fixtures.
 - **Taskfile:** new `test-js` task (`npm ci` if `node_modules` is missing, then
   `npx vitest run`) and `test-js-watch`. `task test` (nox) stays Python-only.
 - **Docs:** CONTRIBUTING/README dev-setup gains one line: "JS tests: `task test-js`
-  (requires Node 22+)."
+  (requires Node 20+)."
 - **package.json:** `private: true`, `engines: { node: ">=20" }` (local dev machines run
   Node 20; CI uses 22), scripts `test` / `test:watch`.
 - **Coverage:** dropped during implementation. The sources execute via `new Function` in the

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -67,6 +67,20 @@ tasks:
       - rm -rf .nox
     silent: true
 
+  test-js:
+    desc: Run the JS unit tests (Vitest + jsdom, requires Node 20+)
+    cmds:
+      - test -d node_modules || npm ci
+      - npx vitest run
+    silent: true
+
+  test-js-watch:
+    desc: Run the JS unit tests in watch mode
+    cmds:
+      - test -d node_modules || npm ci
+      - npx vitest
+    silent: true
+
   install-skill-claude:
     cmds:
       - rm -rf ~/.claude/skills/django-crud-views

--- a/tests/js/formset.test.js
+++ b/tests/js/formset.test.js
@@ -189,4 +189,52 @@ describe("formset.js", () => {
             });
         });
     });
+
+    describe("CrudViewsFormset", () => {
+        it("initializes on a non-orderable formset without aborting (regression)", () => {
+            formsetFixture({ canOrder: false });
+            expect(() => new window.cv.CrudViewsFormset()).not.toThrow();
+            // delete still works, proving handlers were bound despite missing up/down
+            document.querySelector("button.cv-form-ctrl-delete").click();
+            expect(document.querySelector('input[name="book-None-0-0-DELETE"]').getAttribute("value")).toBe("1");
+        });
+
+        it("initializes on an edit-only formset without an add button", () => {
+            formsetFixture({ editOnly: true });
+            expect(() => new window.cv.CrudViewsFormset()).not.toThrow();
+            document.querySelector("button.cv-form-ctrl-delete").click();
+            expect(document.querySelector('input[name="book-None-0-0-DELETE"]').getAttribute("value")).toBe("1");
+        });
+
+        it("wires the control buttons to row actions", () => {
+            formsetFixture({ rows: 2 });
+            new window.cv.CrudViewsFormset();
+            document.querySelector('button.cv-form-ctrl-down[cv-data-formset-form-prefix="book-None-0-0"]').click();
+            const prefixes = [...document.querySelectorAll(".cv-formset-row")]
+                .map((el) => el.getAttribute("cv-data-formset-form-prefix"));
+            expect(prefixes).toEqual(["book-None-0-1", "book-None-0-0"]);
+        });
+
+        it("reorders all formsets on submit and lets the submit proceed", () => {
+            formsetFixture({ rows: 2 });
+            new window.cv.CrudViewsFormset();
+            document.querySelectorAll("input[name$=-ORDER]").forEach((el) => (el.value = "9"));
+            const form = document.querySelector("form.cv-form");
+            const event = new Event("submit", { bubbles: true, cancelable: true });
+            form.dispatchEvent(event);
+            expect(event.defaultPrevented).toBe(false);
+            expect([...document.querySelectorAll("input[name$=-ORDER]")].map((el) => el.value)).toEqual(["1", "2"]);
+        });
+
+        it("blocks the submit when reordering fails outright", () => {
+            formsetFixture({ rows: 2 });
+            const controller = new window.cv.CrudViewsFormset();
+            const form = document.querySelector("form.cv-form");
+            // make reorder_formsets throw: the controller can no longer find form.cv-form
+            form.className = "";
+            const event = new Event("submit", { bubbles: true, cancelable: true });
+            form.dispatchEvent(event);
+            expect(event.defaultPrevented).toBe(true);
+        });
+    });
 });

--- a/tests/js/formset.test.js
+++ b/tests/js/formset.test.js
@@ -1,6 +1,6 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { loadScript } from "./helpers/load.js";
-import { formsetFixture } from "./helpers/dom.js";
+import { formsetFixture, rowHtml } from "./helpers/dom.js";
 
 function orderValues() {
     return [...document.querySelectorAll("input[name$=-ORDER]")].map((el) => el.value);
@@ -74,6 +74,119 @@ describe("formset.js", () => {
             const fs = new window.cv.XFormset(null, "book-None-0");
             expect(() => fs.reorder()).not.toThrow();
             expect(document.querySelectorAll("input[name$=-ORDER]")).toHaveLength(0);
+        });
+    });
+
+    describe("XForm", () => {
+        it("computes row position facts", () => {
+            formsetFixture({ rows: 3 });
+            const middle = new window.cv.XForm(null, "book-None-0-1");
+            expect(middle.rows_total).toBe(3);
+            expect(middle.row_index).toBe(1);
+            expect(middle.row_is_first).toBe(false);
+            expect(middle.row_is_last).toBe(false);
+            expect(middle.row_previous.attr("cv-data-formset-form-prefix")).toBe("book-None-0-0");
+            expect(middle.row_next.attr("cv-data-formset-form-prefix")).toBe("book-None-0-2");
+
+            const first = new window.cv.XForm(null, "book-None-0-0");
+            expect(first.row_is_first).toBe(true);
+            expect(first.row_previous).toBeNull();
+
+            const last = new window.cv.XForm(null, "book-None-0-2");
+            expect(last.row_is_last).toBe(true);
+            expect(last.row_next).toBeNull();
+        });
+
+        it("delete() toggles the hidden DELETE input and button styling", () => {
+            formsetFixture();
+            const del = document.querySelector('input[name="book-None-0-0-DELETE"]');
+            const btn = document.querySelector('button.cv-form-ctrl-delete[cv-data-formset-form-prefix="book-None-0-0"]');
+
+            new window.cv.XForm(null, "book-None-0-0").delete();
+            expect(del.getAttribute("value")).toBe("1");
+            expect(btn.classList.contains("btn-danger")).toBe(true);
+            expect(btn.classList.contains("btn-light")).toBe(false);
+
+            new window.cv.XForm(null, "book-None-0-0").delete();
+            expect(del.getAttribute("value")).toBe("0");
+            expect(btn.classList.contains("btn-light")).toBe(true);
+        });
+
+        function rowOrderInDom() {
+            return [...document.querySelectorAll(".cv-formset-row")]
+                .map((el) => el.getAttribute("cv-data-formset-form-prefix"));
+        }
+
+        it("up() moves the row before its predecessor and renumbers", () => {
+            formsetFixture({ rows: 3 });
+            new window.cv.XForm(null, "book-None-0-1").up();
+            expect(rowOrderInDom()).toEqual(["book-None-0-1", "book-None-0-0", "book-None-0-2"]);
+            expect(document.querySelector('input[name="book-None-0-1-ORDER"]').value).toBe("1");
+            expect(document.querySelector('input[name="book-None-0-0-ORDER"]').value).toBe("2");
+        });
+
+        it("up() on the first row is a no-op", () => {
+            formsetFixture({ rows: 2 });
+            new window.cv.XForm(null, "book-None-0-0").up();
+            expect(rowOrderInDom()).toEqual(["book-None-0-0", "book-None-0-1"]);
+        });
+
+        it("down() moves the row after its successor and renumbers", () => {
+            formsetFixture({ rows: 3 });
+            new window.cv.XForm(null, "book-None-0-1").down();
+            expect(rowOrderInDom()).toEqual(["book-None-0-0", "book-None-0-2", "book-None-0-1"]);
+            expect(document.querySelector('input[name="book-None-0-1-ORDER"]').value).toBe("3");
+        });
+
+        it("down() on the last row is a no-op", () => {
+            formsetFixture({ rows: 2 });
+            new window.cv.XForm(null, "book-None-0-1").down();
+            expect(rowOrderInDom()).toEqual(["book-None-0-0", "book-None-0-1"]);
+        });
+
+        describe("add()", () => {
+            function stubAjax(newIndex) {
+                return vi.spyOn($, "ajax").mockImplementation((options) => {
+                    options.success({ html: rowHtml(newIndex), rows: [`book-None-0-${newIndex}`] });
+                });
+            }
+
+            it("requests a new row with the formset's coordinates", () => {
+                formsetFixture({ rows: 2 });
+                const ajax = stubAjax(2);
+                const ctl = { add_form_control_for_new_rows: vi.fn() };
+                new window.cv.XForm(ctl, "book-None-0-1").add();
+                const options = ajax.mock.calls[0][0];
+                expect(options.url).toBe("/formset-rows/");
+                expect(options.type).toBe("get");
+                expect(options.data).toEqual({
+                    template: "book",
+                    pk: "None",
+                    num: 2,
+                    formset_parent_prefix_key: "",
+                });
+                ajax.mockRestore();
+            });
+
+            it("appends after the last row, bumps TOTAL_FORMS and wires controls", () => {
+                formsetFixture({ rows: 2 });
+                const ajax = stubAjax(2);
+                const ctl = { add_form_control_for_new_rows: vi.fn() };
+                new window.cv.XForm(ctl, "book-None-0-1").add();
+                expect(rowOrderInDom()).toEqual(["book-None-0-0", "book-None-0-1", "book-None-0-2"]);
+                expect(document.querySelector('input[name="book-None-0-TOTAL_FORMS"]').getAttribute("value")).toBe("3");
+                expect(ctl.add_form_control_for_new_rows).toHaveBeenCalledWith(["book-None-0-2"]);
+                ajax.mockRestore();
+            });
+
+            it("inserts before the next row when adding from a middle row", () => {
+                formsetFixture({ rows: 2 });
+                const ajax = stubAjax(2);
+                const ctl = { add_form_control_for_new_rows: vi.fn() };
+                new window.cv.XForm(ctl, "book-None-0-0").add();
+                expect(rowOrderInDom()).toEqual(["book-None-0-0", "book-None-0-2", "book-None-0-1"]);
+                ajax.mockRestore();
+            });
         });
     });
 });

--- a/tests/js/formset.test.js
+++ b/tests/js/formset.test.js
@@ -1,0 +1,79 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { loadScript } from "./helpers/load.js";
+import { formsetFixture } from "./helpers/dom.js";
+
+function orderValues() {
+    return [...document.querySelectorAll("input[name$=-ORDER]")].map((el) => el.value);
+}
+
+describe("formset.js", () => {
+    beforeAll(async () => {
+        await loadScript("formset");
+    });
+
+    describe("XFormset", () => {
+        it("parses config, pk and index from the fixture", () => {
+            formsetFixture();
+            const fs = new window.cv.XFormset(null, "book-None-0");
+            expect(fs.prefix).toBe("book-None-0");
+            expect(fs.pk).toBeNull();
+            expect(fs.index).toBe(0);
+            expect(fs.can_order).toBe(true);
+            expect(fs.can_delete).toBe(true);
+            expect(fs.rows).toHaveLength(2);
+        });
+
+        it("parses a concrete parent pk", () => {
+            formsetFixture({ pk: "7" });
+            const fs = new window.cv.XFormset(null, "book-7-0");
+            expect(fs.pk).toBe("7");
+            expect(fs.index).toBe(0);
+        });
+
+        it("reads and writes the management form", () => {
+            formsetFixture({ rows: 2 });
+            const fs = new window.cv.XFormset(null, "book-None-0");
+            expect(fs.get_total_forms()).toBe(2);
+            expect(fs.get_initial_forms()).toBe(2);
+            expect(fs.get_min_num_forms()).toBe(0);
+            expect(fs.get_max_num_forms()).toBe(1000);
+            fs.increment_total_forms();
+            expect(fs.get_total_forms()).toBe(3);
+        });
+
+        it("renumbers ORDER inputs 1..n in DOM order", () => {
+            formsetFixture({ rows: 3 });
+            document.querySelectorAll("input[name$=-ORDER]").forEach((el) => (el.value = "9"));
+            new window.cv.XFormset(null, "book-None-0").reorder();
+            expect(orderValues()).toEqual(["1", "2", "3"]);
+        });
+
+        it("blanks ORDER for empty rows", () => {
+            formsetFixture({ rows: 3, rowValues: ["a", "", "b"] });
+            new window.cv.XFormset(null, "book-None-0").reorder();
+            expect(orderValues()).toEqual(["1", "", "2"]);
+        });
+
+        it("blanks ORDER for delete-marked rows (hidden DELETE input)", () => {
+            formsetFixture({ rows: 3, rowDeleted: [1] });
+            new window.cv.XFormset(null, "book-None-0").reorder();
+            expect(orderValues()).toEqual(["1", "", "2"]);
+        });
+
+        it("blanks ORDER for delete-marked rows (checkbox DELETE input)", () => {
+            formsetFixture({ rows: 2 });
+            const del = document.querySelector('input[name="book-None-0-1-DELETE"]');
+            del.type = "checkbox";
+            del.checked = true;
+            new window.cv.XFormset(null, "book-None-0").reorder();
+            expect(orderValues()).toEqual(["1", ""]);
+        });
+
+        it("does nothing when the formset is not orderable", () => {
+            formsetFixture({ canOrder: false });
+            const fs = new window.cv.XFormset(null, "book-None-0");
+            expect(() => fs.reorder()).not.toThrow();
+            expect(document.querySelectorAll("input[name$=-ORDER]")).toHaveLength(0);
+        });
+    });
+});

--- a/tests/js/harness.test.js
+++ b/tests/js/harness.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { loadScript } from "./helpers/load.js";
+
+describe("harness", () => {
+    it("executes shipped scripts against the jsdom window", async () => {
+        expect(window.__cvToggleInit).toBeUndefined();
+        await loadScript("toggle");
+        expect(window.__cvToggleInit).toBe(true);
+    });
+
+    it("provides real jQuery as a global", () => {
+        expect(window.$).toBeDefined();
+        expect(window.$.fn.jquery).toMatch(/^3\.7\./);
+    });
+});

--- a/tests/js/helpers/dom.js
+++ b/tests/js/helpers/dom.js
@@ -7,3 +7,103 @@ export function modalSkeleton() {
             </div>
         </div>`;
 }
+
+// formsetFixture()/rowHtml() mirror:
+//   src/crud_views/templates/crud_views/formsets/formset.html (+ control.html)
+//   JSON: XFormSet.data / XForm.data in src/crud_views/lib/formsets/render_tree.py
+// Keep in sync when those change.
+const FORMSET_DEFAULTS = {
+    key: "book",
+    pk: "None",
+    index: 0,
+    rows: 2,
+    canOrder: true,
+    canDelete: true,
+    editOnly: false,
+    fields: ["name"],
+    pkField: "id",
+    rowValues: null,
+    rowDeleted: [],
+};
+
+export function formsetPrefix(opts = {}) {
+    const o = { ...FORMSET_DEFAULTS, ...opts };
+    return `${o.key}-${o.pk}-${o.index}`;
+}
+
+export function rowHtml(i, opts = {}) {
+    const o = { ...FORMSET_DEFAULTS, ...opts };
+    const prefix = formsetPrefix(o);
+    const formPrefix = `${prefix}-${i}`;
+    const value = o.rowValues?.[i] ?? `row ${i}`;
+    const deleted = o.rowDeleted.includes(i) ? "1" : "0";
+    const formData = JSON.stringify({
+        key: o.key,
+        prefix: formPrefix,
+        prefix_key: `${o.pk}-${o.index}-${i}`,
+        formset_prefix: prefix,
+        pk: o.pk,
+    });
+    const orderInput = o.canOrder
+        ? `<input type="hidden" name="${formPrefix}-ORDER" value="${i + 1}">`
+        : "";
+    const deleteInput = o.canDelete
+        ? `<input type="hidden" name="${formPrefix}-DELETE" value="${deleted}">`
+        : "";
+    const orderButtons = o.canOrder
+        ? `<button type="button" class="btn btn-light cv-form-ctrl-up" cv-data-formset-form-prefix="${formPrefix}"></button>
+           <button type="button" class="btn btn-light cv-form-ctrl-down" cv-data-formset-form-prefix="${formPrefix}"></button>`
+        : "";
+    const addButton = o.editOnly
+        ? ""
+        : `<button type="button" class="btn btn-light cv-form-ctrl-add" cv-data-formset-form-prefix="${formPrefix}"></button>`;
+    const deleteButton = o.canDelete
+        ? `<button type="button" class="btn btn-light cv-form-ctrl-delete" cv-data-formset-form-prefix="${formPrefix}"></button>`
+        : "";
+    return `
+        <div class="cv-formset-row" cv-data-formset-form='${formData}'
+             cv-data-formset-prefix="${prefix}" cv-data-formset-form-prefix="${formPrefix}">
+            <div class="cv-formset-form">
+                <input type="hidden" name="${formPrefix}-${o.pkField}" value="">
+                <input type="text" name="${formPrefix}-${o.fields[0]}" value="${value}">
+                ${orderInput}
+                ${deleteInput}
+                <div class="cv-form-ctrl">${orderButtons}${addButton}${deleteButton}</div>
+            </div>
+        </div>`;
+}
+
+export function formsetFixture(opts = {}) {
+    const o = { ...FORMSET_DEFAULTS, ...opts };
+    const prefix = formsetPrefix(o);
+    const data = JSON.stringify({
+        key: o.key,
+        prefix,
+        prefix_key: `${o.pk}-${o.index}`,
+        hierarchy: [o.key],
+        parent_prefix: "",
+        parent_prefix_key: "",
+        can_delete: o.canDelete,
+        can_delete_extra: true,
+        can_order: o.canOrder,
+        edit_only: o.editOnly,
+        path: "/formset-rows/",
+        fields: o.fields,
+        pk_field: o.pkField,
+        pk: o.pk,
+    });
+    const rowsHtml = Array.from({ length: o.rows }, (_, i) => rowHtml(i, o)).join("");
+    document.body.innerHTML = `
+        <form class="cv-form">
+            <fieldset class="cv-formset-fieldset" cv-data-formset-key="${o.key}" cv-data-formset-prefix="${prefix}">
+                <div class="cv-formset-content" cv-data-formset='${data}' cv-data-formset-prefix="${prefix}">
+                    <input type="hidden" name="${prefix}-TOTAL_FORMS" value="${o.rows}">
+                    <input type="hidden" name="${prefix}-INITIAL_FORMS" value="${o.rows}">
+                    <input type="hidden" name="${prefix}-MIN_NUM_FORMS" value="0">
+                    <input type="hidden" name="${prefix}-MAX_NUM_FORMS" value="1000">
+                    ${rowsHtml}
+                </div>
+            </fieldset>
+        </form>`;
+    return { prefix };
+}

--- a/tests/js/helpers/dom.js
+++ b/tests/js/helpers/dom.js
@@ -1,0 +1,9 @@
+export function modalSkeleton() {
+    document.body.innerHTML = `
+        <div id="cv-config" data-request-path="/books/" data-query-string="" data-csrf-token="test-token" hidden></div>
+        <div class="modal fade" id="cv-modal" tabindex="-1" aria-hidden="true">
+            <div class="modal-dialog" id="cv-modal-dialog">
+                <div class="modal-content" id="cv-modal-content"></div>
+            </div>
+        </div>`;
+}

--- a/tests/js/helpers/load.js
+++ b/tests/js/helpers/load.js
@@ -1,15 +1,11 @@
 import fs from "node:fs";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { vi } from "vitest";
 
-// jsdom's URL constructor differs from Node's; wrap in try/catch for compatibility
-const JS_DIR = (() => {
-    try {
-        return fileURLToPath(new URL("../../../src/crud_views/static/crud_views/js/", import.meta.url));
-    } catch {
-        return fileURLToPath(new URL("../../../src/crud_views/static/crud_views/js/", `file://${process.cwd()}/tests/js/helpers/load.js`));
-    }
-})();
+// Resolve via path, not `new URL(relative, base)` — in the jsdom test
+// environment the global URL is jsdom's and rejects file-scheme resolution.
+const JS_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../src/crud_views/static/crud_views/js");
 
 // jsdom's window.location is unforgeable (cannot be spied on or replaced) and
 // its navigation methods are no-ops. The shipped files always navigate via
@@ -33,7 +29,7 @@ function testWindow() {
 }
 
 export async function loadScript(name) {
-    const code = fs.readFileSync(`${JS_DIR}${name}.js`, "utf-8");
+    const code = fs.readFileSync(path.join(JS_DIR, `${name}.js`), "utf-8");
     new Function("window", code)(testWindow());
     // jQuery defers $(document).ready() callbacks by a microtask even when the
     // document is already complete; wait for them so wiring is done on return.

--- a/tests/js/helpers/load.js
+++ b/tests/js/helpers/load.js
@@ -1,0 +1,41 @@
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import { vi } from "vitest";
+
+// jsdom's URL constructor differs from Node's; wrap in try/catch for compatibility
+const JS_DIR = (() => {
+    try {
+        return fileURLToPath(new URL("../../../src/crud_views/static/crud_views/js/", import.meta.url));
+    } catch {
+        return fileURLToPath(new URL("../../../src/crud_views/static/crud_views/js/", `file://${process.cwd()}/tests/js/helpers/load.js`));
+    }
+})();
+
+// jsdom's window.location is unforgeable (cannot be spied on or replaced) and
+// its navigation methods are no-ops. The shipped files always navigate via
+// `window.location.*`, so loadScript executes them against a Proxy whose
+// `location` is this stub; everything else falls through to the real window.
+export const nav = {
+    assign: vi.fn(),
+    href: "",
+};
+
+export function resetNav() {
+    nav.assign = vi.fn();
+    nav.href = "";
+}
+
+function testWindow() {
+    return new Proxy(window, {
+        get: (target, prop) => (prop === "location" ? nav : Reflect.get(target, prop)),
+        set: (target, prop, value) => Reflect.set(target, prop, value),
+    });
+}
+
+export async function loadScript(name) {
+    const code = fs.readFileSync(`${JS_DIR}${name}.js`, "utf-8");
+    new Function("window", code)(testWindow());
+    // jQuery defers $(document).ready() callbacks by a microtask even when the
+    // document is already complete; wait for them so wiring is done on return.
+    await new Promise((resolve) => window.jQuery(resolve));
+}

--- a/tests/js/helpers/setup.js
+++ b/tests/js/helpers/setup.js
@@ -1,0 +1,16 @@
+import $ from "jquery";
+import { beforeEach, vi } from "vitest";
+import { resetNav } from "./load.js";
+
+// The shipped files resolve `$` / `jQuery` as bare globals; stubGlobal sets
+// them on both globalThis and the jsdom window.
+vi.stubGlobal("$", $);
+vi.stubGlobal("jQuery", $);
+
+// formset.js logs debug chatter via console.log/console.assert.
+vi.spyOn(console, "log").mockImplementation(() => {});
+vi.spyOn(console, "assert").mockImplementation(() => {});
+
+beforeEach(() => {
+    resetNav();
+});

--- a/tests/js/modal.test.js
+++ b/tests/js/modal.test.js
@@ -1,0 +1,168 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadScript, nav } from "./helpers/load.js";
+import { modalSkeleton } from "./helpers/dom.js";
+
+function textResponse(html, { ok = true, status = 200, headers = {} } = {}) {
+    return {
+        ok,
+        status,
+        headers: { get: (name) => headers[name] ?? null },
+        text: () => Promise.resolve(html),
+    };
+}
+
+function stubFetch(responseOrError) {
+    const impl = responseOrError instanceof Error
+        ? () => Promise.reject(responseOrError)
+        : () => Promise.resolve(responseOrError);
+    const fetchMock = vi.fn(impl);
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+}
+
+describe("modal.js", () => {
+    let show;
+
+    beforeAll(async () => {
+        await loadScript("modal");
+    });
+
+    beforeEach(() => {
+        modalSkeleton();
+        show = vi.fn();
+        vi.stubGlobal("bootstrap", { Modal: { getOrCreateInstance: vi.fn(() => ({ show })) } });
+    });
+
+    describe("cvModalOpen", () => {
+        it("GETs the url with the X-CV-Modal header", async () => {
+            const fetchMock = stubFetch(textResponse("<p>hi</p>"));
+            window.cv.cvModalOpen("/books/create/", "");
+            await vi.waitFor(() => expect(show).toHaveBeenCalled());
+            expect(fetchMock).toHaveBeenCalledWith("/books/create/", { headers: { "X-CV-Modal": "true" } });
+        });
+
+        it("injects the partial, sets url + size and shows the modal on 200", async () => {
+            stubFetch(textResponse("<p>partial</p>"));
+            const loaded = vi.fn();
+            document.getElementById("cv-modal").addEventListener("cv:modal:loaded", loaded);
+            window.cv.cvModalOpen("/books/create/", "modal-lg");
+            await vi.waitFor(() => expect(show).toHaveBeenCalled());
+            expect(document.getElementById("cv-modal-content").innerHTML).toBe("<p>partial</p>");
+            expect(document.getElementById("cv-modal-dialog").className).toBe("modal-dialog modal-lg");
+            expect(document.getElementById("cv-modal").getAttribute("data-cv-url")).toBe("/books/create/");
+            expect(loaded).toHaveBeenCalled();
+            expect(nav.assign).not.toHaveBeenCalled();
+        });
+
+        it("resets the dialog class when no size is given", async () => {
+            stubFetch(textResponse("<p>x</p>"));
+            document.getElementById("cv-modal-dialog").className = "modal-dialog modal-lg";
+            window.cv.cvModalOpen("/books/create/", "");
+            await vi.waitFor(() => expect(show).toHaveBeenCalled());
+            expect(document.getElementById("cv-modal-dialog").className).toBe("modal-dialog");
+        });
+
+        it("falls back to full-page navigation on a non-OK response", async () => {
+            stubFetch(textResponse("boom", { ok: false, status: 500 }));
+            window.cv.cvModalOpen("/books/create/", "");
+            await vi.waitFor(() => expect(nav.assign).toHaveBeenCalledWith("/books/create/"));
+            expect(show).not.toHaveBeenCalled();
+            expect(document.getElementById("cv-modal-content").innerHTML).toBe("");
+        });
+
+        it("falls back to full-page navigation on a network error", async () => {
+            stubFetch(new Error("offline"));
+            window.cv.cvModalOpen("/books/create/", "");
+            await vi.waitFor(() => expect(nav.assign).toHaveBeenCalledWith("/books/create/"));
+        });
+    });
+
+    describe("cvModalSubmit", () => {
+        function modalForm({ action = "/books/create/", modalUrl = null } = {}) {
+            if (modalUrl) {
+                document.getElementById("cv-modal").setAttribute("data-cv-url", modalUrl);
+            }
+            document.getElementById("cv-modal-content").innerHTML =
+                `<form action="${action}"><input type="text" name="title" value="t"></form>`;
+            return document.querySelector("#cv-modal-content form");
+        }
+
+        it("POSTs FormData with the X-CV-Modal header", async () => {
+            const fetchMock = stubFetch(textResponse("", { status: 204, headers: { "X-CV-Redirect": "/books/" } }));
+            window.cv.cvModalSubmit(modalForm());
+            await vi.waitFor(() => expect(nav.assign).toHaveBeenCalled());
+            const [url, options] = fetchMock.mock.calls[0];
+            expect(url).toBe("/books/create/");
+            expect(options.method).toBe("POST");
+            expect(options.headers).toEqual({ "X-CV-Modal": "true" });
+            expect(options.body).toBeInstanceOf(FormData);
+        });
+
+        it("navigates to the X-CV-Redirect target on success", async () => {
+            stubFetch(textResponse("", { status: 204, headers: { "X-CV-Redirect": "/books/" } }));
+            window.cv.cvModalSubmit(modalForm());
+            await vi.waitFor(() => expect(nav.assign).toHaveBeenCalledWith("/books/"));
+        });
+
+        it("swaps in the re-rendered partial on 422", async () => {
+            stubFetch(textResponse("<form>errors</form>", { ok: false, status: 422 }));
+            window.cv.cvModalSubmit(modalForm());
+            await vi.waitFor(() =>
+                expect(document.getElementById("cv-modal-content").innerHTML).toBe("<form>errors</form>"));
+            expect(nav.assign).not.toHaveBeenCalled();
+        });
+
+        it("navigates to data-cv-url on an unexpected status", async () => {
+            stubFetch(textResponse("boom", { ok: false, status: 500 }));
+            window.cv.cvModalSubmit(modalForm({ modalUrl: "/books/create/?step=1" }));
+            await vi.waitFor(() => expect(nav.assign).toHaveBeenCalledWith("/books/create/?step=1"));
+        });
+
+        it("navigates to the form action when no data-cv-url is set", async () => {
+            stubFetch(textResponse("boom", { ok: false, status: 500 }));
+            window.cv.cvModalSubmit(modalForm());
+            await vi.waitFor(() => expect(nav.assign).toHaveBeenCalledWith("/books/create/"));
+        });
+
+        it("navigates to the fallback on a network error", async () => {
+            stubFetch(new Error("offline"));
+            window.cv.cvModalSubmit(modalForm({ modalUrl: "/books/create/" }));
+            await vi.waitFor(() => expect(nav.assign).toHaveBeenCalledWith("/books/create/"));
+        });
+    });
+
+    describe("guards", () => {
+        it("throws a descriptive error when #cv-modal is missing", () => {
+            document.body.innerHTML = "";
+            expect(() => window.cv.cvModalElements()).toThrow(/#cv-modal not found/);
+        });
+
+        it("throws a descriptive error when Bootstrap is missing", () => {
+            vi.stubGlobal("bootstrap", undefined);
+            expect(() => window.cv.cvModalElements()).toThrow(/Bootstrap 5 JavaScript not loaded/);
+        });
+    });
+
+    describe("delegated handlers", () => {
+        it("opens the modal from a [data-cv-modal] link click", async () => {
+            const fetchMock = stubFetch(textResponse("<p>x</p>"));
+            document.body.insertAdjacentHTML("beforeend",
+                `<a href="/books/1/delete/" data-cv-modal="true" data-cv-modal-size="modal-xl">del</a>`);
+            document.querySelector("a[data-cv-modal]").click();
+            await vi.waitFor(() => expect(show).toHaveBeenCalled());
+            expect(fetchMock).toHaveBeenCalledWith("/books/1/delete/", { headers: { "X-CV-Modal": "true" } });
+            expect(document.getElementById("cv-modal-dialog").className).toBe("modal-dialog modal-xl");
+        });
+
+        it("intercepts form submits inside the modal content", async () => {
+            const fetchMock = stubFetch(textResponse("", { status: 204, headers: { "X-CV-Redirect": "/done/" } }));
+            document.getElementById("cv-modal-content").innerHTML = `<form action="/books/create/"></form>`;
+            const form = document.querySelector("#cv-modal-content form");
+            const event = new Event("submit", { bubbles: true, cancelable: true });
+            form.dispatchEvent(event);
+            expect(event.defaultPrevented).toBe(true);
+            await vi.waitFor(() => expect(nav.assign).toHaveBeenCalledWith("/done/"));
+            expect(fetchMock.mock.calls[0][1].method).toBe("POST");
+        });
+    });
+});

--- a/tests/js/toggle.test.js
+++ b/tests/js/toggle.test.js
@@ -1,0 +1,121 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadScript } from "./helpers/load.js";
+
+function fixture({ field = "active", checked = true, checkboxName = field } = {}) {
+    document.body.innerHTML = `
+        <form>
+            <input type="checkbox" name="${checkboxName}" ${checked ? "checked" : ""}>
+            <div cv-data-toggle-group cv-data-toggle-field="${field}">
+                <input type="text" name="title">
+                <select name="genre"></select>
+                <textarea name="notes"></textarea>
+                <input type="hidden" name="book-None-0-TOTAL_FORMS" value="2">
+            </div>
+        </form>`;
+    return {
+        group: document.querySelector("[cv-data-toggle-group]"),
+        checkbox: document.querySelector("input[type=checkbox]"),
+    };
+}
+
+function wire() {
+    document.dispatchEvent(new Event("DOMContentLoaded", { bubbles: true }));
+}
+
+describe("toggle.js", () => {
+    beforeAll(async () => {
+        await loadScript("toggle");
+    });
+
+    beforeEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("keeps a group with a checked toggle visible and enabled", () => {
+        const { group } = fixture({ checked: true });
+        wire();
+        expect(group.style.display).toBe("");
+        expect(group.querySelector("[name=title]").disabled).toBe(false);
+    });
+
+    it("hides and disables a group whose toggle is unchecked", () => {
+        const { group } = fixture({ checked: false });
+        wire();
+        expect(group.style.display).toBe("none");
+        expect(group.querySelector("[name=title]").disabled).toBe(true);
+        expect(group.querySelector("[name=genre]").disabled).toBe(true);
+        expect(group.querySelector("[name=notes]").disabled).toBe(true);
+    });
+
+    it("keeps management-form hidden inputs enabled even when the group is off", () => {
+        const { group } = fixture({ checked: false });
+        wire();
+        expect(group.querySelector("[name$=-TOTAL_FORMS]").disabled).toBe(false);
+    });
+
+    it("reacts to checkbox change in both directions", () => {
+        const { group, checkbox } = fixture({ checked: true });
+        wire();
+        checkbox.click();
+        expect(group.style.display).toBe("none");
+        expect(group.querySelector("[name=title]").disabled).toBe(true);
+        checkbox.click();
+        expect(group.style.display).toBe("");
+        expect(group.querySelector("[name=title]").disabled).toBe(false);
+    });
+
+    it("finds the checkbox by formset-prefixed suffix name", () => {
+        const { group } = fixture({ field: "active", checkboxName: "book-None-0-active", checked: false });
+        wire();
+        expect(group.style.display).toBe("none");
+    });
+
+    it("scopes the checkbox lookup to the nearest form", () => {
+        document.body.innerHTML = `
+            <form id="a"><input type="checkbox" name="active" checked></form>
+            <form id="b">
+                <input type="checkbox" name="active">
+                <div cv-data-toggle-group cv-data-toggle-field="active">
+                    <input type="text" name="title">
+                </div>
+            </form>`;
+        wire();
+        const group = document.querySelector("[cv-data-toggle-group]");
+        expect(group.style.display).toBe("none");
+        document.querySelector("#a input").click();
+        expect(group.style.display).toBe("none");
+    });
+
+    it("leaves a group without a matching checkbox untouched", () => {
+        document.body.innerHTML = `
+            <div cv-data-toggle-group cv-data-toggle-field="nope">
+                <input type="text" name="title">
+            </div>`;
+        expect(() => wire()).not.toThrow();
+        const group = document.querySelector("[cv-data-toggle-group]");
+        expect(group.style.display).toBe("");
+        expect(group.querySelector("[name=title]").disabled).toBe(false);
+    });
+
+    it("wires groups injected into the modal via cv:modal:loaded", () => {
+        document.body.innerHTML = `<div id="cv-modal-content"></div>`;
+        const content = document.getElementById("cv-modal-content");
+        content.innerHTML = `
+            <form>
+                <input type="checkbox" name="active">
+                <div cv-data-toggle-group cv-data-toggle-field="active">
+                    <input type="text" name="title">
+                </div>
+            </form>`;
+        content.dispatchEvent(new CustomEvent("cv:modal:loaded", { bubbles: true }));
+        expect(content.querySelector("[cv-data-toggle-group]").style.display).toBe("none");
+    });
+
+    it("does not double-bind an already-wired group", () => {
+        const { checkbox } = fixture();
+        const spy = vi.spyOn(checkbox, "addEventListener");
+        wire();
+        wire();
+        expect(spy.mock.calls.filter(([type]) => type === "change")).toHaveLength(1);
+    });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        environment: "jsdom",
+        include: ["tests/js/**/*.test.js"],
+        setupFiles: ["tests/js/helpers/setup.js"],
+    },
+});


### PR DESCRIPTION
## Summary

Adds a JS unit-test harness (Vitest + jsdom) for the package's first-party static JavaScript — `formset.js`, `modal.js`, `toggle.js` — which previously had zero test coverage. 48 tests, no build step: tests execute the exact files Django serves.

- **Harness**: root `package.json` (dev-only, `private: true`), `vitest.config.js`, `tests/js/` with a `loadScript()` helper that runs each shipped file against a jsdom window whose unforgeable `location` is replaced via Proxy; real jQuery 3.7.x as devDependency; Bootstrap/fetch/AJAX stubbed per test.
- **Bugfix** (`formset.js`): rows marked for deletion now lose their `ORDER` value during client-side reorder. The old check read `.checked` on the hidden `DELETE` input (always false). No server-side impact — Django's `ordered_forms` already excluded deleted forms. Reproduced RED by test before fixing.
- **Behavior-neutral seams**: `formset.js`/`modal.js` gain a trailing `window.cv` attachment block (classes/functions were already lexical/implicit globals in browsers); `toggle.js` untouched — tested purely through events.
- **Fixtures** mirror the real templates (`tags/cv_config.html`, `formsets/formset.html` + `control.html`) and the `render_tree.py` JSON contracts, with sync comments naming the mirrored files.
- **CI/devx**: new `JS Tests` workflow (Node 22, `npm ci`, `npx vitest run`), `task test-js` / `test-js-watch`, CONTRIBUTING + development docs, changelog.
- **Coverage** was attempted (istanbul instrumentation in the loader) and deliberately dropped: Vitest's istanbul provider drops externally-produced `__coverage__` entries. Recorded in the spec with a follow-up candidate (`nyc` over the loader-produced object).

Spec: `superpowers/specs/2026-07-21-js-test-harness-design.md` · Plan: `superpowers/plans/2026-07-21-js-test-harness.md`

## Test plan

- [x] `npx vitest run` → 48 passed (toggle 9, modal 15, formset 22, loader smoke 2)
- [x] `cd tests && pytest` → 855 passed, 2 skipped (Python untouched except the two JS files)
- [x] Per-task adversarial reviews incl. independent RED reproduction of the DELETE bug; final whole-branch review: ready to merge

Follow-up (separate issue): the harness surfaced that `formsets/control.html` renders the add button unconditionally, so edit-only formsets get a live add button (pre-existing).