### PR TITLE
feat(i18n): full internationalization across all packages + example app (#88)

### DIFF
--- a/docs/development/i18n.md
+++ b/docs/development/i18n.md
@@ -95,6 +95,9 @@ PYTHONPATH=../.. python -m django makemessages -l <locale> --settings=settings_i
 strings appear with an empty `msgstr ""`; strings that no longer exist are marked with `#~ `
 (obsolete).
 
+> Re-running `task msg-make` rewrites the `POT-Creation-Date` header in every catalog, so a run
+> with no actual string changes still produces header-only diffs — this is expected.
+
 **2. Edit the `.po` file** and fill in the empty `msgstr` values for the new strings. Remove any
 `#, fuzzy` flags after reviewing the suggested translations.
 
@@ -105,8 +108,8 @@ task msg-comp             # all packages
 task examples:msg-comp    # example app
 ```
 
-`task msg-comp` runs `python -m django compilemessages --settings=settings_i18n` from `src/`,
-which compiles every package's catalogs in one pass. `task examples:msg-comp` runs
+`task msg-comp` runs `PYTHONPATH=.. python -m django compilemessages --settings=settings_i18n`
+from `src/`, which compiles every package's catalogs in one pass. `task examples:msg-comp` runs
 `manage.py compilemessages` inside `examples/bootstrap5`.
 
 **4. Commit both `.po` and `.mo` files.**

--- a/examples/bootstrap5/test_i18n.py
+++ b/examples/bootstrap5/test_i18n.py
@@ -1,5 +1,11 @@
+import gettext as gettext_mod
+from pathlib import Path
+
 import pytest
 from django.test import Client
+
+LOCALE_DIR = Path(__file__).resolve().parent / "locale"
+LOCALES = ["de", "fr", "es", "pt", "it", "zh_Hans"]
 
 
 @pytest.mark.django_db
@@ -31,3 +37,24 @@ def test_nav_logout_translated_de(client, django_user_model):
     client.force_login(user)
     resp = client.get("/", HTTP_ACCEPT_LANGUAGE="de")
     assert "Abmelden" in resp.content.decode()  # "Log Out" -> German
+
+
+# NOTE: mirrors tests/test1/test_i18n.py's package-catalog guards, applied to the
+# example app's own locale/ catalogs (#88 final review, Task 9).
+def test_no_empty_or_fuzzy_msgstr():
+    polib = pytest.importorskip("polib")  # pip/uv add polib to the dev deps if missing
+    for loc in LOCALES:
+        po = polib.pofile(str(LOCALE_DIR / loc / "LC_MESSAGES" / "django.po"))
+        # polib .translated() correctly handles plurals (msgstr[0..n]) and multi-line strings:
+        untranslated = [e.msgid for e in po if not e.obsolete and not e.translated()]
+        assert not untranslated, f"{loc}: untranslated {untranslated}"
+        fuzzy = [e.msgid for e in po if "fuzzy" in e.flags]
+        assert not fuzzy, f"{loc}: fuzzy entries render as English: {fuzzy}"
+
+
+def test_mo_files_load():
+    for loc in LOCALES:
+        mo = LOCALE_DIR / loc / "LC_MESSAGES" / "django.mo"
+        assert mo.exists(), f"missing {mo}"
+        with mo.open("rb") as fh:
+            gettext_mod.GNUTranslations(fh)  # raises if corrupt

--- a/superpowers/specs/2026-07-22-i18n-native-review-followup.md
+++ b/superpowers/specs/2026-07-22-i18n-native-review-followup.md
@@ -30,6 +30,12 @@ inconsistent in register/formality, or wrong for domain-specific UI terms (e.g. 
 "Confirm deletion", permission/workflow vocabulary). `de` is the baseline for what a
 human-reviewed catalog should look like.
 
+`pt` additionally mixes European and Brazilian Portuguese across its own catalogs — e.g.
+`crud_views` pt uses European forms ("Guardar", "Gerir", "Repor filtro") while
+`crud_views_guardian` and the example app use Brazilian forms ("Usuários", "aplicativo"). The
+`pt` reviewer needs to normalize dialect consistently across all six `pt` catalogs, not just fix
+correctness/tone issues.
+
 ## Files to review
 
 Each locale has one catalog per package — 5 packages × 5 locales = 25 files:


### PR DESCRIPTION
Closes #88

## Summary

Full i18n across all five packages and the bootstrap5 example app:

- **Pipeline**: gettext infrastructure (`settings_i18n`, loop-based `msg-make`/`msg-comp` tasks) for all packages; example app gets its own msg tasks.
- **String marking**: user-facing strings marked in `crud_views_guardian`, `crud_views_polymorphic`, `crud_views_object_detail` (templates + python); example app nav/home/features marked.
- **Catalogs**: 6 locales (de, fr, es, pt, it, zh-hans) for all 5 packages and the example app; 12 drifted/fuzzy de entries in `crud_views` corrected.
- **Language selector**: reusable `cv_language_selector` component + example-app `LocaleMiddleware`/`LANGUAGES`/i18n URLs integration.
- **Guard tests**: no empty/fuzzy msgstr, catalogs compile, wheel ships all 30 `.mo` files.
- **Docs**: `docs/development/i18n.md` rewritten for full package + example-app coverage.

## Review status

Went through the full SDD workflow (9 tasks, each spec-checked and reviewer-approved). Final whole-branch review verdict after fix commit `69cd353`: **Ready to merge — Yes**.

## At merge time

- Create the native-review follow-up issue from `superpowers/specs/2026-07-22-i18n-native-review-followup.md` (machine-authored locales need native-speaker review).
- Reviewer-approved fast follow-up (separate PR): `.po` rewrap normalization + POT-Creation-Date strip in msg-make, zh `Language:` header consistency, dead `{% load i18n %}` in selector partial, two docs sentences.

## Test plan

- Package suite 864 passed / 1 skipped; example suite 134 passed; ruff clean (verified on branch).
- Full nox matrix (3.12/3.13/3.14 × Django 4.2/5.2/6.0) deliberately deferred to this PR's CI.