### PR TITLE
fix(ci): coverage config never read — measure src/ instead of tests/ (#103)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@
 
 ## Checklist
 
-- [ ] Tests pass (`cd tests && pytest`)
+- [ ] Tests pass (`pytest tests`)
 - [ ] `task format` and `task check` are clean
 - [ ] `CHANGELOG.md` has an entry under `## Unreleased`
 - [ ] Documentation updated (if behavior changed)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
         if: matrix.python-version == '3.13'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: tests/coverage.xml
+          files: coverage.xml
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,4 +26,4 @@ jobs:
         if: matrix.python-version == '3.13'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: tests/coverage.xml
+          files: coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@
   under PEP 649 deferred evaluation on Python 3.14. Only affects code that reads the
   settings object directly; the template context it feeds is unchanged.
 
+### Fixed
+
+- Coverage is now measured for the package source. `pytest` runs from the repository
+  root instead of `tests/`, so coverage.py finds the `[tool.coverage.*]` config in
+  `pyproject.toml` — previously it found none, measured the test suite instead of
+  `src/`, and emitted absolute paths that Codecov silently discarded. The reported
+  project figure drops from ~99% to ~94% as a result: that is a measurement
+  correction, not a regression. `crud_views_guardian`, missing from the coverage
+  `source` list, is now included. (#103)
+
 ## 0.19.0
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,14 +20,14 @@ task dev
 # Run tests via nox (matrix: Python 3.12/3.13/3.14 × Django 4.2/5.2/6.0)
 task test
 
-# Run tests directly for quick iteration (from tests/ directory)
-cd tests && pytest
+# Run tests directly for quick iteration (from the repo root)
+pytest tests
 
 # Run a single test file
-cd tests && pytest test1/test_crud.py
+pytest tests/test1/test_crud.py
 
 # Run a single test
-cd tests && pytest test1/test_crud.py::test_name -v
+pytest tests/test1/test_crud.py::test_name -v
 
 # Lint and format
 task format   # ruff format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ task dev
 2. Make your change following the existing patterns. Write tests first (this
    project follows test-driven development).
 3. Run the tests:
-   - quick: `cd tests && pytest`
+   - quick: `pytest tests`
    - full matrix (Python 3.12/3.13/3.14 × Django 4.2/5.2/6.0): `task test`
    - JS unit tests (requires Node 20+): `task test-js`
 4. Format and lint before committing:

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,8 +13,7 @@ def tests(session, django):
     session.install(f"django~={django}.0")
     session.install(".[polymorphic,workflow,ordered,test]")
 
-    with session.chdir("./tests"):
-        session.run("pytest", "-n", "auto", "--cov", "--cov-report=term-missing", *session.posargs)
+    session.run("pytest", "tests", "-n", "auto", "--cov", "--cov-report=term-missing", *session.posargs)
 
 
 @nox.session(python=["3.12", "3.13", "3.14"], venv_backend="uv")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,14 @@ allowed-confusables = ["›"]
 addopts = "--strict-markers"
 
 [tool.coverage.run]
-source = ["crud_views", "crud_views_polymorphic", "crud_views_workflow", "crud_views_object_detail"]
+relative_files = true
+source = [
+    "crud_views",
+    "crud_views_guardian",
+    "crud_views_object_detail",
+    "crud_views_polymorphic",
+    "crud_views_workflow",
+]
 
 [tool.coverage.report]
 show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,15 @@ source = [
     "crud_views_workflow",
 ]
 
+[tool.coverage.paths]
+# nox installs the package rather than linking it, so measured files live under
+# .nox/<session>/lib/python3.X/site-packages/. Map them back onto src/ so the
+# report names files Codecov can find in the repository. See issue #103.
+source = [
+    "src/",
+    "*/site-packages/",
+]
+
 [tool.coverage.report]
 show_missing = true
 skip_empty = true

--- a/superpowers/plans/2026-07-28-coverage-config-src-measurement.md
+++ b/superpowers/plans/2026-07-28-coverage-config-src-measurement.md
@@ -1,0 +1,418 @@
+# Coverage Config / `src/` Measurement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Codecov measure the package source in `src/` instead of the test suite, by running pytest from the repository root so coverage.py finds its config and emits repo-relative paths.
+
+**Architecture:** The root `pyproject.toml` already carries a `[tool.coverage.*]` config that has never been read, because `noxfile.py` chdirs into `tests/` and coverage.py neither walks up to find a config nor can make `src/` paths relative to `tests/`. Removing that single `chdir` fixes both halves at once — the existing config becomes live automatically, and paths come out as `src/…`. Everything else in this plan is following that change to its consequences: the emitted `coverage.xml` moves to the repo root (two workflows reference it), three documents tell contributors to `cd tests`, and a regression test pins the `source` list to the actual contents of `src/`.
+
+**Tech Stack:** coverage.py 7.15.2, pytest + pytest-cov + pytest-xdist, nox (uv backend), GitHub Actions, `codecov/codecov-action@v5`, `tomllib` (stdlib).
+
+**Spec:** `superpowers/specs/2026-07-28-coverage-config-src-measurement-design.md`
+**Issue:** [#103](https://github.com/jacob-consulting/django-crud-views/issues/103) — see also the [correction comment](https://github.com/jacob-consulting/django-crud-views/issues/103#issuecomment-5109148896), which supersedes the issue's "Suggested fix" section.
+**Branch:** `feature/coverage-config-src-measurement-103` (already created; spec already committed there)
+
+## Global Constraints
+
+- Line length 120, double quotes, ruff-formatted. `ruff-format` runs as a pre-commit hook.
+- Python floor is 3.12, so `tomllib` is available in the stdlib — do not add a `toml` dependency.
+- `fail_under` **stays at 88**. Do not retune it. This change corrects measurement, not policy.
+- Do not add a `codecov.yml`. Do not add `--cov-append` or otherwise merge matrix rows. Both are explicitly out of scope and tracked as follow-ups.
+- The `examples` nox session keeps its own `session.chdir("./examples/bootstrap5")`. Only the `tests` session loses its chdir.
+- All work happens on `feature/coverage-config-src-measurement-103`. Do not commit to `main`.
+- Every commit message references `#103`.
+
+---
+
+### Task 1: Pin the coverage `source` list to `src/`, and fix it
+
+The `source` list omits `crud_views_guardian`. Nobody noticed because the entire config was inert. This task adds the test that would have caught it, then makes the config correct.
+
+**Files:**
+- Create: `tests/test1/test_coverage_config.py`
+- Modify: `pyproject.toml:129-131` (the `[tool.coverage.run]` block)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: a corrected `[tool.coverage.run]` block containing `relative_files = true` and a five-element sorted `source` list. Task 2 depends on this config being both correct and discoverable from the repo root.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test1/test_coverage_config.py`:
+
+```python
+"""Guards against drift between the coverage config and the packages in src/.
+
+`crud_views_guardian` was missing from `[tool.coverage.run].source` for a long time
+without anyone noticing, because the whole config was inert — coverage.py never found
+it while pytest ran from `tests/`. See issue #103.
+"""
+
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _coverage_run_config() -> dict:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as fh:
+        return tomllib.load(fh)["tool"]["coverage"]["run"]
+
+
+def test_coverage_source_lists_every_src_package():
+    """Every distributed package must be measured, in sorted order."""
+    packages = sorted(p.name for p in (REPO_ROOT / "src").iterdir() if (p / "__init__.py").is_file())
+    assert _coverage_run_config()["source"] == packages
+
+
+def test_coverage_emits_relative_paths():
+    """Without this, coverage.xml carries an absolute machine-specific <source> prefix."""
+    assert _coverage_run_config()["relative_files"] is True
+```
+
+`parents[2]` resolves to the repo root: `parents[0]` is `test1`, `parents[1]` is `tests`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test1/test_coverage_config.py -v`
+
+Expected: both tests FAIL.
+- `test_coverage_source_lists_every_src_package` — AssertionError; the config list is 4 items in unsorted order (`crud_views`, `crud_views_polymorphic`, `crud_views_workflow`, `crud_views_object_detail`), the computed list is 5 items sorted.
+- `test_coverage_emits_relative_paths` — `KeyError: 'relative_files'`.
+
+Both failures are the point. Do not proceed until you have seen them.
+
+- [ ] **Step 3: Fix the config**
+
+In `pyproject.toml`, replace:
+
+```toml
+[tool.coverage.run]
+source = ["crud_views", "crud_views_polymorphic", "crud_views_workflow", "crud_views_object_detail"]
+```
+
+with:
+
+```toml
+[tool.coverage.run]
+relative_files = true
+source = [
+    "crud_views",
+    "crud_views_guardian",
+    "crud_views_object_detail",
+    "crud_views_polymorphic",
+    "crud_views_workflow",
+]
+```
+
+Leave `[tool.coverage.report]` exactly as it is — `show_missing`, `skip_empty`, and `fail_under = 88` are all unchanged.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test1/test_coverage_config.py -v`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test1/test_coverage_config.py pyproject.toml
+git commit -m "test(coverage): pin source list to src/ packages; add guardian, relative_files (#103)"
+```
+
+---
+
+### Task 2: Run the test suite from the repository root
+
+This is the actual fix. Removing the `chdir` makes coverage.py discover the root `pyproject.toml` and anchor relative paths to the repo root. The emitted `coverage.xml` moves from `tests/` to the root, so both workflows that upload it must change in the same commit or CI breaks.
+
+**Files:**
+- Modify: `noxfile.py:16-17`
+- Modify: `.github/workflows/tests.yml:29`
+- Modify: `.github/workflows/publish.yml:27`
+- Modify: `CLAUDE.md:23-30`
+- Modify: `CONTRIBUTING.md:27`
+- Modify: `.github/PULL_REQUEST_TEMPLATE.md:19`
+
+**Interfaces:**
+- Consumes: the corrected `[tool.coverage.run]` block from Task 1.
+- Produces: `coverage.xml` at the repository root, containing `<source></source>`, filenames beginning `src/`, and no `tests/` entries. Task 3 asserts on exactly these properties.
+
+- [ ] **Step 1: Remove the chdir from the nox `tests` session**
+
+In `noxfile.py`, replace lines 16-17:
+
+```python
+    with session.chdir("./tests"):
+        session.run("pytest", "-n", "auto", "--cov", "--cov-report=term-missing", *session.posargs)
+```
+
+with:
+
+```python
+    session.run("pytest", "tests", "-n", "auto", "--cov", "--cov-report=term-missing", *session.posargs)
+```
+
+Note the de-indent — the `session.run` is no longer inside a `with` block. Do not touch the `examples` session at line 30; it keeps its own chdir.
+
+No `--cov-config` flag is needed. pytest-cov's default of `.coveragerc` is special-cased by coverage.py to mean "search the defaults", so `pyproject.toml` in the CWD is found.
+
+- [ ] **Step 2: Point both workflows at the new coverage.xml location**
+
+In `.github/workflows/tests.yml`, line 29, change:
+
+```yaml
+          files: tests/coverage.xml
+```
+
+to:
+
+```yaml
+          files: coverage.xml
+```
+
+Then make the identical change in `.github/workflows/publish.yml`, line 27. This second one is easy to miss — it is a separate copy of the upload step that runs on release, and leaving it would make every release upload a nonexistent file.
+
+- [ ] **Step 3: Update the three documents that say `cd tests`**
+
+In `CLAUDE.md`, replace lines 23-30:
+
+```markdown
+# Run tests directly for quick iteration (from tests/ directory)
+cd tests && pytest
+
+# Run a single test file
+cd tests && pytest test1/test_crud.py
+
+# Run a single test
+cd tests && pytest test1/test_crud.py::test_name -v
+```
+
+with:
+
+```markdown
+# Run tests directly for quick iteration (from the repo root)
+pytest tests
+
+# Run a single test file
+pytest tests/test1/test_crud.py
+
+# Run a single test
+pytest tests/test1/test_crud.py::test_name -v
+```
+
+In `CONTRIBUTING.md`, line 27, change:
+
+```markdown
+   - quick: `cd tests && pytest`
+```
+
+to:
+
+```markdown
+   - quick: `pytest tests`
+```
+
+In `.github/PULL_REQUEST_TEMPLATE.md`, line 19, change:
+
+```markdown
+- [ ] Tests pass (`cd tests && pytest`)
+```
+
+to:
+
+```markdown
+- [ ] Tests pass (`pytest tests`)
+```
+
+- [ ] **Step 4: Verify the suite still passes from the new working directory**
+
+Run: `.venv/bin/python -m pytest tests -n auto -q`
+
+Expected: **870 passed, 1 skipped** — the 868 pre-existing passes plus Task 1's 2 new tests. The exact count matters less than the absence of failures and errors; what you are checking is that no conftest, fixture, or path behaviour depends on the old working directory.
+
+- [ ] **Step 5: Verify coverage now measures `src/`**
+
+Run:
+
+```bash
+.venv/bin/python -m pytest tests -n auto --cov --cov-report=xml -q
+```
+
+Expected: the run reports roughly 94% and does **not** fail the `fail_under = 88` gate. A `coverage.xml` appears at the repository root.
+
+Then assert on its contents:
+
+```bash
+echo "source element: $(grep -o '<source>[^<]*</source>' coverage.xml)"
+echo "test files:     $(grep -c 'filename="tests/' coverage.xml)"
+echo "guardian files: $(grep -c 'crud_views_guardian' coverage.xml)"
+grep -o 'filename="[^"]*"' coverage.xml | sort -u | head -3
+```
+
+Expected, all four:
+- `source element: <source></source>` — empty, no absolute prefix
+- `test files:     0`
+- `guardian files:` a non-zero count
+- filenames beginning `src/`, e.g. `filename="src/crud_views/apps.py"`
+
+If `<source>` contains an absolute path, `relative_files` did not take effect — recheck Task 1 Step 3. If any `tests/` files appear, the `source` list is not being applied — confirm you are running from the repo root.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add noxfile.py .github/workflows/tests.yml .github/workflows/publish.yml \
+        CLAUDE.md CONTRIBUTING.md .github/PULL_REQUEST_TEMPLATE.md
+git commit -m "fix(ci): run pytest from repo root so coverage measures src/ (#103)"
+```
+
+---
+
+### Task 3: Changelog, full matrix check, and pull request
+
+**Files:**
+- Modify: `CHANGELOG.md` (the `## Unreleased` section)
+
+**Interfaces:**
+- Consumes: the root `coverage.xml` produced by Task 2.
+- Produces: an open PR against `main`.
+
+- [ ] **Step 1: Add the changelog entry**
+
+`CHANGELOG.md` already has an `## Unreleased` section with a `### Changed` subsection. Add a `### Fixed` subsection directly after the existing `### Changed` block (before the `## 0.19.0` heading):
+
+```markdown
+### Fixed
+
+- Coverage is now measured for the package source. `pytest` runs from the repository
+  root instead of `tests/`, so coverage.py finds the `[tool.coverage.*]` config in
+  `pyproject.toml` — previously it found none, measured the test suite instead of
+  `src/`, and emitted absolute paths that Codecov silently discarded. The reported
+  project figure drops from ~99% to ~94% as a result: that is a measurement
+  correction, not a regression. `crud_views_guardian`, missing from the coverage
+  `source` list, is now included. (#103)
+```
+
+- [ ] **Step 2: Run the lint and format gates**
+
+Run: `task format && task check`
+Expected: both clean, no diff left unstaged. If `ruff format` rewrites `noxfile.py` after the de-indent in Task 2, stage the result.
+
+- [ ] **Step 3: Run one full nox session end to end**
+
+Run: `uv run nox -s "tests-3.12(django='5.2')" -- --cov-report=xml`
+
+Expected: the session passes and the `fail_under = 88` gate is satisfied. This exercises the real CI invocation path — the previous verification ran pytest directly, which does not prove the nox session works after the chdir removal.
+
+Note: `fail_under` is being enforced for the first time ever, across all 8 matrix rows. Local headroom is 6 points (94% vs 88%), but this is the one place CI could surprise you.
+
+- [ ] **Step 4: Commit and push**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): coverage now measures src/ (#103)"
+git push -u origin feature/coverage-config-src-measurement-103
+```
+
+- [ ] **Step 5: Open the pull request**
+
+```bash
+gh pr create --title "fix(ci): coverage config never read — measure src/ instead of tests/ (#103)" --body "$(cat <<'EOF'
+Fixes #103.
+
+## What was wrong
+
+The `[tool.coverage.*]` config in the root `pyproject.toml` was never read. `noxfile.py`
+chdir'd into `tests/`, and coverage.py neither walks up to find a config nor can make
+`src/` paths relative to `tests/`. So `--cov` measured every imported module including the
+test suite, and emitted absolute paths for `src/` that Codecov silently discarded.
+
+**Codecov has never measured this package.** The ~99% figure was the test suite measuring
+itself.
+
+## What changed
+
+`pytest` now runs from the repository root. That single change fixes both halves: the
+existing config becomes live, and paths come out as `src/crud_views/…`.
+
+Note that the fix is *not* the one suggested in the issue — `relative_files = true` is not
+load-bearing; the working directory is. Both of the issue's preferred options were tested
+and leave `src/` unmappable; see the [correction comment](https://github.com/jacob-consulting/django-crud-views/issues/103#issuecomment-5109148896).
+
+- `noxfile.py` — drop `session.chdir("./tests")` from the `tests` session
+- `pyproject.toml` — add `relative_files = true`; add the missing `crud_views_guardian` to `source`
+- `tests.yml` / `publish.yml` — `coverage.xml` moved to the repo root
+- `CLAUDE.md`, `CONTRIBUTING.md`, PR template — quick loop is now `pytest tests` from the root
+- `tests/test1/test_coverage_config.py` — new; pins `source` to the actual contents of `src/`
+
+## Expect the number to drop
+
+Project coverage goes from ~99% to **~94%** (4429 statements, 268 missing). This is a
+measurement correction, not a regression — `tests/` leaves the report and `src/` enters it,
+so the tracked file set changes wholesale. Only `codecov/patch` posts a status on this repo,
+so nothing turns red.
+
+`fail_under` stays at 88 — retuning the gate in the same PR as the measurement fix would
+make neither attributable. Note it becomes an enforced gate for the first time here.
+
+| Package | Stmts | Miss | Cov |
+|---|---:|---:|---:|
+| `crud_views` | 3387 | 221 | 93.5% |
+| `crud_views_guardian` | 264 | 27 | 89.8% |
+| `crud_views_object_detail` | 382 | 9 | 97.6% |
+| `crud_views_polymorphic` | 135 | 4 | 97.0% |
+| `crud_views_workflow` | 261 | 7 | 97.3% |
+
+`crud_views_guardian` — the package the `source` drift omitted — is the weakest of the five.
+
+## Follow-ups, deliberately not in this PR
+
+- Matrix rows clobber each other: all three Django sessions write the same `coverage.xml`
+  with no `--cov-append`, so only Django 6.0 × py3.13 is uploaded. Version-gated
+  `try/except ImportError` branches will now read as uncovered.
+- No `codecov.yml`; project and patch targets are inherited from Codecov's auto-defaults.
+- `crud_views_guardian` coverage at 89.8%.
+EOF
+)"
+```
+
+- [ ] **Step 6: Wait for CI, then verify Codecov actually changed**
+
+Wait for all checks. `gh pr checks` is known to exit 0 while Codecov is still pending on this repo, so query the API directly:
+
+```bash
+gh api repos/jacob-consulting/django-crud-views/commits/$(git rev-parse HEAD)/status \
+  --jq '.statuses[] | "\(.context)\t\(.state)"'
+```
+
+Then confirm the fix actually landed on Codecov's side — this is the real acceptance test, since a green build proves nothing about what Codecov ingested:
+
+```bash
+PR=$(gh pr view --json number --jq .number)
+curl -s "https://api.codecov.io/api/v2/github/jacob-consulting/repos/django-crud-views/compare/?pullid=$PR" \
+  | python3 -c "
+import json, sys
+from collections import Counter
+files = json.load(sys.stdin).get('files', [])
+print(Counter(f['head_name'].split('/')[0] for f in files))
+print('src/ files tracked:', sum(1 for f in files if f['head_name'].startswith('src/')))"
+```
+
+Expected: the counter is dominated by `src`, and the `src/` count is non-zero. Before this change the same query returned `Counter({'tests': 97})` with zero `src/` files.
+
+If `src/` is still absent, stop and re-inspect the uploaded `coverage.xml` in the CI logs — do not merge.
+
+- [ ] **Step 7: Report and hand off**
+
+Report the CI status, the Codecov compare result, and the new project percentage. Do **not** merge — the squash-merge decision is the maintainer's.
+
+---
+
+## Self-Review
+
+**Spec coverage:** every change in the spec maps to a task — `pyproject.toml` and the drift guard to Task 1; `noxfile.py`, both workflows, and the three documents to Task 2; `CHANGELOG.md` to Task 3. The spec's two verification steps are Task 2 Step 5 and Task 3 Step 6. `fail_under` staying at 88 is a global constraint. The three out-of-scope items appear in the PR body as follow-ups.
+
+**Placeholders:** none. Every code and config change is quoted verbatim with its before and after.
+
+**Consistency:** `_coverage_run_config()` is defined once in Task 1 and used by both tests in that file; no later task references it. The `source` list in Task 1 Step 3 is byte-identical to the sorted list Task 1 Step 1's test computes. The `coverage.xml` properties asserted in Task 2 Step 5 are the same ones Task 2's Interfaces block promises.
+
+**Known soft spot:** the expected test count in Task 2 Step 4 (870) is derived, not observed — the pre-change baseline was 868 passed / 1 skipped and Task 1 adds 2 tests. Treat a mismatch as worth investigating, not as an automatic failure.

--- a/superpowers/plans/2026-07-28-coverage-config-src-measurement.md
+++ b/superpowers/plans/2026-07-28-coverage-config-src-measurement.md
@@ -21,7 +21,7 @@ Everything below was established in the planning session. **You do not need to r
 ### Where things stand
 
 - **Branch:** `feature/coverage-config-src-measurement-103`, three commits ahead of `main` (`main` tip is `cf3f038`). All three are documentation only — spec `6590916`, spec amendment `5ff0666`, this plan `977dc93`. **No implementation work has started.** Task 1 Step 1 is the first thing to do.
-- **Working tree:** three untracked files at the repo root — `PR-ruff-0.16-explicit-select.md`, `feature-ruff-0.16-explicit-select.patch`, and a long `docs(view)__…patch`. These are **leftovers from earlier, unrelated work on #102**. Do not commit them, do not delete them, do not let them into the PR.
+- **Working tree:** clean. (Three untracked `#102` ruff patch leftovers were deleted on 2026-07-28 after confirming the work is merged as `cf3f038` and the branch `feature/ruff-0.16-explicit-select` still holds all 11 commits.)
 - **Issue #103's "Suggested fix" section is wrong** and has been publicly corrected — see the [correction comment](https://github.com/jacob-consulting/django-crud-views/issues/103#issuecomment-5109148896). Read the comment, not the issue body, for the mechanism.
 - **No PR exists yet.** Task 3 Step 5 opens it.
 

--- a/superpowers/plans/2026-07-28-coverage-config-src-measurement.md
+++ b/superpowers/plans/2026-07-28-coverage-config-src-measurement.md
@@ -12,6 +12,64 @@
 **Issue:** [#103](https://github.com/jacob-consulting/django-crud-views/issues/103) — see also the [correction comment](https://github.com/jacob-consulting/django-crud-views/issues/103#issuecomment-5109148896), which supersedes the issue's "Suggested fix" section.
 **Branch:** `feature/coverage-config-src-measurement-103` (already created; spec already committed there)
 
+---
+
+## Starting Point — read this first (written 2026-07-28)
+
+Everything below was established in the planning session. **You do not need to re-derive any of it, and re-running the experiments is a waste of time — they are recorded here with their results.**
+
+### Where things stand
+
+- **Branch:** `feature/coverage-config-src-measurement-103`, three commits ahead of `main` (`main` tip is `cf3f038`). All three are documentation only — spec `6590916`, spec amendment `5ff0666`, this plan `977dc93`. **No implementation work has started.** Task 1 Step 1 is the first thing to do.
+- **Working tree:** three untracked files at the repo root — `PR-ruff-0.16-explicit-select.md`, `feature-ruff-0.16-explicit-select.patch`, and a long `docs(view)__…patch`. These are **leftovers from earlier, unrelated work on #102**. Do not commit them, do not delete them, do not let them into the PR.
+- **Issue #103's "Suggested fix" section is wrong** and has been publicly corrected — see the [correction comment](https://github.com/jacob-consulting/django-crud-views/issues/103#issuecomment-5109148896). Read the comment, not the issue body, for the mechanism.
+- **No PR exists yet.** Task 3 Step 5 opens it.
+
+### The finding that drives the whole plan
+
+Coverage.py's relative directory follows the **process CWD**, not the location of the config file. `relative_files = true` only strips the prefix from files living *under* that directory, and `src/` is not under `tests/`. This is why the issue's proposed fixes fail.
+
+Tested against coverage.py 7.15.2 with the package installed editable:
+
+| Setup | Emitted filename | Codecov-mappable |
+|---|---|---|
+| `relative_files`, `tests/.coveragerc` (issue option 1) | `home/alex/…/src/crud_views/checks.py` | no |
+| `relative_files`, root config via `--cov-config` (issue option 2) | `home/alex/…/src/crud_views/checks.py` | no |
+| `[paths]` remapping, cwd=`tests/` | `home/alex/…/src/crud_views/checks.py` | no |
+| `relative_files`, **cwd = repo root** (issue option 3) | `src/crud_views/checks.py` | **yes** |
+
+Two corollaries worth not rediscovering:
+
+- Running from the root makes the root config live with **no `--cov-config` flag**. Coverage discovers `pyproject.toml` in the CWD, and pytest-cov's `.coveragerc` default is special-cased by coverage.py to mean "search the defaults". Confirmed directly: from the root, `coverage.Coverage()` reports `config_file: …/pyproject.toml`, `source: [4 packages]`, `fail_under: 88.0`.
+- `relative_files` is **not** needed for the filenames — running from the root yields `src/…` without it. It is worth setting for a different reason: it empties the XML `<source>` element. Without it the report carries `<source>/home/alex/projects/alex/django-crud-views</source>`, a machine-specific prefix Codecov's path-fixing must guess past.
+
+### Baseline measurements (py3.12 / Django 5.2, this machine)
+
+Already taken with the full suite run from the repo root. **868 passed, 1 skipped — identical to running from `tests/`**, so the CWD change breaks no conftest, xdist, or path behaviour. That is the main execution risk, and it is already retired.
+
+src-only total: **4429 statements, 268 missing, 94%**.
+
+| Package | Stmts | Miss | Cov |
+|---|---:|---:|---:|
+| `crud_views` | 3387 | 221 | 93.5% |
+| `crud_views_guardian` | 264 | 27 | 89.8% |
+| `crud_views_object_detail` | 382 | 9 | 97.6% |
+| `crud_views_polymorphic` | 135 | 4 | 97.0% |
+| `crud_views_workflow` | 261 | 7 | 97.3% |
+
+### Decisions already made — do not relitigate
+
+- **Scope is minimal.** No `codecov.yml`, no matrix combining. Both were considered and deliberately deferred to follow-up issues.
+- **`fail_under` stays at 88.** The number was going to be retuned out of fear the figure would drop below the gate; it doesn't — 94% leaves 6 points of headroom. Keeping measurement and policy changes separate is the point.
+- **One working directory everywhere.** The alternative — change nox only, leave `cd tests && pytest` documented — was rejected because the bug exists precisely because two CWDs were in play. Hence the `CLAUDE.md` / `CONTRIBUTING.md` / PR-template edits.
+- **Nothing turns red on landing.** This repo posts only `codecov/patch`, not `codecov/project` (verified against `cf3f038`'s statuses), so the 99% → 94% move affects the badge and Codecov UI only.
+
+### Environment
+
+- Local venv: `.venv/bin/python` — Python 3.12.3, Django 5.2.14, coverage.py 7.15.2.
+- CI matrix is Python 3.12/3.13/3.14 × Django 4.2/5.2/6.0, minus Django 4.2 × py3.14 = **8 rows**. Codecov uploads only from the py3.13 row.
+- `taskfile.yaml` (lowercase, not `Taskfile.yml`) provides `task format`, `task check`, `task test`. It needs **no change** — `task test` shells out to nox.
+
 ## Global Constraints
 
 - Line length 120, double quotes, ruff-formatted. `ruff-format` runs as a pre-commit hook.
@@ -416,3 +474,26 @@ Report the CI status, the Codecov compare result, and the new project percentage
 **Consistency:** `_coverage_run_config()` is defined once in Task 1 and used by both tests in that file; no later task references it. The `source` list in Task 1 Step 3 is byte-identical to the sorted list Task 1 Step 1's test computes. The `coverage.xml` properties asserted in Task 2 Step 5 are the same ones Task 2's Interfaces block promises.
 
 **Known soft spot:** the expected test count in Task 2 Step 4 (870) is derived, not observed — the pre-change baseline was 868 passed / 1 skipped and Task 1 adds 2 tests. Treat a mismatch as worth investigating, not as an automatic failure.
+
+---
+
+## Resuming Mid-Plan
+
+If you are picking this up after some tasks are already done, establish where you are before touching anything:
+
+```bash
+git log --oneline main..HEAD
+```
+
+Map the commits you find onto the plan:
+
+| Last commit subject | Completed through | Resume at |
+|---|---|---|
+| `docs(plan): …` | plan only, nothing implemented | Task 1, Step 1 |
+| `test(coverage): pin source list …` | Task 1 | Task 2, Step 1 |
+| `fix(ci): run pytest from repo root …` | Task 2 | Task 3, Step 1 |
+| `docs(changelog): …` | Task 3 Step 4 | Task 3, Step 5 (open the PR) |
+
+Then check whether a PR is already open with `gh pr view --json number,state,url` before running Task 3 Step 5, so you don't open a duplicate.
+
+The single highest-value confirmation, if you want one cheap check that the work is behaving, is Task 2 Step 5's assertions on the root `coverage.xml`. Empty `<source>`, filenames starting `src/`, zero `tests/` entries — that quartet is the whole point of the change.

--- a/superpowers/specs/2026-07-28-coverage-config-src-measurement-design.md
+++ b/superpowers/specs/2026-07-28-coverage-config-src-measurement-design.md
@@ -67,11 +67,21 @@ have to guess past. The CWD is the fix; `relative_files` makes the result unambi
 **`pyproject.toml`**, `[tool.coverage.run]` — add `relative_files = true`; add the missing
 `crud_views_guardian` and alphabetize `source` across all five packages in `src/`.
 
-**`.github/workflows/tests.yml`** — `coverage.xml` is now written at the repo root, so the
-upload step's `files: tests/coverage.xml` becomes `files: coverage.xml`.
+**`.github/workflows/tests.yml`** and **`.github/workflows/publish.yml`** — `coverage.xml` is
+now written at the repo root, so the `codecov-action` step's `files: tests/coverage.xml`
+becomes `files: coverage.xml` in *both* workflows. `publish.yml` carries an independent copy
+of the upload step; missing it would leave every release uploading a nonexistent file.
 
-**`CLAUDE.md`** — the documented quick loop moves to the repo root: `pytest tests`,
+**`CLAUDE.md`**, **`CONTRIBUTING.md`**, and **`.github/PULL_REQUEST_TEMPLATE.md`** — all three
+document `cd tests && pytest`. The quick loop moves to the repo root: `pytest tests`,
 `pytest tests/test1/test_crud.py`, `pytest tests/test1/test_crud.py::test_name -v`.
+
+**`CHANGELOG.md`** — an entry under `## Unreleased`, per the project's PR checklist.
+
+**`tests/test1/test_coverage_config.py`** (new) — a regression test asserting that
+`[tool.coverage.run].source` lists every package directory under `src/`, in sorted order, and
+that `relative_files` is enabled. The `crud_views_guardian` omission survived precisely because
+nothing checked it; this is the guard against the same drift recurring.
 
 Collapsing to a single working directory is part of the fix, not incidental tidying. The bug
 exists because two CWDs were in play and the config matched only one of them; leaving

--- a/superpowers/specs/2026-07-28-coverage-config-src-measurement-design.md
+++ b/superpowers/specs/2026-07-28-coverage-config-src-measurement-design.md
@@ -1,0 +1,132 @@
+# Coverage config: make Codecov measure `src/`
+
+**Issue:** [#103](https://github.com/jacob-consulting/django-crud-views/issues/103)
+**Date:** 2026-07-28
+**Status:** approved, ready for planning
+
+## Problem
+
+The `[tool.coverage.*]` config in the root `pyproject.toml` has never taken effect. Codecov
+has been tracking only the test suite — the reported ~99% project figure is `tests/`
+measuring itself, and the package source has never been measured at all.
+
+## Root cause
+
+The issue that surfaced this names `relative_files = true` as "the load-bearing part" of the
+fix. That is wrong, and the correction matters because it invalidates two of the three fixes
+the issue proposes.
+
+Coverage.py's relative directory follows the **process CWD**, not the location of the config
+file. `noxfile.py` does `session.chdir("./tests")` before invoking pytest, which causes two
+independent failures:
+
+1. **No config is found.** Coverage looks for a config file in the CWD only — it does not
+   walk up the tree. `tests/` contains none, so `source` and `fail_under` are both inert and
+   a bare `--cov` measures every imported module, including `tests/`.
+2. **`src/` paths are unmappable.** With the relative directory anchored to `tests/`, paths
+   under `src/` cannot be made relative to it, so they stay absolute. Codecov resolves the
+   relative `tests/` entries against the repo tree and silently discards the absolute ones.
+
+### Empirically tested alternatives
+
+Measured against coverage.py 7.15.2 with the package installed editable:
+
+| Setup | Emitted filename | Codecov-mappable |
+|---|---|---|
+| `relative_files`, config in `tests/.coveragerc`, cwd=`tests/` | `home/alex/…/src/crud_views/checks.py` | no |
+| `relative_files`, config in repo root via `--cov-config`, cwd=`tests/` | `home/alex/…/src/crud_views/checks.py` | no |
+| `[paths]` remapping, cwd=`tests/` | `home/alex/…/src/crud_views/checks.py` | no |
+| `relative_files`, **cwd=repo root** | `src/crud_views/checks.py` | **yes** |
+
+The first two rows are the issue's preferred options 1 and 2. Both fail. Only running from
+the repo root — the issue's option 3 — produces Codecov-mappable paths.
+
+Running from the root also makes the existing root config live with no extra flags:
+coverage discovers `pyproject.toml` in the CWD and applies `source` and `fail_under`. Also
+confirmed: pytest-cov's `--cov-config` default of `.coveragerc` is special-cased by
+coverage.py to mean "search the defaults", so `pyproject.toml` is found without passing
+`--cov-config` explicitly.
+
+### Role of `relative_files`
+
+Not required for the filenames — running from the root already yields `src/…` without it.
+It is still worth setting, because it empties the XML `<source>` element:
+
+- without: `<source>/home/alex/projects/alex/django-crud-views</source>`
+- with: `<source></source>`
+
+That removes a machine-specific absolute prefix that Codecov's path-fixing would otherwise
+have to guess past. The CWD is the fix; `relative_files` makes the result unambiguous.
+
+## Changes
+
+**`noxfile.py`** — remove `with session.chdir("./tests")` from the `tests` session and run
+`pytest tests -n auto --cov --cov-report=term-missing`. The `examples` session keeps its own
+`chdir` and is untouched.
+
+**`pyproject.toml`**, `[tool.coverage.run]` — add `relative_files = true`; add the missing
+`crud_views_guardian` and alphabetize `source` across all five packages in `src/`.
+
+**`.github/workflows/tests.yml`** — `coverage.xml` is now written at the repo root, so the
+upload step's `files: tests/coverage.xml` becomes `files: coverage.xml`.
+
+**`CLAUDE.md`** — the documented quick loop moves to the repo root: `pytest tests`,
+`pytest tests/test1/test_crud.py`, `pytest tests/test1/test_crud.py::test_name -v`.
+
+Collapsing to a single working directory is part of the fix, not incidental tidying. The bug
+exists because two CWDs were in play and the config matched only one of them; leaving
+`cd tests && pytest` documented would keep the trap loaded for anyone running coverage
+locally.
+
+No `.gitignore` change is needed — the bare `.coverage` and `coverage.xml` patterns already
+match at any depth.
+
+## Measured impact
+
+Full suite from the repo root, py3.12 / Django 5.2, src-only: **4429 statements, 268
+missing, 94%**. All 868 tests pass, 1 skipped — identical to running from `tests/`, so the
+CWD change breaks no conftest, xdist, or path behaviour.
+
+| Package | Stmts | Miss | Cov |
+|---|---:|---:|---:|
+| `crud_views` | 3387 | 221 | 93.5% |
+| `crud_views_guardian` | 264 | 27 | 89.8% |
+| `crud_views_object_detail` | 382 | 9 | 97.6% |
+| `crud_views_polymorphic` | 135 | 4 | 97.0% |
+| `crud_views_workflow` | 261 | 7 | 97.3% |
+
+`crud_views_guardian` — the package the `source` drift omitted — is the weakest of the five.
+The drift hid the worst number.
+
+## The gate
+
+`fail_under` **stays at 88.** Measured coverage is 94%, leaving 6 points of headroom, and
+this change corrects measurement rather than tightening policy; moving both at once would
+make neither attributable. Note that 88 has never been enforced before this change — it
+becomes a live gate on all 8 matrix rows here.
+
+Nothing turns red on landing: this repo posts only `codecov/patch`, not `codecov/project`,
+so the 99% → 94% move affects the badge and the Codecov UI only. The PR body must state
+that the drop is a measurement correction, not a regression, since Codecov will also show a
+wholesale change in the tracked file set as `tests/` leaves the report and `src/` enters it.
+
+## Verification
+
+1. `nox -s "tests-3.12(django='5.2')" -- --cov-report=xml`, then assert on the root
+   `coverage.xml`: `<source></source>`, filenames beginning `src/`, zero occurrences of
+   `filename="tests/`, `crud_views_guardian` present, and `fail_under` satisfied.
+2. After CI, re-run the Codecov compare-API query used as evidence on #103 and confirm the
+   tracked-file list contains `src/` paths rather than `Counter({'tests': 97})`.
+
+## Out of scope
+
+To be filed as follow-up issues, not fixed here:
+
+- **Matrix rows clobber each other.** All three Django sessions write the same
+  `coverage.xml` with no `--cov-append`, so only the last (Django 6.0 × py3.13) is uploaded.
+  Now that `src/` is measured, version-gated `try/except ImportError` branches will read as
+  uncovered. Deliberately deferred so the ~5-point measurement correction lands alone and
+  attributable.
+- **`crud_views_guardian` at 89.8%** — the weakest package, worth its own coverage work.
+- **No `codecov.yml`.** Project and patch targets are inherited from Codecov's auto-defaults
+  rather than declared in-repo.

--- a/tests/test1/test_coverage_config.py
+++ b/tests/test1/test_coverage_config.py
@@ -11,9 +11,13 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-def _coverage_run_config() -> dict:
+def _coverage_config() -> dict:
     with (REPO_ROOT / "pyproject.toml").open("rb") as fh:
-        return tomllib.load(fh)["tool"]["coverage"]["run"]
+        return tomllib.load(fh)["tool"]["coverage"]
+
+
+def _coverage_run_config() -> dict:
+    return _coverage_config()["run"]
 
 
 def test_coverage_source_lists_every_src_package():
@@ -25,3 +29,15 @@ def test_coverage_source_lists_every_src_package():
 def test_coverage_emits_relative_paths():
     """Without this, coverage.xml carries an absolute machine-specific <source> prefix."""
     assert _coverage_run_config()["relative_files"] is True
+
+
+def test_coverage_remaps_installed_package_paths_to_src():
+    """nox installs the package non-editably, so coverage sees it under site-packages.
+
+    Without this remapping the report names files
+    `.nox/<session>/lib/python3.X/site-packages/crud_views/apps.py`, which Codecov
+    cannot match to anything in the repository — the same failure #103 is about,
+    only in a different disguise. Running pytest directly against the editable
+    `.venv` does *not* reproduce it, which is why it was nearly missed.
+    """
+    assert _coverage_config()["paths"]["source"] == ["src/", "*/site-packages/"]

--- a/tests/test1/test_coverage_config.py
+++ b/tests/test1/test_coverage_config.py
@@ -1,0 +1,27 @@
+"""Guards against drift between the coverage config and the packages in src/.
+
+`crud_views_guardian` was missing from `[tool.coverage.run].source` for a long time
+without anyone noticing, because the whole config was inert — coverage.py never found
+it while pytest ran from `tests/`. See issue #103.
+"""
+
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _coverage_run_config() -> dict:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as fh:
+        return tomllib.load(fh)["tool"]["coverage"]["run"]
+
+
+def test_coverage_source_lists_every_src_package():
+    """Every distributed package must be measured, in sorted order."""
+    packages = sorted(p.name for p in (REPO_ROOT / "src").iterdir() if (p / "__init__.py").is_file())
+    assert _coverage_run_config()["source"] == packages
+
+
+def test_coverage_emits_relative_paths():
+    """Without this, coverage.xml carries an absolute machine-specific <source> prefix."""
+    assert _coverage_run_config()["relative_files"] is True


### PR DESCRIPTION
Fixes #103.

## What was wrong

The `[tool.coverage.*]` config in the root `pyproject.toml` was never read. `noxfile.py`
chdir'd into `tests/`, and coverage.py neither walks up to find a config nor can make
`src/` paths relative to `tests/`. So `--cov` measured every imported module including the
test suite, and emitted absolute paths for `src/` that Codecov silently discarded.

**Codecov has never measured this package.** The ~99% figure was the test suite measuring
itself.

## What changed

`pytest` now runs from the repository root. That single change fixes both halves: the
existing config becomes live, and paths come out as `src/crud_views/…`.

Note that the fix is *not* the one suggested in the issue — `relative_files = true` is not
load-bearing; the working directory is. Both of the issue's preferred options were tested
and leave `src/` unmappable; see the [correction comment](https://github.com/jacob-consulting/django-crud-views/issues/103#issuecomment-5109148896).

- `noxfile.py` — drop `session.chdir("./tests")` from the `tests` session
- `pyproject.toml` — add `relative_files = true`; add the missing `crud_views_guardian` to `source`; add `[tool.coverage.paths]` (see below)
- `tests.yml` / `publish.yml` — `coverage.xml` moved to the repo root
- `CLAUDE.md`, `CONTRIBUTING.md`, PR template — quick loop is now `pytest tests` from the root
- `tests/test1/test_coverage_config.py` — new; pins `source` to the actual contents of `src/`

### The second half: `[tool.coverage.paths]`

Moving the working directory is necessary but not sufficient. nox *installs* the package
rather than linking it, so under nox — which is how CI runs — coverage measures the copy in
`.nox/<session>/lib/python3.X/site-packages/crud_views/…` and names files by that path.
Codecov cannot match those to the repository either; it is the same failure in a different
disguise.

Running `pytest` directly against the editable `.venv` emits `src/…` and does **not**
reproduce it, which is exactly why it nearly slipped through. `[tool.coverage.paths]` maps
`*/site-packages/` back onto `src/`, and both invocation paths now produce identical
reports. A third test pins the remapping.

Verified on the real CI invocation (`nox -s \"tests-3.12(django='5.2')\" -- --cov-report=xml`):
86 `src/` files, zero `.nox/` entries, zero `tests/` entries, and an empty `<source>`
element.

## Expect the number to drop

Project coverage goes from ~99% to **~94%** (4429 statements, 268 missing). This is a
measurement correction, not a regression — `tests/` leaves the report and `src/` enters it,
so the tracked file set changes wholesale. Only `codecov/patch` posts a status on this repo,
so nothing turns red.

`fail_under` stays at 88 — retuning the gate in the same PR as the measurement fix would
make neither attributable. Note it becomes an enforced gate for the first time here.

| Package | Stmts | Miss | Cov |
|---|---:|---:|---:|
| `crud_views` | 3387 | 221 | 93.5% |
| `crud_views_guardian` | 264 | 27 | 89.8% |
| `crud_views_object_detail` | 382 | 9 | 97.6% |
| `crud_views_polymorphic` | 135 | 4 | 97.0% |
| `crud_views_workflow` | 261 | 7 | 97.3% |

`crud_views_guardian` — the package the `source` drift omitted — is the weakest of the five.

## Follow-ups, deliberately not in this PR

- Matrix rows clobber each other: all three Django sessions write the same `coverage.xml`
  with no `--cov-append`, so only Django 6.0 × py3.13 is uploaded. Version-gated
  `try/except ImportError` branches will now read as uncovered.
- No `codecov.yml`; project and patch targets are inherited from Codecov's auto-defaults.
- `crud_views_guardian` coverage at 89.8%.